### PR TITLE
fix using $this in a static context

### DIFF
--- a/lib/Stripe/Object.php
+++ b/lib/Stripe/Object.php
@@ -149,8 +149,7 @@ class Stripe_Object implements ArrayAccess
    */
   public static function constructFrom($values, $apiKey=null)
   {
-    $class = get_called_class();
-    return self::scopedConstructFrom($class, $values, $apiKey);
+    return self::scopedConstructFrom(__CLASS__, $values, $apiKey);
   }
 
   /**


### PR DESCRIPTION
Current code produces an error notice. As the method is static get_called_class should be used.
