### PR TITLE
Properly handle list URLs with query params

### DIFF
--- a/lib/Stripe/List.php
+++ b/lib/Stripe/List.php
@@ -4,34 +4,51 @@ class Stripe_List extends Stripe_Object
 {
   public function all($params=null)
   {
+    list($url, $params) = $this->extractPathAndUpdateParams($params);
+
     $requestor = new Stripe_ApiRequestor($this->_apiKey);
-    list($response, $apiKey) = $requestor->request(
-        'get',
-        $this['url'],
-        $params
-    );
+    list($response, $apiKey) = $requestor->request('get', $url, $params);
     return Stripe_Util::convertToStripeObject($response, $apiKey);
   }
 
   public function create($params=null)
   {
+    list($url, $params) = $this->extractPathAndUpdateParams($params);
+
     $requestor = new Stripe_ApiRequestor($this->_apiKey);
-    list($response, $apiKey) = $requestor->request(
-        'post', $this['url'], $params
-    );
+    list($response, $apiKey) = $requestor->request('post', $url, $params);
     return Stripe_Util::convertToStripeObject($response, $apiKey);
   }
 
   public function retrieve($id, $params=null)
   {
+    list($url, $params) = $this->extractPathAndUpdateParams($params);
+
     $requestor = new Stripe_ApiRequestor($this->_apiKey);
-    $base = $this['url'];
     $id = Stripe_ApiRequestor::utf8($id);
     $extn = urlencode($id);
     list($response, $apiKey) = $requestor->request(
-        'get', "$base/$extn", $params
+        'get', "$url/$extn", $params
     );
     return Stripe_Util::convertToStripeObject($response, $apiKey);
   }
 
+  private function extractPathAndUpdateParams($params)
+  {
+    $url = parse_url($this->url);
+    if (!isset($url['path'])) {
+      throw new Stripe_APIError("Could not parse list url into parts: $url");
+    }
+
+    if (isset($url['query'])) {
+      // If the URL contains a query param, parse it out into $params so they
+      // don't interact weirdly with each other.
+      $query = array();
+      parse_str($url['query'], $query);
+      // PHP 5.2 doesn't support the ?: operator :(
+      $params = array_merge($params ? $params : array(), $query);
+    }
+
+    return array($url['path'], $params);
+  }
 }

--- a/test/Stripe/InvoiceTest.php
+++ b/test/Stripe/InvoiceTest.php
@@ -24,6 +24,35 @@ class Stripe_InvoiceTest extends StripeTestCase
     $this->assertEqual($invoice->attempted, false);
   }
 
+  public function testItemsAccessWithParameter()
+  {
+    self::authorizeFromEnv();
+    $customer = self::createTestCustomer();
+
+    Stripe_InvoiceItem::create(
+        array(
+            'customer'  => $customer->id,
+            'amount'    => 100,
+            'currency'  => 'usd',
+        )
+    );
+
+    $invoice = Stripe_Invoice::upcoming(
+        array(
+            'customer' => $customer->id,
+        )
+    );
+
+    $lines = $invoice->lines->all(
+        array(
+          'limit' => 10,
+        )
+    );
+
+    $this->assertEqual(count($lines->data), 1);
+    $this->assertEqual($lines->data[0]->amount, 100);
+  }
+
   // This is really just making sure that this operation does not trigger any
   // warnings, as it's highly nested.
   public function testAll()


### PR DESCRIPTION
Upcoming invoices use a URL of the form `/v1/invoices/upcoming/lines?customer=cus_4ozMxJvDf1vy39` for their `url` field. This breaks calls to `Stripe_List` on `$upcoming_invoice->lines`.

r? @michelle 
CC @andrewpthorp 
