### PR TITLE
Remove Stripe_Util::cloneArray()

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -87,7 +87,6 @@ class Stripe_ApiRequestor
       throw new Stripe_AuthenticationError('No API key provided.  (HINT: set your API key using "Stripe::setApiKey(<API-KEY>)".  You can generate API keys from the Stripe web interface.  See https://stripe.com/api for details, or email support@stripe.com if you have any questions.');
 
     $absUrl = $this->apiUrl($url);
-    $params = Stripe_Util::arrayClone($params);
     $params = self::_encodeObjects($params);
     $langVersion = phpversion();
     $uname = php_uname();

--- a/lib/Stripe/Util.php
+++ b/lib/Stripe/Util.php
@@ -2,13 +2,6 @@
 
 abstract class Stripe_Util
 {
-  public static function arrayClone($array)
-  {
-    if (!is_array($array))
-      throw new Stripe_Error("Trying to clone non-array: $array");
-    return array_merge($array);
-  }
-
   public static function isList($array)
   {
     if (!is_array($array))
@@ -27,9 +20,9 @@ abstract class Stripe_Util
     foreach ($values as $k => $v) {
       // FIXME: this is an encapsulation violation
       if (Stripe_Object::$_permanentAttributes->includes($k)) {
-        continue;        
+        continue;
       }
-      if ($v instanceof Stripe_Object) {        
+      if ($v instanceof Stripe_Object) {
         $results[$k] = $v->__toArray(true);
       }
       else if (is_array($v)) {
@@ -54,7 +47,6 @@ abstract class Stripe_Util
         array_push($mapped, self::convertToStripeObject($i, $apiKey));
       return $mapped;
     } else if (is_array($resp)) {
-      $resp = self::arrayClone($resp);
       if (isset($resp['object']) && is_string($resp['object']) && isset($types[$resp['object']]))
         $class = $types[$resp['object']];
       else

--- a/test/Stripe/UtilTest.php
+++ b/test/Stripe/UtilTest.php
@@ -11,13 +11,12 @@ class Stripe_UtilTest extends UnitTestCase
     $this->assertFalse(Stripe_Util::isList($notlist));
   }
 
-  public function testArrayClone()
+  public function testThatPHPHasValueSemanticsForArrays()
   {
-    try {
-      Stripe_Util::arrayClone(1);
-      $this->assertFalse(true);
-    } catch (Stripe_Error $e) {
-      $this->assertTrue(true);
-    }
+    $original = array('php-arrays' => 'value-semantics');
+    $derived = $original;
+    $derived['php-arrays'] = 'reference-semantics';
+
+    $this->assertEqual('value-semantics', $original['php-arrays']);
   }
 }


### PR DESCRIPTION
Summary: PHP has copy-on-write value-semantics for arrays. This method doesn't do anything. It _would_ break references and convert Iterators to raw arrays, but isn't used to do either.

My editor also stripped some trailing whitespace.

I tried to figure out what problem this was solving when it was introduced, but blame goes past the first commit.

Test Plan: Ran unit tests. Many of them fail -- they seem to depend on a specific API key? Is there a way I can get them to work? But, these failures were the same before this change. Added a troll test to demonstrate that PHP has the behavior I claim it does. Grepped for 'arrayClone()'.
