### PR TITLE
Update travis to include php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
+
 php:
   - 5.2
   - 5.3
   - 5.4
+  - 5.5
+
 before_script:
-  - wget http://iweb.dl.sourceforge.net/project/simpletest/simpletest/simpletest_1.1/simpletest_1.1.0.tar.gz
-  - tar xf simpletest_1.1.0.tar.gz -C test
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then wget http://iweb.dl.sourceforge.net/project/simpletest/simpletest/simpletest_1.1/simpletest_1.1.0.tar.gz; tar xf simpletest_1.1.0.tar.gz -C test; else composer install --dev --prefer-source; fi"
+
 script: php test/Stripe.php


### PR DESCRIPTION
Updates Travis to check PHP 5.5. Also switched it to use composer to be more consistent.
