### PR TITLE
Add phpcs to travis to check that code matches zend style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ php:
   - 5.5
 
 before_script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then wget http://iweb.dl.sourceforge.net/project/simpletest/simpletest/simpletest_1.1/simpletest_1.1.0.tar.gz; tar xf simpletest_1.1.0.tar.gz -C test; else composer install --dev --prefer-source; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ]; then pyrus install http://phptal.org/latest.tar.gz && pear install pear/PHP_CodeSniffer && phpenv rehash; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then git clone https://github.com/vierbergenlars/simpletest test/simpletest; else composer install --dev --prefer-source; fi"
 
-script: php test/Stripe.php
+script:
+ - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.5' ]; then phpcs --standard=zend --encoding=UTF-8 --report=summary --ignore=*/vendor/* -p; fi"
+ - php test/Stripe.php

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "vierbergenlars/simpletest": "*"
+    "vierbergenlars/simpletest": "*",
+    "squizlabs/php_codesniffer": "*"
   },
   "autoload": {
     "classmap": ["lib/Stripe/"]


### PR DESCRIPTION
This adds CodeSniff to travis to complain when stuff gets off the style guide. Will need to be changed based on #43. I also updated it to use the git repo instead of downloading from sourceforge. The codesniff only needs to be run on one copy so so I force it on 5.5.
