### PR TITLE
composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "stripe/stripe-php",
+  "description": "PHP bindings for Stripe api",
+  "keywords": [
+    "stripe",
+    "payment processing",
+    "api"
+  ],
+  "homepage": "http://stripe.com/",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Stripe and contributors",
+      "homepage": "https://github.com/stripe/stripe-php/contributors"
+    }
+  ],
+  "require": {
+    "php": ">=5.3.2"
+  },
+  "autoload": {
+    "psr-0": {
+      "Stripe": "lib/"
+    }
+  }
+}


### PR DESCRIPTION
Composer is a tool to help with including dependencies within your project.

This is the code to register the stripe php bindings with packagist.org for using with composer. I've validated the .json, but if there are any problems discovered when adding to packagist.org, I'll make sure to correct them

http://getcomposer.org/ 
http://packagist.org/
