### PR TITLE
Add support for a per-request options hash in the place of an API key

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -36,6 +36,7 @@ require(dirname(__FILE__) . '/Stripe/ApiResource.php');
 require(dirname(__FILE__) . '/Stripe/SingletonApiResource.php');
 require(dirname(__FILE__) . '/Stripe/AttachedObject.php');
 require(dirname(__FILE__) . '/Stripe/List.php');
+require(dirname(__FILE__) . '/Stripe/RequestOptions.php');
 
 // Stripe API Resources
 require(dirname(__FILE__) . '/Stripe/Account.php');

--- a/lib/Stripe/Charge.php
+++ b/lib/Stripe/Charge.php
@@ -8,10 +8,10 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return Stripe_Charge
    */
-  public static function retrieve($id, $apiKey=null)
+  public static function retrieve($id, $options=null)
   {
     $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
+    return self::_scopedRetrieve($class, $id, $options);
   }
 
   /**
@@ -20,10 +20,10 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return array An array of Stripe_Charges.
    */
-  public static function all($params=null, $apiKey=null)
+  public static function all($params=null, $options=null)
   {
     $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
+    return self::_scopedAll($class, $params, $options);
   }
 
   /**
@@ -32,19 +32,19 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return Stripe_Charge The created charge.
    */
-  public static function create($params=null, $apiKey=null)
+  public static function create($params=null, $options=null)
   {
     $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
+    return self::_scopedCreate($class, $params, $options);
   }
 
   /**
    * @return Stripe_Charge The saved charge.
    */
-  public function save()
+  public function save($options=null)
   {
     $class = get_class();
-    return self::_scopedSave($class);
+    return self::_scopedSave($class, $options);
   }
 
   /**
@@ -52,11 +52,13 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return Stripe_Charge The refunded charge.
    */
-  public function refund($params=null)
+  public function refund($params=null, $options=null)
   {
-    $requestor = new Stripe_ApiRequestor($this->_apiKey);
+    $opts = $this->parseOptions($options);
+    $requestor = new Stripe_ApiRequestor($opts->apiKey);
     $url = $this->instanceUrl() . '/refund';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
+    list($response, $apiKey) = 
+      $requestor->request('post', $url, $params, $opts->headers);
     $this->refreshFrom($response, $apiKey);
     return $this;
   }
@@ -66,11 +68,13 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return Stripe_Charge The captured charge.
    */
-  public function capture($params=null)
+  public function capture($params=null, $options=null)
   {
-    $requestor = new Stripe_ApiRequestor($this->_apiKey);
+    $opts = $this->parseOptions($options);
+    $requestor = new Stripe_ApiRequestor($opts->apiKey);
     $url = $this->instanceUrl() . '/capture';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
+    list($response, $apiKey) = 
+      $requestor->request('post', $url, $params, $opts->headers);
     $this->refreshFrom($response, $apiKey);
     return $this;
   }
@@ -80,11 +84,13 @@ class Stripe_Charge extends Stripe_ApiResource
    *
    * @return array The updated dispute.
    */
-  public function updateDispute($params=null)
+  public function updateDispute($params=null, $option=null)
   {
-    $requestor = new Stripe_ApiRequestor($this->_apiKey);
+    $opts = $this->parseOptions($options);
+    $requestor = new Stripe_ApiRequestor($opts->apiKey);
     $url = $this->instanceUrl() . '/dispute';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
+    list($response, $apiKey) = 
+      $requestor->request('post', $url, $params, $headers);
     $this->refreshFrom(array('dispute' => $response), $apiKey, true);
     return $this->dispute;
   }
@@ -92,11 +98,13 @@ class Stripe_Charge extends Stripe_ApiResource
   /**
    * @return Stripe_Charge The updated charge.
    */
-  public function closeDispute()
+  public function closeDispute($options=null)
   {
-    $requestor = new Stripe_ApiRequestor($this->_apiKey);
+    $opts = $this->parseOptions($options);
+    $requestor = new Stripe_ApiRequestor($opts->apiKey);
     $url = $this->instanceUrl() . '/dispute/close';
-    list($response, $apiKey) = $requestor->request('post', $url);
+    list($response, $apiKey) = 
+      $requestor->request('post', $url, null, $opts->headers);
     $this->refreshFrom($response, $apiKey);
     return $this;
   }

--- a/lib/Stripe/RequestOptions.php
+++ b/lib/Stripe/RequestOptions.php
@@ -1,0 +1,43 @@
+<?php
+
+class Stripe_RequestOptions
+{
+  public $headers;
+  public $apiKey;
+ 
+  public function __construct($key, $headers)
+  {
+    $this->apiKey = $key;
+    $this->headers = $headers;
+  }
+
+  /**
+   * Unpacks an options array into an Options object
+   * @param array|string $options a key => value array
+   * @return Options
+   */
+  public static function parse($options)
+  {
+    if (is_null($options)) {
+      return new Stripe_RequestOptions(null, array());
+    }
+
+    if (is_string($options)) {
+      return new Stripe_RequestOptions($options, array());
+    }
+
+    if (is_array($options)) {
+      $headers = array();
+      $key = null;
+      if (array_key_exists('api_key', $options)) {
+        $key = $options['api_key'];
+      }
+      if (array_key_exists('idempotency_key', $options)) {
+        $headers['Idempotency-Key'] = $options['idempotency_key'];
+      }
+      return new Stripe_RequestOptions($key, $headers);
+    }
+
+    throw new Stripe_Error("options must be a string, an array, or null");
+  }
+}

--- a/test/Stripe.php
+++ b/test/Stripe.php
@@ -53,3 +53,4 @@ require_once(dirname(__FILE__) . '/Stripe/RefundTest.php');
 require_once(dirname(__FILE__) . '/Stripe/ApplicationFeeTest.php');
 require_once(dirname(__FILE__) . '/Stripe/ApplicationFeeRefundTest.php');
 require_once(dirname(__FILE__) . '/Stripe/UtilTest.php');
+require_once(dirname(__FILE__) . '/Stripe/RequestOptionsTest.php');

--- a/test/Stripe/ChargeTest.php
+++ b/test/Stripe/ChargeTest.php
@@ -30,6 +30,32 @@ class Stripe_ChargeTest extends StripeTestCase
     $this->assertFalse($c->refunded);
   }
 
+  public function testIdempotentCreate()
+  {
+    self::authorizeFromEnv();
+
+    $card = array(
+      'number' => '4242424242424242',
+      'exp_month' => 5,
+      'exp_year' => 2015
+    );
+
+    $c = Stripe_Charge::create(
+        array(
+          'amount' => 100,
+          'currency' => 'usd',
+          'card' => $card
+        ),
+        array(
+          'idempotency_key' => $this->generateRandomString(),
+        )
+    );
+
+    $this->assertTrue($c->paid);
+    $this->assertFalse($c->refunded);
+  }
+
+
   public function testRetrieve()
   {
     self::authorizeFromEnv();

--- a/test/Stripe/RequestOptionsTest.php
+++ b/test/Stripe/RequestOptionsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+class Stripe_RequestOptionsTest extends StripeTestCase
+{
+  public function testStringAPIKey()
+  {
+    $opts = Stripe_RequestOptions::parse("foo");
+    $this->assertEqual("foo", $opts->apiKey);
+    $this->assertEqual(array(), $opts->headers);
+  }
+
+  public function testNull()
+  {
+    $opts = Stripe_RequestOptions::parse(null);
+    $this->assertEqual(null, $opts->apiKey);
+    $this->assertEqual(array(), $opts->headers);
+  }
+
+  public function testEmptyArray()
+  {
+    $opts = Stripe_RequestOptions::parse(array());
+    $this->assertEqual(null, $opts->apiKey);
+    $this->assertEqual(array(), $opts->headers);
+  }
+
+  public function testAPIKeyArray()
+  {
+    $opts = Stripe_RequestOptions::parse(
+        array(
+            'api_key' => 'foo',
+        )
+    );
+    $this->assertEqual('foo', $opts->apiKey);
+    $this->assertEqual(array(), $opts->headers);
+  }
+
+  public function testIdempotentKeyArray()
+  {
+    $opts = Stripe_RequestOptions::parse(
+        array(
+            'idempotency_key' => 'foo',
+        )
+    );
+    $this->assertEqual(null, $opts->apiKey);
+    $this->assertEqual(array('Idempotency-Key' => 'foo'), $opts->headers);
+  }
+
+  public function testKeyArray()
+  {
+    $opts = Stripe_RequestOptions::parse(
+        array(
+            'idempotency_key' => 'foo',
+            'api_key' => 'foo'
+        )
+    );
+    $this->assertEqual('foo', $opts->apiKey);
+    $this->assertEqual(array('Idempotency-Key' => 'foo'), $opts->headers);
+  }
+
+  public function testWrongType()
+  {
+    $caught = false;
+    try {
+      $opts = Stripe_RequestOptions::parse(5);
+    } catch (Stripe_Error $e) {
+      $caught = true;
+    }
+    $this->assertTrue($caught);
+  }
+}

--- a/test/Stripe/TestCase.php
+++ b/test/Stripe/TestCase.php
@@ -135,4 +135,18 @@ abstract class StripeTestCase extends UnitTestCase
       );
     }
   }
+
+  /**
+   * Genereate a semi-random string
+   */
+  public function generateRandomString($length = 24)
+  {
+    $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTU';
+    $charactersLength = strlen($characters);
+    $randomString = '';
+    for ($i = 0; $i < $length; $i++) {
+        $randomString .= $characters[rand(0, $charactersLength - 1)];
+    }
+    return $randomString;
+  }
 }


### PR DESCRIPTION
For example, when creating a customer, you can specify an idempotency
key:

```
Stripe_Customer::create(array(
  'description' => 'Some customer',
), array(
  'idempotency_key' => 'foo',
));
```
This allows us to add more per-request attributes in the future.