### PR TITLE
Improve UTF-8 support

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -26,7 +26,7 @@ class Stripe_ApiRequestor
   private static function _encodeObjects($d)
   {
     if ($d instanceof Stripe_ApiResource) {
-      return $d->id;
+      return self::utf8($d->id);
     } else if ($d === true) {
       return 'true';
     } else if ($d === false) {
@@ -37,7 +37,7 @@ class Stripe_ApiRequestor
       	$res[$k] = self::_encodeObjects($v);
       return $res;
     } else {
-      return $d;
+      return self::utf8($d);
     }
   }
 

--- a/test/Stripe/ApiRequestorTest.php
+++ b/test/Stripe/ApiRequestorTest.php
@@ -49,6 +49,16 @@ class Stripe_ApiRequestorTest extends UnitTestCase
       $a = array('customer' => new Stripe_Customer('abcd'));
       $enc = $method->invoke(null, $a);
       $this->assertEqual($enc, array('customer' => 'abcd'));
+
+      // Preserves UTF-8
+      $v = array('customer' => "☃");
+      $enc = $method->invoke(null, $v);
+      $this->assertEqual($enc, $v);
+
+      // Encodes latin-1 -> UTF-8
+      $v = array('customer' => "\xe9");
+      $enc = $method->invoke(null, $v);
+      $this->assertEqual($enc, array('customer' => "\xc3\xa9"));
     }
   }
 }


### PR DESCRIPTION
@boucher Any opinions on this?

This will notably cause a slight backwards incompatibility if people were previously creating resources by passing UTF-8-encoded IDs. Previously they would get double-encoded both when they were created and when they were retrieved; now they will only be single-encoded, so we may see some new 404s.

I've checked the DB for user-provided IDs which aren't pure-ASCII && are still valid UTF-8 after going through an UTF-8->ISO-8859-1 transcoding (I think that's the correct check). I didn't find any, so I don't think the incompatibility matters in practice.
