### PR TITLE
Underscored namespaces: ApiResource.php

### DIFF
--- a/lib/Stripe/ApiResource.php
+++ b/lib/Stripe/ApiResource.php
@@ -38,6 +38,10 @@ abstract class Stripe_ApiResource extends Stripe_Object
     if ($postfix = strrchr($class, '\\')) {
       $class = substr($postfix, 1);
     }
+    // Useful for underscored 'namespaces': Foo_Stripe_Charge
+    if ($postfix2 = strrchr($class, 'Stripe_')) {
+      $class = substr($postfix2, 0);
+    }
     if (substr($class, 0, strlen('Stripe')) == 'Stripe') {
       $class = substr($class, strlen('Stripe'));
     }


### PR DESCRIPTION
Fix for underscored namespaces and className method.

If the library is included in a project that uses an autoloader with underscored class names, the className method won't work correctly to get the API endpoint. This fixes that.
