### PR TITLE
Add note for accidental test/Stripe.php includes

### DIFF
--- a/test/Stripe.php
+++ b/test/Stripe.php
@@ -1,5 +1,9 @@
 <?php
 
+echo "Running the Stripe PHP bindings test suite.\n".
+     "If you're trying to use the Stripe PHP bindings you'll probably want ".
+     "to require('lib/Stripe.php'); instead of this file\n";
+
 function authorizeFromEnv()
 {
   $apiKey = getenv('STRIPE_API_KEY');
@@ -16,8 +20,6 @@ if (!$ok) {
   echo "MISSING DEPENDENCY: The Stripe API test cases depend on SimpleTest. ".
        "Download it at <http://www.simpletest.org/>, and either install it ".
        "in your PHP include_path or put it in the test/ directory.\n";
-  echo "If you're trying to use the Stripe PHP bindings you'll probably want ".
-       "to require('lib/Stripe.php'); instead of this file\n";
   exit(1);
 }
 


### PR DESCRIPTION
Some users get confused when they include "test/Stripe.php" (presumably thinking that it is used for test mode API calls). Add a note suggesting they include "lib/Stripe.php".
