### PR TITLE
retrieve() can accept an array

### DIFF
--- a/lib/Stripe/Invoice.php
+++ b/lib/Stripe/Invoice.php
@@ -17,6 +17,13 @@ class Stripe_Invoice extends Stripe_ApiResource
   public static function retrieve($id, $apiKey=null)
   {
     $class = get_class();
+    if (is_array($id)) {
+      $result = array();
+      foreach ($id as $line) {
+        $result[$line] = self::_scopedRetrieve($class, $line, $apiKey);
+      }
+      return $result;
+    }
     return self::_scopedRetrieve($class, $id, $apiKey);
   }
 


### PR DESCRIPTION
An array of invoices can be retrieved, making this appropriate for pages that display a list of particular invoices for a customer in the database they want to check the status of. Necessary if logic goes into finding the list that would not be supported in `all()`
