### PR TITLE
Allow use of ApiRequestor for Stripe Connect

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -106,7 +106,15 @@ class Stripe_ApiRequestor
     if (!$myApiKey)
       throw new Stripe_AuthenticationError('No API key provided.  (HINT: set your API key using "Stripe::setApiKey(<API-KEY>)".  You can generate API keys from the Stripe web interface.  See https://stripe.com/api for details, or email support@stripe.com if you have any questions.');
 
-    $absUrl = $this->apiUrl($url);
+    // Check if $url is an absolute URL (over SSL)
+    if (preg_match("#^https://#", $url)) {
+        // It is, so use it as-is
+        $absUrl = $url;
+    } else {
+        // It's not, so append it to Stripe::$apiBase
+        $absUrl = $this->apiUrl($url);
+    }
+
     $params = self::_encodeObjects($params);
     $langVersion = phpversion();
     $uname = php_uname();


### PR DESCRIPTION
Hi guys,

Firstly, I'm loving Stripe; nice work!

Secondly, I'd like to be able to make use of your `ApiRequestor` class to make the post to `https://connect.stripe.com/oauth/token` while trying to connect users.

I notice that the `ApiRequestor::request()` method takes a `$url` argument. Unfortunately, this can only be a URL relative to `https://api.stripe.com` and so we can't use it to post to `https://connect.stripe.com/oauth/token`.

I propose updating the `ApiRequestor::_requestRaw()` method to check whether the URL is already an absolute URL. If it is, we use it as-is. Otherwise we append it to the base API URL (existing behavior).  

```
// ...
// Check if $url is an absolute URL (over SSL)
if (preg_match("#^https://#", $url)) {
    // It is, so use it as-is
    $absUrl = $url;
} else {
    // It's not, so append it to Stripe::$apiBase
    $absUrl = $this->apiUrl($url);
}
// ...
```

We can then use it as follows:

```
$url = 'https://connect.stripe.com/oauth/token';
$request = array(
    'client_secret' => MY_SECRET_KEY,
    'grant_type'    => 'authorization_code',
    'client_id'     => MY_CLIENT_ID,
    'code'          => $_GET['code'],
);

$requestor = new \Stripe_ApiRequestor(MY_SECRET_KEY);
$response  = $requestor->request('post', $url, $request);
```

Let me know what you think.

Cheers,

Tom
