### PR TITLE
Add ID to singleton account resource

### DIFF
--- a/lib/Stripe/Object.php
+++ b/lib/Stripe/Object.php
@@ -177,7 +177,7 @@ class Stripe_Object implements ArrayAccess
     }
 
     foreach ($values as $k => $v) {
-      if (self::$permanentAttributes->includes($k))
+      if (self::$permanentAttributes->includes($k) && isset($this[$k]))
         continue;
 
       if (self::$nestedUpdatableAttributes->includes($k) && is_array($v))

--- a/test/Stripe/AccountTest.php
+++ b/test/Stripe/AccountTest.php
@@ -6,6 +6,7 @@ class Stripe_AccountTest extends StripeTestCase
   {
     authorizeFromEnv();
     $d = Stripe_Account::retrieve();
+    $this->assertEqual($d->id, "cuD9Rwx8pgmRZRpVe02lsuR9cwp2Bzf7");
     $this->assertEqual($d->email, "test+bindings@stripe.com");
     // @codingStandardsIgnoreStart
     $this->assertEqual($d->charge_enabled, false);


### PR DESCRIPTION
ID wasn't showing on the account object before, because we considered it a permanent attribute (from the other resources) and never set it. However, when it's not set in the object, we should go ahead and set it from the value from the response.
