### PR TITLE
Make sure $errno is set, fixes an issue with HHVM where $errno is null.

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -372,7 +372,7 @@ class Stripe_ApiRequestor
     $result = stream_socket_client(
         $url, $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $sslContext
     );
-    if ($errno !== 0) {
+    if ( $errno !== null && $errno !== 0 ) {
       $apiBase = Stripe::$apiBase;
       throw new Stripe_ApiConnectionError(
           'Could not connect to Stripe (' . $apiBase . ').  Please check your '.


### PR DESCRIPTION
This fixes an issue with HHVM where they do not set `$errno` if there is no error. This means `$errno` is `null` which makes the Stripe API wrapper think there was an error (since `null !== 0`).
