### PR TITLE
Support http status code in getCode to handleApiError method. Also pass error type.

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -64,13 +64,18 @@ class Stripe_ApiRequestor
     case 400:
     case 404:
       throw new Stripe_InvalidRequestError(isset($error['message']) ? $error['message'] : null,
-					    isset($error['param']) ? $error['param'] : null);
+					    isset($error['param']) ? $error['param'] : null,
+							$rcode,
+							isset($error['type']) ? $error['type'] : null);
     case 401:
       throw new Stripe_AuthenticationError(isset($error['message']) ? $error['message'] : null);
     case 402:
       throw new Stripe_CardError(isset($error['message']) ? $error['message'] : null,
 				  isset($error['param']) ? $error['param'] : null,
-				  isset($error['code']) ? $error['code'] : null);
+				  $rcode,
+					isset($error['type']) ? $error['type'] : null
+				
+				);
     default:
       throw new Stripe_ApiError(isset($error['message']) ? $error['message'] : null);
     }

--- a/lib/Stripe/CardError.php
+++ b/lib/Stripe/CardError.php
@@ -2,10 +2,11 @@
 
 class Stripe_CardError extends Stripe_Error
 {
-  public function __construct($message, $param, $code)
+  public function __construct($message, $param, $code, $type=null)
   {
     parent::__construct($message);
     $this->param = $param;
     $this->code = $code;
+		$this->type = $type;
   }
 }

--- a/lib/Stripe/Error.php
+++ b/lib/Stripe/Error.php
@@ -2,4 +2,10 @@
 
 class Stripe_Error extends Exception
 {
+	public function getType(){
+		return $this->type;
+	}
+	public function getParam(){
+		return $this->param;
+	}
 }

--- a/lib/Stripe/InvalidRequestError.php
+++ b/lib/Stripe/InvalidRequestError.php
@@ -2,9 +2,11 @@
 
 class Stripe_InvalidRequestError extends Stripe_Error
 {
-  public function __construct($message, $param)
+  public function __construct($message, $param, $code, $type=null)
   {
     parent::__construct($message);
     $this->param = $param;
+    $this->code = $code;
+		$this->type = $type;
   }
 }


### PR DESCRIPTION
Update handleApiError to support passing of http status code and also pass type. 

Add getType and getParam to parent Stripe_Error exception class
