### PR TITLE
Fix HHVM test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ php:
   - 5.6
   - hhvm
 
-matrix:
-  allow_failures:
-      - php: hhvm
-
 before_script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then wget http://iweb.dl.sourceforge.net/project/simpletest/simpletest/simpletest_1.1/simpletest_1.1.0.tar.gz; tar xf simpletest_1.1.0.tar.gz -C test; else composer install --dev --prefer-source; fi"
 

--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -338,6 +338,12 @@ class Stripe_ApiRequestor
       return true;
     }
 
+    if (strpos(PHP_VERSION, 'hiphop') !== false) {
+      error_log("Warning: HHVM does not support SSL certificate verification. (See http://docs.hhvm.com/manual/en/context.ssl.php) " .
+                "Stripe cannot guarantee that the server has a certificate which is not blacklisted");
+      return true;
+    }
+
     $url = parse_url($url);
     $port = isset($url["port"]) ? $url["port"] : 443;
     $url = "ssl://{$url["host"]}:{$port}";
@@ -349,6 +355,7 @@ class Stripe_ApiRequestor
         )));
     $result = stream_socket_client($url, $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $sslContext);
     if ($errno !== 0) {
+        $apiBase = Stripe::$apiBase;
         throw new Stripe_ApiConnectionError(
              "Could not connect to Stripe ($apiBase).  Please check your "
            . "internet connection and try again.  If this problem persists, "

--- a/test/Stripe/PlanTest.php
+++ b/test/Stripe/PlanTest.php
@@ -21,19 +21,20 @@ class Stripe_PlanTest extends StripeTestCase
   public function testId()
   {
     authorizeFromEnv();
+    $id = self::randomString();
     $plan = Stripe_Plan::create(
         array(
             'amount'   => 2000,
             'interval' => 'month',
             'currency' => 'usd',
             'name'     => 'Plan',
-            'id'       => '0'
+            'id'       => $id
         )
     );
-    $retrieved_plan = Stripe_Plan::retrieve('0');
+    $retrieved_plan = Stripe_Plan::retrieve($id);
 
     $this->assertEqual($plan->id, $retrieved_plan->id);
-    $this->assertEqual($plan->id, '0');
+    $this->assertEqual($plan->id, $id);
 
     $plan->delete();
   }


### PR DESCRIPTION
Looks like HHVM doesn't support our revocation checking: http://docs.hhvm.com/manual/en/context.ssl.php

Can we convert this to hit a blank endpoint and check CURLINFO_SSL_VERIFYRESULT instead?
