### PR TITLE
stream_socket_client may return FALSE (and $errno may be NULL on HHVM)

### DIFF
--- a/lib/Stripe/ApiRequestor.php
+++ b/lib/Stripe/ApiRequestor.php
@@ -363,7 +363,7 @@ class Stripe_ApiRequestor
     $result = stream_socket_client(
         $url, $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $sslContext
     );
-    if ($errno !== 0) {
+    if (($errno !== 0 && $errno !== NULL) || $result === false) {
       $apiBase = Stripe::$apiBase;
       throw new Stripe_ApiConnectionError(
           'Could not connect to Stripe (' . $apiBase . ').  Please check your '.


### PR DESCRIPTION
FIX: on HHVM, stream_socket_client returns $errno of NULL on success.
FIX: stream_socket_client can return FALSE which indicates an error (see php.net/stream_socket_client).

Note that I have not tested what HHVM returns for $errno for all cases. It is possible that if an error occurs $errno is NULL (i.e. HHVM is not setting $errno in all cases and that is their bug). For Zend Engine, the additional test for $errno being NULL should not cause any change in behaviour.
