### PR TITLE
Added documentation on Stripe_Charge methods.

### DIFF
--- a/lib/Stripe/Charge.php
+++ b/lib/Stripe/Charge.php
@@ -8,6 +8,12 @@ class Stripe_Charge extends Stripe_ApiResource
     return self::scopedConstructFrom($class, $values, $apiKey);
   }
 
+  /**
+   * @param string      $id
+   * @param string|null $apiKey
+   *
+   * @return Stripe_Charge
+   */
   public static function retrieve($id, $apiKey=null)
   {
     $class = get_class();
@@ -32,6 +38,11 @@ class Stripe_Charge extends Stripe_ApiResource
     return self::_scopedSave($class);
   }
 
+  /**
+   * @param array|null $params
+   *
+   * @return Stripe_Charge
+   */
   public function refund($params=null)
   {
     $requestor = new Stripe_ApiRequestor($this->_apiKey);
@@ -41,6 +52,11 @@ class Stripe_Charge extends Stripe_ApiResource
     return $this;
   }
 
+  /**
+   * @param array|null $params
+   *
+   * @return Stripe_Charge
+   */
   public function capture($params=null)
   {
     $requestor = new Stripe_ApiRequestor($this->_apiKey);


### PR DESCRIPTION
The way Stripe classes are architectured, there is no way an IDE can understand what class each method returns, which creates inspection issues in our code base.

This PR adds correct documentation to the following methods in `Stripe_Charge`:
- `retrieve()`
- `capture()`
- `refund()`

I'll be happy to do more work on this project if you're willing to merge my pull requests.
