### PR TITLE
Allows array for event()

### DIFF
--- a/lib/Stripe/Event.php
+++ b/lib/Stripe/Event.php
@@ -11,6 +11,13 @@ class Stripe_Event extends Stripe_ApiResource
   public static function retrieve($id, $apiKey=null)
   {
     $class = get_class();
+    if (is_array($id)) {
+      $result = array();
+      foreach ($id as $line) {
+        $result[$line] = self::_scopedRetrieve($class, $line, $apiKey);
+      }
+      return $result;
+    }
     return self::_scopedRetrieve($class, $id, $apiKey);
   }
 


### PR DESCRIPTION
Lets an entire array of events get pulled at once. Useful if someone has particular events in their database.
