### PR TITLE
Add Stripe_RateLimitError that extends Stripe_InvalidRequestError

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -27,6 +27,7 @@ require(dirname(__FILE__) . '/Stripe/ApiConnectionError.php');
 require(dirname(__FILE__) . '/Stripe/AuthenticationError.php');
 require(dirname(__FILE__) . '/Stripe/CardError.php');
 require(dirname(__FILE__) . '/Stripe/InvalidRequestError.php');
+require(dirname(__FILE__) . '/Stripe/RateLimitError.php');
 
 // Plumbing
 require(dirname(__FILE__) . '/Stripe/Object.php');

--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -133,6 +133,11 @@ class Stripe_ApiRequestor
 
     switch ($rcode) {
     case 400:
+        if ($code == 'rate_limit') {
+          throw new Stripe_RateLimitError(
+              $msg, $param, $rcode, $rbody, $resp
+          );
+        }
     case 404:
         throw new Stripe_InvalidRequestError(
             $msg, $param, $rcode, $rbody, $resp

--- a/lib/Stripe/RateLimitError.php
+++ b/lib/Stripe/RateLimitError.php
@@ -1,0 +1,11 @@
+<?php
+
+class Stripe_RateLimitError extends Stripe_InvalidRequestError
+{
+  public function __construct($message, $param, $httpStatus=null,
+      $httpBody=null, $jsonBody=null
+  )
+  {
+    parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+  }
+}


### PR DESCRIPTION
To allow users to catch rate limit errors specifically.

r? @michelle 

Tested manually:

``` text

Fatal error: Uncaught exception 'Stripe_RateLimitError' with message 'Request rate limit exceeded' in /Users/jim/stripe/stripe-php/lib/Stripe/ApiRequestor.php:137
Stack trace:
#0 /Users/jim/stripe/stripe-php/lib/Stripe/ApiRequestor.php(202): Stripe_ApiRequestor->handleApiError('{?  "error": {?...', 400, Array)
#1 /Users/jim/stripe/stripe-php/lib/Stripe/ApiRequestor.php(104): Stripe_ApiRequestor->_interpretResponse('{?  "error": {?...', 400)
#2 /Users/jim/stripe/stripe-php/lib/Stripe/ApiResource.php(102): Stripe_ApiRequestor->request('get', '/v1/charges', Array)
#3 /Users/jim/stripe/stripe-php/lib/Stripe/Charge.php(26): Stripe_ApiResource::_scopedAll('Stripe_Charge', Array, NULL)
#4 /Users/jim/php_test/chunder.php(8): Stripe_Charge::all(Array)
#5 {main}
  thrown in /Users/jim/stripe/stripe-php/lib/Stripe/ApiRequestor.php on line 137
```
