### PR TITLE
Update ApiRequestor for newer hhvm

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -348,7 +348,7 @@ class Stripe_ApiRequestor
       return true;
     }
 
-    if (strpos(PHP_VERSION, 'hiphop') !== false) {
+    if (strpos(PHP_VERSION, 'hiphop') !== false || strpos(PHP_VERSION, 'hhvm') !== false) {
       error_log(
           'Warning: HHVM does not support Stripe\'s SSL certificate '.
           'verification. (See http://docs.hhvm.com/manual/en/context.ssl.php) '.


### PR DESCRIPTION
Current versions of HHVM don't include 'hiphop' in the PHP_VERSION string; they are using hhvm.  Update the SSL Cert check to ignore those versions as well, or your application will return an 'unable to connect to stripe' error.
