### PR TITLE
Set default value to optional parameter

### DIFF
--- a/lib/Stripe/InvalidRequestError.php
+++ b/lib/Stripe/InvalidRequestError.php
@@ -2,7 +2,7 @@
 
 class Stripe_InvalidRequestError extends Stripe_Error
 {
-  public function __construct($message, $param, $http_status=null, $http_body=null, $json_body=null)
+  public function __construct($message, $param=null, $http_status=null, $http_body=null, $json_body=null)
   {
     parent::__construct($message, $http_status, $http_body, $json_body);
     $this->param = $param;


### PR DESCRIPTION
Not passed in `ApiResource::instanceUrl()`.
