### PR TITLE
Add support for updating a refund

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -53,4 +53,5 @@ require(dirname(__FILE__) . '/Stripe/Coupon.php');
 require(dirname(__FILE__) . '/Stripe/Event.php');
 require(dirname(__FILE__) . '/Stripe/Transfer.php');
 require(dirname(__FILE__) . '/Stripe/Recipient.php');
+require(dirname(__FILE__) . '/Stripe/Refund.php');
 require(dirname(__FILE__) . '/Stripe/ApplicationFee.php');

--- a/lib/Stripe/Refund.php
+++ b/lib/Stripe/Refund.php
@@ -1,0 +1,36 @@
+<?php
+
+class Stripe_Refund extends Stripe_ApiResource
+{
+  /**
+   * @return string The API URL for this Stripe refund.
+   */
+  public function instanceUrl()
+  {
+    $id = $this['id'];
+    $charge = $this['charge'];
+    if (!$id) {
+      throw new Stripe_InvalidRequestError(
+          "Could not determine which URL to request: " .
+          "class instance has invalid ID: $id",
+          null
+      );
+    }
+    $id = Stripe_ApiRequestor::utf8($id);
+    $charge = Stripe_ApiRequestor::utf8($charge);
+
+    $base = self::classUrl('Stripe_Charge');
+    $chargeExtn = urlencode($charge);
+    $extn = urlencode($id);
+    return "$base/$chargeExtn/refunds/$extn";
+  }
+
+  /**
+   * @return Stripe_Refund The saved refund.
+   */
+  public function save()
+  {
+    $class = get_class();
+    return self::_scopedSave($class);
+  }
+}

--- a/lib/Stripe/Util.php
+++ b/lib/Stripe/Util.php
@@ -66,6 +66,7 @@ abstract class Stripe_Util
       'transfer' => 'Stripe_Transfer',
       'plan' => 'Stripe_Plan',
       'recipient' => 'Stripe_Recipient',
+      'refund' => 'Stripe_Refund',
       'subscription' => 'Stripe_Subscription'
     );
     if (self::isList($resp)) {

--- a/test/Stripe.php
+++ b/test/Stripe.php
@@ -55,5 +55,6 @@ require_once(dirname(__FILE__) . '/Stripe/SubscriptionTest.php');
 require_once(dirname(__FILE__) . '/Stripe/Token.php');
 require_once(dirname(__FILE__) . '/Stripe/TransferTest.php');
 require_once(dirname(__FILE__) . '/Stripe/RecipientTest.php');
+require_once(dirname(__FILE__) . '/Stripe/RefundTest.php');
 require_once(dirname(__FILE__) . '/Stripe/ApplicationFeeTest.php');
 require_once(dirname(__FILE__) . '/Stripe/UtilTest.php');

--- a/test/Stripe/RefundTest.php
+++ b/test/Stripe/RefundTest.php
@@ -1,0 +1,36 @@
+<?php
+
+class Stripe_RefundTest extends StripeTestCase
+{
+
+  public function testCreate()
+  {
+    $charge = self::createTestCharge();
+    $ref = $charge->refunds->create(array('amount' => 100));
+    $this->assertEqual(100, $ref->amount);
+    $this->assertEqual($charge->id, $ref->charge);
+  }
+
+  public function testUpdateAndRetrieve()
+  {
+    $charge = self::createTestCharge();
+    $ref = $charge->refunds->create(array('amount' => 100));
+    $ref->metadata["key"] = "value";
+    $ref->save();
+    $ref = $charge->refunds->retrieve($ref->id);
+    $this->assertEqual("value", $ref->metadata["key"], "value");
+  }
+ 
+  public function testList()
+  {
+    $charge = self::createTestCharge();
+    $refA = $charge->refunds->create(array('amount' => 50));
+    $refB = $charge->refunds->create(array('amount' => 50));
+
+    $all = $charge->refunds->all();
+    $this->assertEqual(false, $all->has_more);
+    $this->assertEqual(2, count($all->data));
+    $this->assertEqual($refA->id, $all->data[0]->id);
+    $this->assertEqual($refB->id, $all->data[1]->id);
+  }
+}

--- a/test/Stripe/TestCase.php
+++ b/test/Stripe/TestCase.php
@@ -8,6 +8,28 @@ abstract class StripeTestCase extends UnitTestCase
 {
 
   /**
+   * Create a valid test charge.
+   */
+  protected static function createTestCharge(array $attributes = array())
+  {
+    authorizeFromEnv();
+
+    return Stripe_Charge::create(
+        $attributes + array(
+          "amount" => 2000,
+          "currency" => "usd",
+          "description" => "Charge for test@example.com",
+          'card' => array(
+            'number'    => '4242424242424242',
+            'exp_month' => 5,
+            'exp_year'  => date('Y') + 3,
+          ),
+        )
+    );
+  }
+
+
+  /**
    * Create a valid test customer.
    */
   protected static function createTestCustomer(array $attributes = array())


### PR DESCRIPTION
Now that refunds can be updated, add support for adding and updating metadata.

Note: the tests will not pass until the support in the API has been shipped. Don't merge until then.
