### PR TITLE
Fix missed version number update

### DIFF
--- a/lib/Stripe/Stripe.php
+++ b/lib/Stripe/Stripe.php
@@ -6,7 +6,7 @@ abstract class Stripe
   public static $apiBase = 'https://api.stripe.com';
   public static $apiVersion = null;
   public static $verifySslCerts = true;
-  const VERSION = '1.8.3';
+  const VERSION = '1.8.4';
 
   public static function getApiKey()
   {


### PR DESCRIPTION
Version number is actually 1.8.4 per VERSION file and commit history, however it still says 1.8.3 here. 

**The new version also needs to be tagged as 1.8.4**, which can't be done in a pull request :-)
