### PR TITLE
added missing "new" keyword to call to Stripe_ApiRequestor in the cancelS

### DIFF
--- a/lib/Stripe/Customer.php
+++ b/lib/Stripe/Customer.php
@@ -85,7 +85,7 @@ class Stripe_Customer extends Stripe_ApiResource
 
   public function cancelSubscription()
   {
-    $requestor = Stripe_ApiRequestor($this->_apiKey);
+    $requestor = new Stripe_ApiRequestor($this->_apiKey);
     $url = $this->instanceUrl() . '/subscription';
     list($response, $apiKey) = $requestor->request('delete', $url);
     $this->refreshFrom(array('subscription' => $response), $apiKey, true);


### PR DESCRIPTION
added missing "new" keyword to call to Stripe_ApiRequestor in the cancelSubscription method. This was (obviously) causing a crash when calling Cancel Subscription. 
