### PR TITLE
Add Create Function to Invoice Object to Fit Documentation 

### DIFF
--- a/lib/Stripe/Invoice.php
+++ b/lib/Stripe/Invoice.php
@@ -27,4 +27,10 @@ class Stripe_Invoice extends Stripe_ApiResource
     list($response, $apiKey) = $requestor->request('get', $url, $params);
     return Stripe_Util::convertToStripeObject($response, $apiKey);
   }
+
+  public static function create($params=null, $apiKey=null)
+  {
+      $class = get_class();
+      return self::_scopedCreate($class, $params, $apiKey);
+  }
 }


### PR DESCRIPTION
According to https://stripe.com/docs/api?lang=php#create_invoice the method Stripe_Invoice::create() should work. However, on attempting to run this the user gets a fatal error - undefined method. This change adds the create method back into the invoice object. As far as I can tell the change works perfectly. Alternately, if there is a valid reason why this method should not exist, can you update the documentation to reflect this?
