### PR TITLE
Use PSR2 standard instead of Zend - Fix all errors in code

### DIFF
--- a/build.php
+++ b/build.php
@@ -9,7 +9,7 @@ if ($returnStatus !== 0) {
 }
 
 passthru(
-    './vendor/bin/phpcs --standard=Zend lib tests *.php',
+    './vendor/bin/phpcs --standard=PSR2 -n lib tests *.php',
     $returnStatus
 );
 if ($returnStatus !== 0) {

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -4,14 +4,14 @@ namespace Stripe;
 
 class Account extends SingletonApiResource
 {
-  /**
+    /**
     * @param string|null $apiKey
     *
     * @return Account
     */
-  public static function retrieve($apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedSingletonRetrieve($class, $apiKey);
-  }
+    public static function retrieve($apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedSingletonRetrieve($class, $apiKey);
+    }
 }

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -4,92 +4,96 @@ namespace Stripe;
 
 class ApiRequestor
 {
-  private $_apiKey;
+    private $_apiKey;
 
-  private $_apiBase;
+    private $_apiBase;
 
-  private static $_preFlight = array();
+    private static $_preFlight = array();
 
-  private static $_blacklistedCerts = array(
+    private static $_blacklistedCerts = array(
     '05c0b3643694470a888c6e7feb5c9e24e823dc53',
     '5b7dc7fbc98d78bf76d4d4fa6f597a0c901fad5c',
-  );
+    );
 
-  public function __construct($apiKey=null, $apiBase=null)
-  {
-    $this->_apiKey = $apiKey;
-    if (!$apiBase) {
-      $apiBase = Stripe::$apiBase;
+    public function __construct($apiKey = null, $apiBase = null)
+    {
+        $this->_apiKey = $apiKey;
+        if (!$apiBase) {
+            $apiBase = Stripe::$apiBase;
+        }
+        $this->_apiBase = $apiBase;
     }
-    $this->_apiBase = $apiBase;
-  }
 
-  /**
+    /**
    * @param string|mixed $value A string to UTF8-encode.
    *
    * @returns string|mixed The UTF8-encoded string, or the object passed in if
    *    it wasn't a string.
    */
-  public static function utf8($value)
-  {
-    if (is_string($value)
-        && mb_detect_encoding($value, "UTF-8", TRUE) != "UTF-8") {
-      return utf8_encode($value);
-    } else {
-      return $value;
+    public static function utf8($value)
+    {
+        if (is_string($value)
+        && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
+            return utf8_encode($value);
+        } else {
+            return $value;
+        }
     }
-  }
 
-  private static function _encodeObjects($d)
-  {
-    if ($d instanceof ApiResource) {
-      return self::utf8($d->id);
-    } else if ($d === true) {
-      return 'true';
-    } else if ($d === false) {
-      return 'false';
-    } else if (is_array($d)) {
-      $res = array();
-      foreach ($d as $k => $v)
-              $res[$k] = self::_encodeObjects($v);
-      return $res;
-    } else {
-      return self::utf8($d);
+    private static function _encodeObjects($d)
+    {
+        if ($d instanceof ApiResource) {
+            return self::utf8($d->id);
+        } elseif ($d === true) {
+            return 'true';
+        } elseif ($d === false) {
+            return 'false';
+        } elseif (is_array($d)) {
+            $res = array();
+            foreach ($d as $k => $v) {
+                $res[$k] = self::_encodeObjects($v);
+            }
+            return $res;
+        } else {
+            return self::utf8($d);
+        }
     }
-  }
 
-  /**
+    /**
    * @param array $arr An map of param keys to values.
    * @param string|null $prefix (It doesn't look like we ever use $prefix...)
    *
    * @returns string A querystring, essentially.
    */
-  public static function encode($arr, $prefix=null)
-  {
-    if (!is_array($arr))
-      return $arr;
+    public static function encode($arr, $prefix = null)
+    {
+        if (!is_array($arr)) {
+            return $arr;
+        }
 
-    $r = array();
-    foreach ($arr as $k => $v) {
-      if (is_null($v))
-        continue;
+        $r = array();
+        foreach ($arr as $k => $v) {
+            if (is_null($v)) {
+                continue;
+            }
 
-      if ($prefix && $k && !is_int($k))
-        $k = $prefix."[".$k."]";
-      else if ($prefix)
-        $k = $prefix."[]";
+            if ($prefix && $k && !is_int($k)) {
+                $k = $prefix."[".$k."]";
+            } elseif ($prefix) {
+                        $k = $prefix."[]";
+            }
 
-      if (is_array($v)) {
-        $r[] = self::encode($v, $k, true);
-      } else {
-        $r[] = urlencode($k)."=".urlencode($v);
-      }
+            if (is_array($v)) {
+                $r[] = self::encode($v, $k, true);
+            } else {
+                $r[] = urlencode($k)."=".urlencode($v);
+            }
+        }
+
+        return implode("&", $r);
     }
 
-    return implode("&", $r);
-  }
-
-  /**
+    /**
    * @param string $method
    * @param string $url
    * @param array|null $params
@@ -97,17 +101,18 @@ class ApiRequestor
    * @return array An array whose first element is the response and second
    *    element is the API key used to make the request.
    */
-  public function request($method, $url, $params=null)
-  {
-    if (!$params)
-      $params = array();
-    list($rbody, $rcode, $myApiKey) =
-      $this->_requestRaw($method, $url, $params);
-    $resp = $this->_interpretResponse($rbody, $rcode);
-    return array($resp, $myApiKey);
-  }
+    public function request($method, $url, $params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        list($rbody, $rcode, $myApiKey) =
+        $this->_requestRaw($method, $url, $params);
+        $resp = $this->_interpretResponse($rbody, $rcode);
+        return array($resp, $myApiKey);
+    }
 
-  /**
+    /**
    * @param string $rbody A JSON string.
    * @param int $rcode
    * @param array $resp
@@ -119,251 +124,262 @@ class ApiRequestor
    *    required)
    * @throws ApiError otherwise.
    */
-  public function handleApiError($rbody, $rcode, $resp)
-  {
-    if (!is_array($resp) || !isset($resp['error'])) {
-      $msg = "Invalid response object from API: $rbody "
-           ."(HTTP response code was $rcode)";
-      throw new ApiError($msg, $rcode, $rbody, $resp);
-    }
-
-    $error = $resp['error'];
-    $msg = isset($error['message']) ? $error['message'] : null;
-    $param = isset($error['param']) ? $error['param'] : null;
-    $code = isset($error['code']) ? $error['code'] : null;
-
-    switch ($rcode) {
-    case 400:
-        if ($code == 'rate_limit') {
-          throw new RateLimitError(
-              $msg, $param, $rcode, $rbody, $resp
-          );
+    public function handleApiError($rbody, $rcode, $resp)
+    {
+        if (!is_array($resp) || !isset($resp['error'])) {
+            $msg = "Invalid response object from API: $rbody "
+             ."(HTTP response code was $rcode)";
+            throw new ApiError($msg, $rcode, $rbody, $resp);
         }
-    case 404:
-        throw new InvalidRequestError(
-            $msg, $param, $rcode, $rbody, $resp
-        );
-    case 401:
-        throw new AuthenticationError($msg, $rcode, $rbody, $resp);
-    case 402:
-        throw new CardError($msg, $param, $code, $rcode, $rbody, $resp);
-    default:
-        throw new ApiError($msg, $rcode, $rbody, $resp);
-    }
-  }
 
-  private function _requestRaw($method, $url, $params)
-  {
-    if (!array_key_exists($this->_apiBase, self::$_preFlight)
-      || !self::$_preFlight[$this->_apiBase]) {
-      self::$_preFlight[$this->_apiBase] = $this->checkSslCert($this->_apiBase);
+        $error = $resp['error'];
+        $msg = isset($error['message']) ? $error['message'] : null;
+        $param = isset($error['param']) ? $error['param'] : null;
+        $code = isset($error['code']) ? $error['code'] : null;
+
+        switch ($rcode) {
+            case 400:
+                if ($code == 'rate_limit') {
+                    throw new RateLimitError(
+                        $msg,
+                        $param,
+                        $rcode,
+                        $rbody,
+                        $resp
+                    );
+                }
+
+                // intentional fall-through
+            case 404:
+                throw new InvalidRequestError(
+                    $msg,
+                    $param,
+                    $rcode,
+                    $rbody,
+                    $resp
+                );
+            case 401:
+                throw new AuthenticationError($msg, $rcode, $rbody, $resp);
+            case 402:
+                throw new CardError($msg, $param, $code, $rcode, $rbody, $resp);
+            default:
+                throw new ApiError($msg, $rcode, $rbody, $resp);
+        }
     }
 
-    $myApiKey = $this->_apiKey;
-    if (!$myApiKey) {
-      $myApiKey = Stripe::$apiKey;
-    }
+    private function _requestRaw($method, $url, $params)
+    {
+        if (!array_key_exists($this->_apiBase, self::$_preFlight)
+        || !self::$_preFlight[$this->_apiBase]) {
+            self::$_preFlight[$this->_apiBase] = $this->checkSslCert($this->_apiBase);
+        }
 
-    if (!$myApiKey) {
-      $msg = 'No API key provided.  (HINT: set your API key using '
-           . '"Stripe::setApiKey(<API-KEY>)".  You can generate API keys from '
-           . 'the Stripe web interface.  See https://stripe.com/api for '
-           . 'details, or email support@stripe.com if you have any questions.';
-      throw new AuthenticationError($msg);
-    }
+        $myApiKey = $this->_apiKey;
+        if (!$myApiKey) {
+            $myApiKey = Stripe::$apiKey;
+        }
 
-    $absUrl = $this->_apiBase.$url;
-    $params = self::_encodeObjects($params);
-    $langVersion = phpversion();
-    $uname = php_uname();
-    $ua = array(
+        if (!$myApiKey) {
+            $msg = 'No API key provided.  (HINT: set your API key using '
+             . '"Stripe::setApiKey(<API-KEY>)".  You can generate API keys from '
+             . 'the Stripe web interface.  See https://stripe.com/api for '
+             . 'details, or email support@stripe.com if you have any questions.';
+            throw new AuthenticationError($msg);
+        }
+
+        $absUrl = $this->_apiBase.$url;
+        $params = self::_encodeObjects($params);
+        $langVersion = phpversion();
+        $uname = php_uname();
+        $ua = array(
         'bindings_version' => Stripe::VERSION,
         'lang' => 'php',
         'lang_version' => $langVersion,
         'publisher' => 'stripe',
         'uname' => $uname,
-    );
-    $headers = array(
+        );
+        $headers = array(
         'X-Stripe-Client-User-Agent: ' . json_encode($ua),
         'User-Agent: Stripe/v1 PhpBindings/' . Stripe::VERSION,
         'Authorization: Bearer ' . $myApiKey,
-    );
-    if (Stripe::$apiVersion) {
-      $headers[] = 'Stripe-Version: ' . Stripe::$apiVersion;
-    }
-    $hasFile = false;
-    $hasCurlFile = class_exists('\CURLFile');
-    foreach ($params as $k => $v) {
-      if (is_resource($v)) {
-        $hasFile = true;
-        $params[$k] = self::_processResourceParam($v);
-      } else if ($hasCurlFile && $v instanceof \CURLFile) {
-        $hasFile = true;
-      }
-    }
-
-    if ($hasFile) {
-      $headers[] = 'Content-Type: multipart/form-data';
-    } else {
-      $headers[] = 'Content-Type: application/x-www-form-urlencoded';
-    }
-
-    list($rbody, $rcode) = $this->_curlRequest(
-        $method,
-        $absUrl,
-        $headers,
-        $params,
-        $hasFile
-    );
-    return array($rbody, $rcode, $myApiKey);
-  }
-
-  private function _processResourceParam($resource)
-  {
-    if (get_resource_type($resource) !== 'stream') {
-      throw new ApiError(
-          'Attempted to upload a resource that is not a stream'
-      );
-    }
-
-    $metaData = stream_get_meta_data($resource);
-    if ($metaData['wrapper_type'] !== 'plainfile') {
-      throw new ApiError(
-          'Only plainfile resource streams are supported'
-      );
-    }
-
-    if (class_exists('\CURLFile')) {
-      // We don't have the filename or mimetype, but the API doesn't care
-      return new \CURLFile($metaData['uri']);
-    } else {
-      return '@'.$metaData['uri'];
-    }
-  }
-
-  private function _interpretResponse($rbody, $rcode)
-  {
-    try {
-      $resp = json_decode($rbody, true);
-    } catch (Exception $e) {
-      $msg = "Invalid response body from API: $rbody "
-           . "(HTTP response code was $rcode)";
-      throw new ApiError($msg, $rcode, $rbody);
-    }
-
-    if ($rcode < 200 || $rcode >= 300) {
-      $this->handleApiError($rbody, $rcode, $resp);
-    }
-    return $resp;
-  }
-
-  private function _curlRequest($method, $absUrl, $headers, $params, $hasFile)
-  {
-    $curl = curl_init();
-    $method = strtolower($method);
-    $opts = array();
-    if ($method == 'get') {
-      if ($hasFile) {
-        throw new ApiError(
-            "Issuing a GET request with a file parameter"
         );
-      }
-      $opts[CURLOPT_HTTPGET] = 1;
-      if (count($params) > 0) {
-        $encoded = self::encode($params);
-        $absUrl = "$absUrl?$encoded";
-      }
-    } else if ($method == 'post') {
-      $opts[CURLOPT_POST] = 1;
-      $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : self::encode($params);
-    } else if ($method == 'delete') {
-      $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
-      if (count($params) > 0) {
-        $encoded = self::encode($params);
-        $absUrl = "$absUrl?$encoded";
-      }
-    } else {
-      throw new ApiError("Unrecognized method $method");
+        if (Stripe::$apiVersion) {
+            $headers[] = 'Stripe-Version: ' . Stripe::$apiVersion;
+        }
+        $hasFile = false;
+        $hasCurlFile = class_exists('\CURLFile');
+        foreach ($params as $k => $v) {
+            if (is_resource($v)) {
+                $hasFile = true;
+                $params[$k] = self::_processResourceParam($v);
+            } elseif ($hasCurlFile && $v instanceof \CURLFile) {
+                $hasFile = true;
+            }
+        }
+
+        if ($hasFile) {
+            $headers[] = 'Content-Type: multipart/form-data';
+        } else {
+            $headers[] = 'Content-Type: application/x-www-form-urlencoded';
+        }
+
+        list($rbody, $rcode) = $this->_curlRequest(
+            $method,
+            $absUrl,
+            $headers,
+            $params,
+            $hasFile
+        );
+        return array($rbody, $rcode, $myApiKey);
     }
 
-    $absUrl = self::utf8($absUrl);
-    $opts[CURLOPT_URL] = $absUrl;
-    $opts[CURLOPT_RETURNTRANSFER] = true;
-    $opts[CURLOPT_CONNECTTIMEOUT] = 30;
-    $opts[CURLOPT_TIMEOUT] = 80;
-    $opts[CURLOPT_RETURNTRANSFER] = true;
-    $opts[CURLOPT_HTTPHEADER] = $headers;
-    if (!Stripe::$verifySslCerts)
-      $opts[CURLOPT_SSL_VERIFYPEER] = false;
+    private function _processResourceParam($resource)
+    {
+        if (get_resource_type($resource) !== 'stream') {
+            throw new ApiError(
+                'Attempted to upload a resource that is not a stream'
+            );
+        }
 
-    curl_setopt_array($curl, $opts);
-    $rbody = curl_exec($curl);
+        $metaData = stream_get_meta_data($resource);
+        if ($metaData['wrapper_type'] !== 'plainfile') {
+            throw new ApiError(
+                'Only plainfile resource streams are supported'
+            );
+        }
 
-    if (!defined('CURLE_SSL_CACERT_BADFILE')) {
-      define('CURLE_SSL_CACERT_BADFILE', 77);  // constant not defined in PHP
+        if (class_exists('\CURLFile')) {
+          // We don't have the filename or mimetype, but the API doesn't care
+            return new \CURLFile($metaData['uri']);
+        } else {
+            return '@'.$metaData['uri'];
+        }
     }
 
-    $errno = curl_errno($curl);
-    if ($errno == CURLE_SSL_CACERT ||
+    private function _interpretResponse($rbody, $rcode)
+    {
+        try {
+            $resp = json_decode($rbody, true);
+        } catch (Exception $e) {
+            $msg = "Invalid response body from API: $rbody "
+             . "(HTTP response code was $rcode)";
+            throw new ApiError($msg, $rcode, $rbody);
+        }
+
+        if ($rcode < 200 || $rcode >= 300) {
+            $this->handleApiError($rbody, $rcode, $resp);
+        }
+        return $resp;
+    }
+
+    private function _curlRequest($method, $absUrl, $headers, $params, $hasFile)
+    {
+        $curl = curl_init();
+        $method = strtolower($method);
+        $opts = array();
+        if ($method == 'get') {
+            if ($hasFile) {
+                throw new ApiError(
+                    "Issuing a GET request with a file parameter"
+                );
+            }
+            $opts[CURLOPT_HTTPGET] = 1;
+            if (count($params) > 0) {
+                $encoded = self::encode($params);
+                $absUrl = "$absUrl?$encoded";
+            }
+        } elseif ($method == 'post') {
+            $opts[CURLOPT_POST] = 1;
+            $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : self::encode($params);
+        } elseif ($method == 'delete') {
+            $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
+            if (count($params) > 0) {
+                $encoded = self::encode($params);
+                $absUrl = "$absUrl?$encoded";
+            }
+        } else {
+            throw new ApiError("Unrecognized method $method");
+        }
+
+        $absUrl = self::utf8($absUrl);
+        $opts[CURLOPT_URL] = $absUrl;
+        $opts[CURLOPT_RETURNTRANSFER] = true;
+        $opts[CURLOPT_CONNECTTIMEOUT] = 30;
+        $opts[CURLOPT_TIMEOUT] = 80;
+        $opts[CURLOPT_RETURNTRANSFER] = true;
+        $opts[CURLOPT_HTTPHEADER] = $headers;
+        if (!Stripe::$verifySslCerts) {
+            $opts[CURLOPT_SSL_VERIFYPEER] = false;
+        }
+
+        curl_setopt_array($curl, $opts);
+        $rbody = curl_exec($curl);
+
+        if (!defined('CURLE_SSL_CACERT_BADFILE')) {
+            define('CURLE_SSL_CACERT_BADFILE', 77);  // constant not defined in PHP
+        }
+
+        $errno = curl_errno($curl);
+        if ($errno == CURLE_SSL_CACERT ||
         $errno == CURLE_SSL_PEER_CERTIFICATE ||
         $errno == CURLE_SSL_CACERT_BADFILE) {
-      array_push(
-          $headers,
-          'X-Stripe-Client-Info: {"ca":"using Stripe-supplied CA bundle"}'
-      );
-      $cert = $this->caBundle();
-      curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-      curl_setopt($curl, CURLOPT_CAINFO, $cert);
-      $rbody = curl_exec($curl);
+            array_push(
+                $headers,
+                'X-Stripe-Client-Info: {"ca":"using Stripe-supplied CA bundle"}'
+            );
+            $cert = $this->caBundle();
+            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($curl, CURLOPT_CAINFO, $cert);
+            $rbody = curl_exec($curl);
+        }
+
+        if ($rbody === false) {
+            $errno = curl_errno($curl);
+            $message = curl_error($curl);
+            curl_close($curl);
+            $this->handleCurlError($errno, $message);
+        }
+
+        $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+        return array($rbody, $rcode);
     }
 
-    if ($rbody === false) {
-      $errno = curl_errno($curl);
-      $message = curl_error($curl);
-      curl_close($curl);
-      $this->handleCurlError($errno, $message);
-    }
-
-    $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-    curl_close($curl);
-    return array($rbody, $rcode);
-  }
-
-  /**
+    /**
    * @param number $errno
    * @param string $message
    * @throws ApiConnectionError
    */
-  public function handleCurlError($errno, $message)
-  {
-    $apiBase = $this->_apiBase;
-    switch ($errno) {
-    case CURLE_COULDNT_CONNECT:
-    case CURLE_COULDNT_RESOLVE_HOST:
-    case CURLE_OPERATION_TIMEOUTED:
-      $msg = "Could not connect to Stripe ($apiBase).  Please check your "
-           . "internet connection and try again.  If this problem persists, "
-           . "you should check Stripe's service status at "
-           . "https://twitter.com/stripestatus, or";
-        break;
-    case CURLE_SSL_CACERT:
-    case CURLE_SSL_PEER_CERTIFICATE:
-      $msg = "Could not verify Stripe's SSL certificate.  Please make sure "
-           . "that your network is not intercepting certificates.  "
-           . "(Try going to $apiBase in your browser.)  "
-           . "If this problem persists,";
-        break;
-    default:
-      $msg = "Unexpected error communicating with Stripe.  "
-           . "If this problem persists,";
+    public function handleCurlError($errno, $message)
+    {
+        $apiBase = $this->_apiBase;
+        switch ($errno) {
+            case CURLE_COULDNT_CONNECT:
+            case CURLE_COULDNT_RESOLVE_HOST:
+            case CURLE_OPERATION_TIMEOUTED:
+                $msg = "Could not connect to Stripe ($apiBase).  Please check your "
+                   . "internet connection and try again.  If this problem persists, "
+                   . "you should check Stripe's service status at "
+                   . "https://twitter.com/stripestatus, or";
+                break;
+            case CURLE_SSL_CACERT:
+            case CURLE_SSL_PEER_CERTIFICATE:
+                $msg = "Could not verify Stripe's SSL certificate.  Please make sure "
+                 . "that your network is not intercepting certificates.  "
+                 . "(Try going to $apiBase in your browser.)  "
+                 . "If this problem persists,";
+                break;
+            default:
+                $msg = "Unexpected error communicating with Stripe.  "
+                 . "If this problem persists,";
+        }
+        $msg .= " let us know at support@stripe.com.";
+
+        $msg .= "\n\n(Network error [errno $errno]: $message)";
+        throw new ApiConnectionError($msg);
     }
-    $msg .= " let us know at support@stripe.com.";
 
-    $msg .= "\n\n(Network error [errno $errno]: $message)";
-    throw new ApiConnectionError($msg);
-  }
-
-  /**
+    /**
    * Preflight the SSL certificate presented by the backend. This isn't 100%
    * bulletproof, in that we're not actually validating the transport used to
    * communicate with Stripe, merely that the first attempt to does not use a
@@ -373,77 +389,83 @@ class ApiRequestor
    * certificate before sending potentially sensitive data on the wire. This
    * approach raises the bar for an attacker significantly.
    */
-  private function checkSslCert($url)
-  {
-    if (!function_exists('stream_context_get_params') ||
+    private function checkSslCert($url)
+    {
+        if (!function_exists('stream_context_get_params') ||
         !function_exists('stream_socket_enable_crypto')) {
-      error_log(
-          'Warning: This version of PHP does not support checking SSL '.
-          'certificates Stripe cannot guarantee that the server has a '.
-          'certificate which is not blacklisted.'
-      );
-      return true;
+            error_log(
+                'Warning: This version of PHP does not support checking SSL '.
+                'certificates Stripe cannot guarantee that the server has a '.
+                'certificate which is not blacklisted.'
+            );
+            return true;
+        }
+
+        $url = parse_url($url);
+        $port = isset($url["port"]) ? $url["port"] : 443;
+        $url = "ssl://{$url["host"]}:{$port}";
+
+        $sslContext = stream_context_create(
+            array('ssl' => array(
+            'capture_peer_cert' => true,
+            'verify_peer'   => true,
+            'cafile'        => $this->caBundle(),
+            ))
+        );
+        $result = stream_socket_client(
+            $url,
+            $errno,
+            $errstr,
+            30,
+            STREAM_CLIENT_CONNECT,
+            $sslContext
+        );
+        if (($errno !== 0 && $errno !== null) || $result === false) {
+            throw new ApiConnectionError(
+                'Could not connect to Stripe (' . $url . ').  Please check your '.
+                'internet connection and try again.  If this problem persists, '.
+                'you should check Stripe\'s service status at '.
+                'https://twitter.com/stripestatus. Reason was: '.$errstr
+            );
+        }
+
+        $params = stream_context_get_params($result);
+
+        $cert = $params['options']['ssl']['peer_certificate'];
+
+        openssl_x509_export($cert, $pemCert);
+
+        if (self::isBlackListed($pemCert)) {
+            throw new ApiConnectionError(
+                'Invalid server certificate. You tried to connect to a server that '.
+                'has a revoked SSL certificate, which means we cannot securely send '.
+                'data to that server.  Please email support@stripe.com if you need '.
+                'help connecting to the correct API server.'
+            );
+        }
+
+        return true;
     }
-
-    $url = parse_url($url);
-    $port = isset($url["port"]) ? $url["port"] : 443;
-    $url = "ssl://{$url["host"]}:{$port}";
-
-    $sslContext = stream_context_create(
-        array('ssl' => array(
-          'capture_peer_cert' => true,
-          'verify_peer'   => true,
-          'cafile'        => $this->caBundle(),
-        ))
-    );
-    $result = stream_socket_client(
-        $url, $errno, $errstr, 30, STREAM_CLIENT_CONNECT, $sslContext
-    );
-    if (($errno !== 0 && $errno !== NULL) || $result === false) {
-      throw new ApiConnectionError(
-          'Could not connect to Stripe (' . $url . ').  Please check your '.
-          'internet connection and try again.  If this problem persists, '.
-          'you should check Stripe\'s service status at '.
-          'https://twitter.com/stripestatus. Reason was: '.$errstr
-      );
-    }
-
-    $params = stream_context_get_params($result);
-
-    $cert = $params['options']['ssl']['peer_certificate'];
-
-    openssl_x509_export($cert, $pemCert);
-
-    if (self::isBlackListed($pemCert)) {
-      throw new ApiConnectionError(
-          'Invalid server certificate. You tried to connect to a server that '.
-          'has a revoked SSL certificate, which means we cannot securely send '.
-          'data to that server.  Please email support@stripe.com if you need '.
-          'help connecting to the correct API server.'
-      );
-    }
-
-    return true;
-  }
 
   /* Checks if a valid PEM encoded certificate is blacklisted
    * @return boolean
    */
-  public static function isBlackListed($certificate)
-  {
-    $certificate = trim($certificate);
-    $lines = explode("\n", $certificate);
+    public static function isBlackListed($certificate)
+    {
+        $certificate = trim($certificate);
+        $lines = explode("\n", $certificate);
 
-    // Kludgily remove the PEM padding
-    array_shift($lines); array_pop($lines);
+      // Kludgily remove the PEM padding
+        array_shift($lines);
+        array_pop($lines);
 
-    $derCert = base64_decode(implode("", $lines));
-    $fingerprint = sha1($derCert);
-    return in_array($fingerprint, self::$_blacklistedCerts);
-  }
+        $derCert = base64_decode(implode("", $lines));
+        $fingerprint = sha1($derCert);
+        return in_array($fingerprint, self::$_blacklistedCerts);
+    }
 
-  private function caBundle()
-  {
-    return dirname(__FILE__) . '/../data/ca-certificates.crt';
-  }
+    private function caBundle()
+    {
+        return dirname(__FILE__) . '/../data/ca-certificates.crt';
+    }
 }

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -4,152 +4,152 @@ namespace Stripe;
 
 abstract class ApiResource extends Object
 {
-  public static function baseUrl()
-  {
-    return Stripe::$apiBase;
-  }
+    public static function baseUrl()
+    {
+        return Stripe::$apiBase;
+    }
 
-  protected static function _scopedRetrieve($class, $id, $apiKey=null)
-  {
-    $instance = new $class($id, $apiKey);
-    $instance->refresh();
-    return $instance;
-  }
+    protected static function _scopedRetrieve($class, $id, $apiKey = null)
+    {
+        $instance = new $class($id, $apiKey);
+        $instance->refresh();
+        return $instance;
+    }
 
-  /**
+    /**
    * @returns ApiResource The refreshed resource.
    */
-  public function refresh()
-  {
-    $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
-    $url = $this->instanceUrl();
+    public function refresh()
+    {
+        $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
+        $url = $this->instanceUrl();
 
-    list($response, $apiKey) = $requestor->request(
-        'get',
-        $url,
-        $this->_retrieveOptions
-    );
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+        list($response, $apiKey) = $requestor->request(
+            'get',
+            $url,
+            $this->_retrieveOptions
+        );
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @param string $class
    *
    * @returns string The name of the class, with namespacing and underscores
    *    stripped.
    */
-  public static function className($class)
-  {
-    // Useful for namespaces: Foo\Charge
-    if ($postfixNamespaces = strrchr($class, '\\')) {
-      $class = substr($postfixNamespaces, 1);
+    public static function className($class)
+    {
+      // Useful for namespaces: Foo\Charge
+        if ($postfixNamespaces = strrchr($class, '\\')) {
+            $class = substr($postfixNamespaces, 1);
+        }
+      // Useful for underscored 'namespaces': Foo_Charge
+        if ($postfixFakeNamespaces = strrchr($class, '')) {
+            $class = $postfixFakeNamespaces;
+        }
+        if (substr($class, 0, strlen('Stripe')) == 'Stripe') {
+            $class = substr($class, strlen('Stripe'));
+        }
+        $class = str_replace('_', '', $class);
+        $name = urlencode($class);
+        $name = strtolower($name);
+        return $name;
     }
-    // Useful for underscored 'namespaces': Foo_Charge
-    if ($postfixFakeNamespaces = strrchr($class, '')) {
-      $class = $postfixFakeNamespaces;
-    }
-    if (substr($class, 0, strlen('Stripe')) == 'Stripe') {
-      $class = substr($class, strlen('Stripe'));
-    }
-    $class = str_replace('_', '', $class);
-    $name = urlencode($class);
-    $name = strtolower($name);
-    return $name;
-  }
 
-  /**
+    /**
    * @param string $class
    *
    * @returns string The endpoint URL for the given class.
    */
-  public static function classUrl($class)
-  {
-    $base = self::_scopedLsb($class, 'className', $class);
-    return "/v1/${base}s";
-  }
+    public static function classUrl($class)
+    {
+        $base = self::_scopedLsb($class, 'className', $class);
+        return "/v1/${base}s";
+    }
 
-  /**
+    /**
    * @returns string The full API URL for this API resource.
    */
-  public function instanceUrl()
-  {
-    $id = $this['id'];
-    $class = get_class($this);
-    if ($id === null) {
-      $message = "Could not determine which URL to request: "
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        $class = get_class($this);
+        if ($id === null) {
+            $message = "Could not determine which URL to request: "
                . "$class instance has invalid ID: $id";
-      throw new InvalidRequestError($message, null);
+            throw new InvalidRequestError($message, null);
+        }
+        $id = ApiRequestor::utf8($id);
+        $base = $this->_lsb('classUrl', $class);
+        $extn = urlencode($id);
+        return "$base/$extn";
     }
-    $id = ApiRequestor::utf8($id);
-    $base = $this->_lsb('classUrl', $class);
-    $extn = urlencode($id);
-    return "$base/$extn";
-  }
 
-  private static function _validateCall($method, $params=null, $apiKey=null)
-  {
-    if ($params && !is_array($params)) {
-      $message = "You must pass an array as the first argument to Stripe API "
+    private static function _validateCall($method, $params = null, $apiKey = null)
+    {
+        if ($params && !is_array($params)) {
+            $message = "You must pass an array as the first argument to Stripe API "
                . "method calls.  (HINT: an example call to create a charge "
                . "would be: \"StripeCharge::create(array('amount' => 100, "
                . "'currency' => 'usd', 'card' => array('number' => "
                . "4242424242424242, 'exp_month' => 5, 'exp_year' => 2015)))\")";
-      throw new Error($message);
-    }
+            throw new Error($message);
+        }
 
-    if ($apiKey && !is_string($apiKey)) {
-      $message = 'The second argument to Stripe API method calls is an '
+        if ($apiKey && !is_string($apiKey)) {
+            $message = 'The second argument to Stripe API method calls is an '
                . 'optional per-request apiKey, which must be a string.  '
                . '(HINT: you can set a global apiKey by '
                . '"Stripe::setApiKey(<apiKey>)")';
-      throw new Error($message);
+            throw new Error($message);
+        }
     }
-  }
 
-  protected static function _scopedAll($class, $params=null, $apiKey=null)
-  {
-    self::_validateCall('all', $params, $apiKey);
-    $base = self::_scopedLsb($class, 'baseUrl');
-    $url = self::_scopedLsb($class, 'classUrl', $class);
+    protected static function _scopedAll($class, $params = null, $apiKey = null)
+    {
+        self::_validateCall('all', $params, $apiKey);
+        $base = self::_scopedLsb($class, 'baseUrl');
+        $url = self::_scopedLsb($class, 'classUrl', $class);
 
-    $requestor = new ApiRequestor($apiKey, $base);
-    list($response, $apiKey) = $requestor->request('get', $url, $params);
-    return Util::convertToStripeObject($response, $apiKey);
-  }
-
-  protected static function _scopedCreate($class, $params=null, $apiKey=null)
-  {
-    self::_validateCall('create', $params, $apiKey);
-    $base = self::_scopedLsb($class, 'baseUrl');
-    $url = self::_scopedLsb($class, 'classUrl', $class);
-
-    $requestor = new ApiRequestor($apiKey, $base);
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    return Util::convertToStripeObject($response, $apiKey);
-  }
-
-  protected function _scopedSave($class)
-  {
-    self::_validateCall('save');
-    $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
-    $params = $this->serializeParameters();
-
-    if (count($params) > 0) {
-      $url = $this->instanceUrl();
-      list($response, $apiKey) = $requestor->request('post', $url, $params);
-      $this->refreshFrom($response, $apiKey);
+        $requestor = new ApiRequestor($apiKey, $base);
+        list($response, $apiKey) = $requestor->request('get', $url, $params);
+        return Util::convertToStripeObject($response, $apiKey);
     }
-    return $this;
-  }
 
-  protected function _scopedDelete($class, $params=null)
-  {
-    self::_validateCall('delete');
-    $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
-    $url = $this->instanceUrl();
-    list($response, $apiKey) = $requestor->request('delete', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    protected static function _scopedCreate($class, $params = null, $apiKey = null)
+    {
+        self::_validateCall('create', $params, $apiKey);
+        $base = self::_scopedLsb($class, 'baseUrl');
+        $url = self::_scopedLsb($class, 'classUrl', $class);
+
+        $requestor = new ApiRequestor($apiKey, $base);
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        return Util::convertToStripeObject($response, $apiKey);
+    }
+
+    protected function _scopedSave($class)
+    {
+        self::_validateCall('save');
+        $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
+        $params = $this->serializeParameters();
+
+        if (count($params) > 0) {
+            $url = $this->instanceUrl();
+            list($response, $apiKey) = $requestor->request('post', $url, $params);
+            $this->refreshFrom($response, $apiKey);
+        }
+        return $this;
+    }
+
+    protected function _scopedDelete($class, $params = null)
+    {
+        self::_validateCall('delete');
+        $requestor = new ApiRequestor($this->_apiKey, self::baseUrl());
+        $url = $this->instanceUrl();
+        list($response, $apiKey) = $requestor->request('delete', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 }

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -4,52 +4,52 @@ namespace Stripe;
 
 class ApplicationFee extends ApiResource
 {
-  /**
-   * This is a special case because the application fee endpoint has an 
+    /**
+   * This is a special case because the application fee endpoint has an
    *    underscore in it. The parent `className` function strips underscores.
    *
    * @return string The name of the class.
    */
-  public static function className($class)
-  {
-    return 'application_fee';
-  }
+    public static function className($class)
+    {
+        return 'application_fee';
+    }
 
-  /**
+    /**
    * @param string $id The ID of the application fee to retrieve.
    * @param string|null $apiKey
    *
    * @return ApplicationFee
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param string|null $params
    * @param string|null $apiKey
    *
    * @return array An array of application fees.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param string|null $params
    *
    * @return ApplicationFee The refunded application fee.
    */
-  public function refund($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/refund';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function refund($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/refund';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 }

--- a/lib/ApplicationFeeRefund.php
+++ b/lib/ApplicationFeeRefund.php
@@ -4,35 +4,35 @@ namespace Stripe;
 
 class ApplicationFeeRefund extends ApiResource
 {
-  /**
+    /**
    * @return string The API URL for this Stripe refund.
    */
-  public function instanceUrl()
-  {
-    $id = $this['id'];
-    $fee = $this['fee'];
-    if (!$id) {
-      throw new InvalidRequestError(
-          "Could not determine which URL to request: " .
-          "class instance has invalid ID: $id",
-          null
-      );
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        $fee = $this['fee'];
+        if (!$id) {
+            throw new InvalidRequestError(
+                "Could not determine which URL to request: " .
+                "class instance has invalid ID: $id",
+                null
+            );
+        }
+        $id = ApiRequestor::utf8($id);
+        $fee = ApiRequestor::utf8($fee);
+
+        $base = self::classUrl('Stripe\\ApplicationFee');
+        $feeExtn = urlencode($fee);
+        $extn = urlencode($id);
+        return "$base/$feeExtn/refunds/$extn";
     }
-    $id = ApiRequestor::utf8($id);
-    $fee = ApiRequestor::utf8($fee);
 
-    $base = self::classUrl('Stripe\\ApplicationFee');
-    $feeExtn = urlencode($fee);
-    $extn = urlencode($id);
-    return "$base/$feeExtn/refunds/$extn";
-  }
-
-  /**
+    /**
    * @return ApplicationFeeRefund The saved refund.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 }

--- a/lib/AttachedObject.php
+++ b/lib/AttachedObject.php
@@ -5,21 +5,21 @@ namespace Stripe;
 // e.g. metadata on Stripe objects.
 class AttachedObject extends Object
 {
-  /**
+    /**
    * Updates this object.
    *
    * @param array $properties A mapping of properties to update on this object.
    */
-  public function replaceWith($properties)
-  {
-    $removed = array_diff(array_keys($this->_values), array_keys($properties));
-    // Don't unset, but rather set to null so we send up '' for deletion.
-    foreach ($removed as $k) {
-      $this->$k = null;
-    }
+    public function replaceWith($properties)
+    {
+        $removed = array_diff(array_keys($this->_values), array_keys($properties));
+      // Don't unset, but rather set to null so we send up '' for deletion.
+        foreach ($removed as $k) {
+            $this->$k = null;
+        }
 
-    foreach ($properties as $k => $v) {
-      $this->$k = $v;
+        foreach ($properties as $k => $v) {
+            $this->$k = $v;
+        }
     }
-  }
 }

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -4,14 +4,14 @@ namespace Stripe;
 
 class Balance extends SingletonApiResource
 {
-  /**
+    /**
     * @param string|null $apiKey
     *
     * @return Balance
     */
-  public static function retrieve($apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedSingletonRetrieve($class, $apiKey);
-  }
+    public static function retrieve($apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedSingletonRetrieve($class, $apiKey);
+    }
 }

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -4,38 +4,38 @@ namespace Stripe;
 
 class BalanceTransaction extends ApiResource
 {
-  /**
+    /**
    * @param string $class Ignored.
    *
    * @return string The class URL for this resource. It needs to be special
    *    cased because it doesn't fit into the standard resource pattern.
    */
-  public static function classUrl($class)
-  {
-    return "/v1/balance/history";
-  }
+    public static function classUrl($class)
+    {
+        return "/v1/balance/history";
+    }
 
-  /**
+    /**
    * @param string $id The ID of the balance transaction to retrieve.
    * @param string|null $apiKey
    *
    * @return BalanceTransaction
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of BalanceTransactions.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 }

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -4,65 +4,61 @@ namespace Stripe;
 
 class Card extends ApiResource
 {
-  public static function constructFrom($values, $apiKey=null)
-  {
-    $class = get_class();
-    return self::scopedConstructFrom($class, $values, $apiKey);
-  }
+    public static function constructFrom($values, $apiKey = null)
+    {
+        $class = get_class();
+        return self::scopedConstructFrom($class, $values, $apiKey);
+    }
 
-  /**
+    /**
    * @return string The instance URL for this resource. It needs to be special
    *    cased because it doesn't fit into the standard resource pattern.
    */
-  public function instanceUrl()
-  {
-    $id = $this['id'];
-    if (!$id) {
-      $class = get_class($this);
-      $msg = "Could not determine which URL to request: $class instance "
-           . "has invalid ID: $id";
-      throw new InvalidRequestError($msg, null);
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        if (!$id) {
+            $class = get_class($this);
+            $msg = "Could not determine which URL to request: $class instance "
+             . "has invalid ID: $id";
+            throw new InvalidRequestError($msg, null);
+        }
+
+        if (isset($this['customer'])) {
+            $parent = $this['customer'];
+            $base = self::classUrl('Stripe\\Customer');
+        } elseif (isset($this['recipient'])) {
+            $parent = $this['recipient'];
+            $base = self::classUrl('Stripe\\Recipient');
+        } else {
+            return null;
+        }
+
+        $parent = ApiRequestor::utf8($parent);
+        $id = ApiRequestor::utf8($id);
+
+        $parentExtn = urlencode($parent);
+        $extn = urlencode($id);
+        return "$base/$parentExtn/cards/$extn";
     }
 
-    if (isset($this['customer'])) {
-
-      $parent = $this['customer'];
-      $base = self::classUrl('Stripe\\Customer');
-    } else if (isset($this['recipient'])) {
-
-      $parent = $this['recipient'];
-      $base = self::classUrl('Stripe\\Recipient');
-    } else {
-
-      return null;
-    }
-
-    $parent = ApiRequestor::utf8($parent);
-    $id = ApiRequestor::utf8($id);
-
-    $parentExtn = urlencode($parent);
-    $extn = urlencode($id);
-    return "$base/$parentExtn/cards/$extn";
-  }
-
-  /**
+    /**
    * @param array|null $params
    *
    * @return Card The deleted card.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 
-  /**
+    /**
    * @return Card The saved card.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 }
-

--- a/lib/CardError.php
+++ b/lib/CardError.php
@@ -4,12 +4,16 @@ namespace Stripe;
 
 class CardError extends Error
 {
-  public function __construct($message, $param, $code, $httpStatus, 
-      $httpBody, $jsonBody
-  )
-  {
-    parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
-    $this->param = $param;
-    $this->code = $code;
-  }
+    public function __construct(
+        $message,
+        $param,
+        $code,
+        $httpStatus,
+        $httpBody,
+        $jsonBody
+    ) {
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+        $this->param = $param;
+        $this->code = $code;
+    }
 }

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -4,128 +4,128 @@ namespace Stripe;
 
 class Charge extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the charge to retrieve.
    * @param string|null $apiKey
    *
    * @return Charge
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Charges.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Charge The created charge.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @return Charge The saved charge.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return Charge The refunded charge.
    */
-  public function refund($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/refund';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function refund($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/refund';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return Charge The captured charge.
    */
-  public function capture($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/capture';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function capture($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/capture';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return array The updated dispute.
    */
-  public function updateDispute($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/dispute';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom(array('dispute' => $response), $apiKey, true);
-    return $this->dispute;
-  }
+    public function updateDispute($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/dispute';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom(array('dispute' => $response), $apiKey, true);
+        return $this->dispute;
+    }
 
-  /**
+    /**
    * @return Charge The updated charge.
    */
-  public function closeDispute()
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/dispute/close';
-    list($response, $apiKey) = $requestor->request('post', $url);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function closeDispute()
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/dispute/close';
+        list($response, $apiKey) = $requestor->request('post', $url);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @return Charge The updated charge.
    */
-  public function markAsFraudulent()
-  {
-    $params = array('fraud_details' => array('user_report' => 'fraudulent'));
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl();
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function markAsFraudulent()
+    {
+        $params = array('fraud_details' => array('user_report' => 'fraudulent'));
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl();
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @return Charge The updated charge.
    */
-  public function markAsSafe()
-  {
-    $params = array('fraud_details' => array('user_report' => 'safe'));
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl();
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function markAsSafe()
+    {
+        $params = array('fraud_details' => array('user_report' => 'safe'));
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl();
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 }

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -4,53 +4,55 @@ namespace Stripe;
 
 class Collection extends Object
 {
-  public function all($params=null)
-  {
-    list($url, $params) = $this->extractPathAndUpdateParams($params);
+    public function all($params = null)
+    {
+        list($url, $params) = $this->extractPathAndUpdateParams($params);
 
-    $requestor = new ApiRequestor($this->_apiKey);
-    list($response, $apiKey) = $requestor->request('get', $url, $params);
-    return Util::convertToStripeObject($response, $apiKey);
-  }
-
-  public function create($params=null)
-  {
-    list($url, $params) = $this->extractPathAndUpdateParams($params);
-
-    $requestor = new ApiRequestor($this->_apiKey);
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    return Util::convertToStripeObject($response, $apiKey);
-  }
-
-  public function retrieve($id, $params=null)
-  {
-    list($url, $params) = $this->extractPathAndUpdateParams($params);
-
-    $requestor = new ApiRequestor($this->_apiKey);
-    $id = ApiRequestor::utf8($id);
-    $extn = urlencode($id);
-    list($response, $apiKey) = $requestor->request(
-        'get', "$url/$extn", $params
-    );
-    return Util::convertToStripeObject($response, $apiKey);
-  }
-
-  private function extractPathAndUpdateParams($params)
-  {
-    $url = parse_url($this->url);
-    if (!isset($url['path'])) {
-      throw new APIError("Could not parse list url into parts: $url");
+        $requestor = new ApiRequestor($this->_apiKey);
+        list($response, $apiKey) = $requestor->request('get', $url, $params);
+        return Util::convertToStripeObject($response, $apiKey);
     }
 
-    if (isset($url['query'])) {
-      // If the URL contains a query param, parse it out into $params so they
-      // don't interact weirdly with each other.
-      $query = array();
-      parse_str($url['query'], $query);
-      // PHP 5.2 doesn't support the ?: operator :(
-      $params = array_merge($params ? $params : array(), $query);
+    public function create($params = null)
+    {
+        list($url, $params) = $this->extractPathAndUpdateParams($params);
+
+        $requestor = new ApiRequestor($this->_apiKey);
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        return Util::convertToStripeObject($response, $apiKey);
     }
 
-    return array($url['path'], $params);
-  }
+    public function retrieve($id, $params = null)
+    {
+        list($url, $params) = $this->extractPathAndUpdateParams($params);
+
+        $requestor = new ApiRequestor($this->_apiKey);
+        $id = ApiRequestor::utf8($id);
+        $extn = urlencode($id);
+        list($response, $apiKey) = $requestor->request(
+            'get',
+            "$url/$extn",
+            $params
+        );
+        return Util::convertToStripeObject($response, $apiKey);
+    }
+
+    private function extractPathAndUpdateParams($params)
+    {
+        $url = parse_url($this->url);
+        if (!isset($url['path'])) {
+            throw new APIError("Could not parse list url into parts: $url");
+        }
+
+        if (isset($url['query'])) {
+          // If the URL contains a query param, parse it out into $params so they
+          // don't interact weirdly with each other.
+            $query = array();
+            parse_str($url['query'], $query);
+          // PHP 5.2 doesn't support the ?: operator :(
+            $params = array_merge($params ? $params : array(), $query);
+        }
+
+        return array($url['path'], $params);
+    }
 }

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -4,59 +4,59 @@ namespace Stripe;
 
 class Coupon extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the coupon to retrieve.
    * @param string|null $apiKey
    *
    * @return Coupon
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Coupon The created coupon.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return Coupon The deleted coupon.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 
-  /**
+    /**
    * @return Coupon The saved coupon.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Coupons.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 }

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -4,156 +4,160 @@ namespace Stripe;
 
 class Customer extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the customer to retrieve.
    * @param string|null $apiKey
    *
    * @return Customer
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Customers.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Customer The created customer.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @returns Customer The saved customer.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns Customer The deleted customer.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns InvoiceItem The resulting invoice item.
    */
-  public function addInvoiceItem($params=null)
-  {
-    if (!$params)
-      $params = array();
-    $params['customer'] = $this->id;
-    $ii = InvoiceItem::create($params, $this->_apiKey);
-    return $ii;
-  }
+    public function addInvoiceItem($params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        $params['customer'] = $this->id;
+        $ii = InvoiceItem::create($params, $this->_apiKey);
+        return $ii;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns array An array of the customer's Invoices.
    */
-  public function invoices($params=null)
-  {
-    if (!$params)
-      $params = array();
-    $params['customer'] = $this->id;
-    $invoices = Invoice::all($params, $this->_apiKey);
-    return $invoices;
-  }
+    public function invoices($params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        $params['customer'] = $this->id;
+        $invoices = Invoice::all($params, $this->_apiKey);
+        return $invoices;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns array An array of the customer's InvoiceItems.
    */
-  public function invoiceItems($params=null)
-  {
-    if (!$params)
-      $params = array();
-    $params['customer'] = $this->id;
-    $iis = InvoiceItem::all($params, $this->_apiKey);
-    return $iis;
-  }
+    public function invoiceItems($params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        $params['customer'] = $this->id;
+        $iis = InvoiceItem::all($params, $this->_apiKey);
+        return $iis;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns array An array of the customer's Charges.
    */
-  public function charges($params=null)
-  {
-    if (!$params)
-      $params = array();
-    $params['customer'] = $this->id;
-    $charges = Charge::all($params, $this->_apiKey);
-    return $charges;
-  }
+    public function charges($params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        $params['customer'] = $this->id;
+        $charges = Charge::all($params, $this->_apiKey);
+        return $charges;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns Subscription The updated subscription.
    */
-  public function updateSubscription($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/subscription';
-    list($response, $apiKey) = $requestor->request('post', $url, $params);
-    $this->refreshFrom(array('subscription' => $response), $apiKey, true);
-    return $this->subscription;
-  }
+    public function updateSubscription($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/subscription';
+        list($response, $apiKey) = $requestor->request('post', $url, $params);
+        $this->refreshFrom(array('subscription' => $response), $apiKey, true);
+        return $this->subscription;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns Subscription The cancelled subscription.
    */
-  public function cancelSubscription($params=null)
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/subscription';
-    list($response, $apiKey) = $requestor->request('delete', $url, $params);
-    $this->refreshFrom(array('subscription' => $response), $apiKey, true);
-    return $this->subscription;
-  }
+    public function cancelSubscription($params = null)
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/subscription';
+        list($response, $apiKey) = $requestor->request('delete', $url, $params);
+        $this->refreshFrom(array('subscription' => $response), $apiKey, true);
+        return $this->subscription;
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @returns Customer The updated customer.
    */
-  public function deleteDiscount()
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/discount';
-    list($response, $apiKey) = $requestor->request('delete', $url);
-    $this->refreshFrom(array('discount' => null), $apiKey, true);
-  }
+    public function deleteDiscount()
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/discount';
+        list($response, $apiKey) = $requestor->request('delete', $url);
+        $this->refreshFrom(array('discount' => null), $apiKey, true);
+    }
 }

--- a/lib/Error.php
+++ b/lib/Error.php
@@ -6,28 +6,30 @@ use Exception;
 
 class Error extends Exception
 {
-  public function __construct($message, $httpStatus=null,
-      $httpBody=null, $jsonBody=null
-  )
-  {
-    parent::__construct($message);
-    $this->httpStatus = $httpStatus;
-    $this->httpBody = $httpBody;
-    $this->jsonBody = $jsonBody;
-  }
+    public function __construct(
+        $message,
+        $httpStatus = null,
+        $httpBody = null,
+        $jsonBody = null
+    ) {
+        parent::__construct($message);
+        $this->httpStatus = $httpStatus;
+        $this->httpBody = $httpBody;
+        $this->jsonBody = $jsonBody;
+    }
 
-  public function getHttpStatus()
-  {
-    return $this->httpStatus;
-  }
+    public function getHttpStatus()
+    {
+        return $this->httpStatus;
+    }
 
-  public function getHttpBody()
-  {
-    return $this->httpBody;
-  }
+    public function getHttpBody()
+    {
+        return $this->httpBody;
+    }
 
-  public function getJsonBody()
-  {
-    return $this->jsonBody;
-  }
+    public function getJsonBody()
+    {
+        return $this->jsonBody;
+    }
 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -4,27 +4,27 @@ namespace Stripe;
 
 class Event extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the event to retrieve.
    * @param string|null $apiKey
    *
    * @return Event
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Events.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 }

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -4,37 +4,37 @@ namespace Stripe;
 
 class FileUpload extends ApiResource
 {
-  public static function baseUrl()
-  {
-    return Stripe::$apiUploadBase;
-  }
+    public static function baseUrl()
+    {
+        return Stripe::$apiUploadBase;
+    }
 
-  public static function className($class)
-  {
-    return 'file';
-  }
+    public static function className($class)
+    {
+        return 'file';
+    }
 
-  /**
+    /**
    * @param string $id The ID of the file upload to retrieve.
    * @param string|null $apiKey
    *
    * @return FileUpload
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return FileUpload The created file upload.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 }

--- a/lib/InvalidRequestError.php
+++ b/lib/InvalidRequestError.php
@@ -4,11 +4,14 @@ namespace Stripe;
 
 class InvalidRequestError extends Error
 {
-  public function __construct($message, $param, $httpStatus=null,
-      $httpBody=null, $jsonBody=null
-  )
-  {
-    parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
-    $this->param = $param;
-  }
+    public function __construct(
+        $message,
+        $param,
+        $httpStatus = null,
+        $httpBody = null,
+        $jsonBody = null
+    ) {
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+        $this->param = $param;
+    }
 }

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -4,74 +4,74 @@ namespace Stripe;
 
 class Invoice extends ApiResource
 {
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Invoice The created invoice.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param string $id The ID of the invoice to retrieve.
    * @param string|null $apiKey
    *
    * @return Invoice
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Invoices.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Invoice The upcoming invoice.
    */
-  public static function upcoming($params=null, $apiKey=null)
-  {
-    $requestor = new ApiRequestor($apiKey);
-    $url = self::classUrl(get_class()) . '/upcoming';
-    list($response, $apiKey) = $requestor->request('get', $url, $params);
-    return Util::convertToStripeObject($response, $apiKey);
-  }
+    public static function upcoming($params = null, $apiKey = null)
+    {
+        $requestor = new ApiRequestor($apiKey);
+        $url = self::classUrl(get_class()) . '/upcoming';
+        list($response, $apiKey) = $requestor->request('get', $url, $params);
+        return Util::convertToStripeObject($response, $apiKey);
+    }
 
-  /**
+    /**
    * @return Invoice The saved invoice.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @return Invoice The paid invoice.
    */
-  public function pay()
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/pay';
-    list($response, $apiKey) = $requestor->request('post', $url);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function pay()
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/pay';
+        list($response, $apiKey) = $requestor->request('post', $url);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 }

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -4,57 +4,57 @@ namespace Stripe;
 
 class InvoiceItem extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the invoice item to retrieve.
    * @param string|null $apiKey
    *
    * @return InvoiceItem
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of InvoiceItems.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return InvoiceItem The created invoice item.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @return InvoiceItem The saved invoice item.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @return InvoiceItem The deleted invoice item.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 }

--- a/lib/Object.php
+++ b/lib/Object.php
@@ -7,263 +7,267 @@ use InvalidArgumentException;
 
 class Object implements ArrayAccess
 {
-  /**
-   * @var Util\Set Attributes that should not be sent to the API because
-   *    they're not updatable (e.g. API key, ID).
-   */
-  public static $permanentAttributes;
-  /**
-   * @var Util\Set Attributes that are nested but still updatable from
-   *    the parent class's URL (e.g. metadata).
-   */
-  public static $nestedUpdatableAttributes;
+    /**
+     * @var Util\Set Attributes that should not be sent to the API because
+     *    they're not updatable (e.g. API key, ID).
+     */
+    public static $permanentAttributes;
+    /**
+     * @var Util\Set Attributes that are nested but still updatable from
+     *    the parent class's URL (e.g. metadata).
+     */
+    public static $nestedUpdatableAttributes;
 
-  public static function init()
-  {
-    self::$permanentAttributes = new Util\Set(array('_apiKey', 'id'));
-    self::$nestedUpdatableAttributes = new Util\Set(array('metadata'));
-  }
+    public static function init()
+    {
+        self::$permanentAttributes = new Util\Set(array('_apiKey', 'id'));
+        self::$nestedUpdatableAttributes = new Util\Set(array('metadata'));
+    }
 
-  protected $_apiKey;
-  protected $_values;
-  protected $_unsavedValues;
-  protected $_transientValues;
-  protected $_retrieveOptions;
+    protected $_apiKey;
+    protected $_values;
+    protected $_unsavedValues;
+    protected $_transientValues;
+    protected $_retrieveOptions;
 
-  public function __construct($id=null, $apiKey=null)
-  {
-    $this->_apiKey = $apiKey;
-    $this->_values = array();
-    $this->_unsavedValues = new Util\Set();
-    $this->_transientValues = new Util\Set();
+    public function __construct($id = null, $apiKey = null)
+    {
+        $this->_apiKey = $apiKey;
+        $this->_values = array();
+        $this->_unsavedValues = new Util\Set();
+        $this->_transientValues = new Util\Set();
 
-    $this->_retrieveOptions = array();
-    if (is_array($id)) {
-      foreach ($id as $key => $value) {
-        if ($key != 'id') {
-          $this->_retrieveOptions[$key] = $value;
+        $this->_retrieveOptions = array();
+        if (is_array($id)) {
+            foreach ($id as $key => $value) {
+                if ($key != 'id') {
+                    $this->_retrieveOptions[$key] = $value;
+                }
+            }
+            $id = $id['id'];
         }
-      }
-      $id = $id['id'];
-    }
 
-    if ($id !== null) {
-      $this->id = $id;
-    }
-  }
-
-  // Standard accessor magic methods
-  public function __set($k, $v)
-  {
-    if ($v === "") {
-      throw new InvalidArgumentException(
-          'You cannot set \''.$k.'\'to an empty string. '
-          .'We interpret empty strings as NULL in requests. '
-          .'You may set obj->'.$k.' = NULL to delete the property'
-      );
-    }
-
-    if (self::$nestedUpdatableAttributes->includes($k)
-        && isset($this->$k) && is_array($v)) {
-      $this->$k->replaceWith($v);
-    } else {
-      // TODO: may want to clear from $_transientValues (Won't be user-visible).
-      $this->_values[$k] = $v;
-    }
-    if (!self::$permanentAttributes->includes($k))
-      $this->_unsavedValues->add($k);
-  }
-  public function __isset($k)
-  {
-    return isset($this->_values[$k]);
-  }
-  public function __unset($k)
-  {
-    unset($this->_values[$k]);
-    $this->_transientValues->add($k);
-    $this->_unsavedValues->discard($k);
-  }
-  public function __get($k)
-  {
-    if (array_key_exists($k, $this->_values)) {
-      return $this->_values[$k];
-    } else if ($this->_transientValues->includes($k)) {
-      $class = get_class($this);
-      $attrs = join(', ', array_keys($this->_values));
-      $message = "Stripe Notice: Undefined property of $class instance: $k. "
-               . "HINT: The $k attribute was set in the past, however. "
-               . "It was then wiped when refreshing the object "
-               . "with the result returned by Stripe's API, "
-               . "probably as a result of a save(). The attributes currently "
-               . "available on this object are: $attrs";
-      error_log($message);
-      return null;
-    } else {
-      $class = get_class($this);
-      error_log("Stripe Notice: Undefined property of $class instance: $k");
-      return null;
-    }
-  }
-
-  // ArrayAccess methods
-  public function offsetSet($k, $v)
-  {
-    $this->$k = $v;
-  }
-
-  public function offsetExists($k)
-  {
-    return array_key_exists($k, $this->_values);
-  }
-
-  public function offsetUnset($k)
-  {
-    unset($this->$k);
-  }
-  public function offsetGet($k)
-  {
-    return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
-  }
-
-  public function keys()
-  {
-    return array_keys($this->_values);
-  }
-
-  /**
-   * This unfortunately needs to be public to be used in Util.php
-   *
-   * @param string $class
-   * @param array $values
-   * @param string|null $apiKey
-   *
-   * @return Object The object constructed from the given values.
-   */
-  public static function scopedConstructFrom($class, $values, $apiKey=null)
-  {
-    $obj = new $class(isset($values['id']) ? $values['id'] : null, $apiKey);
-    $obj->refreshFrom($values, $apiKey);
-    return $obj;
-  }
-
-  /**
-   * @param array $values
-   * @param string|null $apiKey
-   *
-   * @return Object The object of the same class as $this constructed
-   *    from the given values.
-   */
-  public static function constructFrom($values, $apiKey=null)
-  {
-    return self::scopedConstructFrom(__CLASS__, $values, $apiKey);
-  }
-
-  /**
-   * Refreshes this object using the provided values.
-   *
-   * @param array $values
-   * @param string $apiKey
-   * @param boolean $partial Defaults to false.
-   */
-  public function refreshFrom($values, $apiKey, $partial=false)
-  {
-    $this->_apiKey = $apiKey;
-
-    // Wipe old state before setting new.  This is useful for e.g. updating a
-    // customer, where there is no persistent card parameter.  Mark those values
-    // which don't persist as transient
-    if ($partial) {
-      $removed = new Util\Set();
-    } else {
-      $removed = array_diff(array_keys($this->_values), array_keys($values));
-    }
-
-    foreach ($removed as $k) {
-      if (self::$permanentAttributes->includes($k))
-        continue;
-      unset($this->$k);
-    }
-
-    foreach ($values as $k => $v) {
-      if (self::$permanentAttributes->includes($k) && isset($this[$k]))
-        continue;
-
-      if (self::$nestedUpdatableAttributes->includes($k) && is_array($v)) {
-        $this->_values[$k] = Object::scopedConstructFrom(
-            'Stripe\\AttachedObject', $v, $apiKey
-        );
-      } else {
-        $this->_values[$k] = Util::convertToStripeObject($v, $apiKey);
-      }
-
-      $this->_transientValues->discard($k);
-      $this->_unsavedValues->discard($k);
-    }
-  }
-
-  /**
-   * @return array A recursive mapping of attributes to values for this object,
-   *    including the proper value for deleted attributes.
-   */
-  public function serializeParameters()
-  {
-    $params = array();
-    if ($this->_unsavedValues) {
-      foreach ($this->_unsavedValues->toArray() as $k) {
-        $v = $this->$k;
-        if ($v === NULL) {
-          $v = '';
+        if ($id !== null) {
+            $this->id = $id;
         }
-        $params[$k] = $v;
-      }
     }
 
-    // Get nested updates.
-    foreach (self::$nestedUpdatableAttributes->toArray() as $property) {
-      if (isset($this->$property)
-          && $this->$property instanceOf Object) {
-        $params[$property] = $this->$property->serializeParameters();
-      }
+    // Standard accessor magic methods
+    public function __set($k, $v)
+    {
+        if ($v === "") {
+            throw new InvalidArgumentException(
+                'You cannot set \''.$k.'\'to an empty string. '
+                .'We interpret empty strings as NULL in requests. '
+                .'You may set obj->'.$k.' = NULL to delete the property'
+            );
+        }
+
+        if (self::$nestedUpdatableAttributes->includes($k)
+                && isset($this->$k) && is_array($v)) {
+            $this->$k->replaceWith($v);
+        } else {
+            // TODO: may want to clear from $_transientValues (Won't be user-visible).
+            $this->_values[$k] = $v;
+        }
+        if (!self::$permanentAttributes->includes($k)) {
+            $this->_unsavedValues->add($k);
+        }
     }
-    return $params;
-  }
 
-  // Pretend to have late static bindings, even in PHP 5.2
-  protected function _lsb($method)
-  {
-    $class = get_class($this);
-    $args = array_slice(func_get_args(), 1);
-    return call_user_func_array(array($class, $method), $args);
-  }
-  protected static function _scopedLsb($class, $method)
-  {
-    $args = array_slice(func_get_args(), 2);
-    return call_user_func_array(array($class, $method), $args);
-  }
-
-  public function __toJSON()
-  {
-    if (defined('JSON_PRETTY_PRINT')) {
-      return json_encode($this->__toArray(true), JSON_PRETTY_PRINT);
-    } else {
-      return json_encode($this->__toArray(true));
+    public function __isset($k)
+    {
+        return isset($this->_values[$k]);
     }
-  }
-
-  public function __toString()
-  {
-    $class = get_class($this);
-    return $class . ' JSON: ' . $this->__toJSON();
-  }
-
-  public function __toArray($recursive=false)
-  {
-    if ($recursive) {
-      return Util::convertStripeObjectToArray($this->_values);
-    } else {
-      return $this->_values;
+    public function __unset($k)
+    {
+        unset($this->_values[$k]);
+        $this->_transientValues->add($k);
+        $this->_unsavedValues->discard($k);
     }
-  }
+    public function __get($k)
+    {
+        if (array_key_exists($k, $this->_values)) {
+            return $this->_values[$k];
+        } else if ($this->_transientValues->includes($k)) {
+            $class = get_class($this);
+            $attrs = join(', ', array_keys($this->_values));
+            $message = "Stripe Notice: Undefined property of $class instance: $k. "
+                    . "HINT: The $k attribute was set in the past, however. "
+                    . "It was then wiped when refreshing the object "
+                    . "with the result returned by Stripe's API, "
+                    . "probably as a result of a save(). The attributes currently "
+                    . "available on this object are: $attrs";
+            error_log($message);
+            return null;
+        } else {
+            $class = get_class($this);
+            error_log("Stripe Notice: Undefined property of $class instance: $k");
+            return null;
+        }
+    }
+
+    // ArrayAccess methods
+    public function offsetSet($k, $v)
+    {
+        $this->$k = $v;
+    }
+
+    public function offsetExists($k)
+    {
+        return array_key_exists($k, $this->_values);
+    }
+
+    public function offsetUnset($k)
+    {
+        unset($this->$k);
+    }
+    public function offsetGet($k)
+    {
+        return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
+    }
+
+    public function keys()
+    {
+        return array_keys($this->_values);
+    }
+
+    /**
+     * This unfortunately needs to be public to be used in Util.php
+     *
+     * @param string $class
+     * @param array $values
+     * @param string|null $apiKey
+     *
+     * @return Object The object constructed from the given values.
+     */
+    public static function scopedConstructFrom($class, $values, $apiKey = null)
+    {
+        $obj = new $class(isset($values['id']) ? $values['id'] : null, $apiKey);
+        $obj->refreshFrom($values, $apiKey);
+        return $obj;
+    }
+
+    /**
+     * @param array $values
+     * @param string|null $apiKey
+     *
+     * @return Object The object of the same class as $this constructed
+     *    from the given values.
+     */
+    public static function constructFrom($values, $apiKey = null)
+    {
+        return self::scopedConstructFrom(__CLASS__, $values, $apiKey);
+    }
+
+    /**
+     * Refreshes this object using the provided values.
+     *
+     * @param array $values
+     * @param string $apiKey
+     * @param boolean $partial Defaults to false.
+     */
+    public function refreshFrom($values, $apiKey, $partial = false)
+    {
+        $this->_apiKey = $apiKey;
+
+        // Wipe old state before setting new.  This is useful for e.g. updating a
+        // customer, where there is no persistent card parameter.  Mark those values
+        // which don't persist as transient
+        if ($partial) {
+            $removed = new Util\Set();
+        } else {
+            $removed = array_diff(array_keys($this->_values), array_keys($values));
+        }
+
+        foreach ($removed as $k) {
+            if (self::$permanentAttributes->includes($k)) {
+                continue;
+            }
+
+            unset($this->$k);
+        }
+
+        foreach ($values as $k => $v) {
+            if (self::$permanentAttributes->includes($k) && isset($this[$k])) {
+                continue;
+            }
+
+            if (self::$nestedUpdatableAttributes->includes($k) && is_array($v)) {
+                $this->_values[$k] = Object::scopedConstructFrom('Stripe\\AttachedObject', $v, $apiKey);
+            } else {
+                $this->_values[$k] = Util::convertToStripeObject($v, $apiKey);
+            }
+
+            $this->_transientValues->discard($k);
+            $this->_unsavedValues->discard($k);
+        }
+    }
+
+    /**
+     * @return array A recursive mapping of attributes to values for this object,
+     *    including the proper value for deleted attributes.
+     */
+    public function serializeParameters()
+    {
+        $params = array();
+        if ($this->_unsavedValues) {
+            foreach ($this->_unsavedValues->toArray() as $k) {
+                $v = $this->$k;
+                if ($v === null) {
+                    $v = '';
+                }
+
+                $params[$k] = $v;
+            }
+        }
+
+        // Get nested updates.
+        foreach (self::$nestedUpdatableAttributes->toArray() as $property) {
+            if (isset($this->$property) && $this->$property instanceof Object) {
+                $params[$property] = $this->$property->serializeParameters();
+            }
+        }
+
+        return $params;
+    }
+
+    // Pretend to have late static bindings, even in PHP 5.2
+    protected function _lsb($method)
+    {
+        $class = get_class($this);
+        $args = array_slice(func_get_args(), 1);
+        return call_user_func_array(array($class, $method), $args);
+    }
+    protected static function _scopedLsb($class, $method)
+    {
+        $args = array_slice(func_get_args(), 2);
+        return call_user_func_array(array($class, $method), $args);
+    }
+
+    public function __toJSON()
+    {
+        if (defined('JSON_PRETTY_PRINT')) {
+            return json_encode($this->__toArray(true), JSON_PRETTY_PRINT);
+        } else {
+            return json_encode($this->__toArray(true));
+        }
+    }
+
+    public function __toString()
+    {
+        $class = get_class($this);
+        return $class . ' JSON: ' . $this->__toJSON();
+    }
+
+    public function __toArray($recursive = false)
+    {
+        if ($recursive) {
+            return Util::convertStripeObjectToArray($this->_values);
+        } else {
+            return $this->_values;
+        }
+    }
 }
 
 Object::init();

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -4,59 +4,59 @@ namespace Stripe;
 
 class Plan extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the plan to retrieve.
    * @param string|null $apiKey
    *
    * @return Plan
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Plan The created plan.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return Plan The deleted plan.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
   
-  /**
+    /**
    * @return Plan The saved plan.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
   
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Plans.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 }

--- a/lib/RateLimitError.php
+++ b/lib/RateLimitError.php
@@ -4,10 +4,13 @@ namespace Stripe;
 
 class RateLimitError extends InvalidRequestError
 {
-  public function __construct($message, $param, $httpStatus=null,
-      $httpBody=null, $jsonBody=null
-  )
-  {
-    parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
-  }
+    public function __construct(
+        $message,
+        $param,
+        $httpStatus = null,
+        $httpBody = null,
+        $jsonBody = null
+    ) {
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+    }
 }

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -4,74 +4,75 @@ namespace Stripe;
 
 class Recipient extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the recipient to retrieve.
    * @param string|null $apiKey
    *
    * @return Recipient
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Recipients.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Recipient The created recipient.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @return Recipient The saved recipient.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @param array|null $params
    *
    * @return Recipient The deleted recipient.
    */
-  public function delete($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function delete($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 
   
-  /**
+    /**
    * @param array|null $params
    *
    * @return array An array of the recipient's Transfers.
    */
-  public function transfers($params=null)
-  {
-    if (!$params)
-      $params = array();
-    $params['recipient'] = $this->id;
-    $transfers = Transfer::all($params, $this->_apiKey);
-    return $transfers;
-  }
+    public function transfers($params = null)
+    {
+        if (!$params) {
+            $params = array();
+        }
+        $params['recipient'] = $this->id;
+        $transfers = Transfer::all($params, $this->_apiKey);
+        return $transfers;
+    }
 }

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -4,35 +4,35 @@ namespace Stripe;
 
 class Refund extends ApiResource
 {
-  /**
+    /**
    * @return string The API URL for this Stripe refund.
    */
-  public function instanceUrl()
-  {
-    $id = $this['id'];
-    $charge = $this['charge'];
-    if (!$id) {
-      throw new InvalidRequestError(
-          "Could not determine which URL to request: " .
-          "class instance has invalid ID: $id",
-          null
-      );
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        $charge = $this['charge'];
+        if (!$id) {
+            throw new InvalidRequestError(
+                "Could not determine which URL to request: " .
+                "class instance has invalid ID: $id",
+                null
+            );
+        }
+        $id = ApiRequestor::utf8($id);
+        $charge = ApiRequestor::utf8($charge);
+
+        $base = self::classUrl('Stripe\\Charge');
+        $chargeExtn = urlencode($charge);
+        $extn = urlencode($id);
+        return "$base/$chargeExtn/refunds/$extn";
     }
-    $id = ApiRequestor::utf8($id);
-    $charge = ApiRequestor::utf8($charge);
 
-    $base = self::classUrl('Stripe\\Charge');
-    $chargeExtn = urlencode($charge);
-    $extn = urlencode($id);
-    return "$base/$chargeExtn/refunds/$extn";
-  }
-
-  /**
+    /**
    * @return Refund The saved refund.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 }

--- a/lib/SingletonApiResource.php
+++ b/lib/SingletonApiResource.php
@@ -4,30 +4,30 @@ namespace Stripe;
 
 abstract class SingletonApiResource extends ApiResource
 {
-  protected static function _scopedSingletonRetrieve($class, $apiKey=null)
-  {
-    $instance = new $class(null, $apiKey);
-    $instance->refresh();
-    return $instance;
-  }
+    protected static function _scopedSingletonRetrieve($class, $apiKey = null)
+    {
+        $instance = new $class(null, $apiKey);
+        $instance->refresh();
+        return $instance;
+    }
 
-  /**
+    /**
    * @param SingletonApiResource $class
    * @return string The endpoint associated with this singleton class.
    */
-  public static function classUrl($class)
-  {
-    $base = self::className($class);
-    return "/v1/${base}";
-  }
+    public static function classUrl($class)
+    {
+        $base = self::className($class);
+        return "/v1/${base}";
+    }
 
-  /**
+    /**
    * @return string The endpoint associated with this singleton API resource.
    */
-  public function instanceUrl()
-  {
-    $class = get_class($this);
-    $base = self::classUrl($class);
-    return "$base";
-  }
+    public function instanceUrl()
+    {
+        $class = get_class($this);
+        $base = self::classUrl($class);
+        return "$base";
+    }
 }

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -4,76 +4,76 @@ namespace Stripe;
 
 abstract class Stripe
 {
-  /**
+    /**
    * @var string The Stripe API key to be used for requests.
    */
-  public static $apiKey;
-  /**
+    public static $apiKey;
+    /**
    * @var string The base URL for the Stripe API.
    */
-  public static $apiBase = 'https://api.stripe.com';
-  /**
+    public static $apiBase = 'https://api.stripe.com';
+    /**
    * @var string The base URL for the Stripe API uploads endpoint.
    */
-  public static $apiUploadBase = 'https://uploads.stripe.com';
-  /**
+    public static $apiUploadBase = 'https://uploads.stripe.com';
+    /**
    * @var string|null The version of the Stripe API to use for requests.
    */
-  public static $apiVersion = null;
-  /**
+    public static $apiVersion = null;
+    /**
    * @var boolean Defaults to true.
    */
-  public static $verifySslCerts = true;
-  const VERSION = '1.17.5';
+    public static $verifySslCerts = true;
+    const VERSION = '1.17.5';
 
-  /**
+    /**
    * @return string The API key used for requests.
    */
-  public static function getApiKey()
-  {
-    return self::$apiKey;
-  }
+    public static function getApiKey()
+    {
+        return self::$apiKey;
+    }
 
-  /**
+    /**
    * Sets the API key to be used for requests.
    *
    * @param string $apiKey
    */
-  public static function setApiKey($apiKey)
-  {
-    self::$apiKey = $apiKey;
-  }
+    public static function setApiKey($apiKey)
+    {
+        self::$apiKey = $apiKey;
+    }
 
-  /**
+    /**
    * @return string The API version used for requests. null if we're using the
    *    latest version.
    */
-  public static function getApiVersion()
-  {
-    return self::$apiVersion;
-  }
+    public static function getApiVersion()
+    {
+        return self::$apiVersion;
+    }
 
-  /**
+    /**
    * @param string $apiVersion The API version to use for requests.
    */
-  public static function setApiVersion($apiVersion)
-  {
-    self::$apiVersion = $apiVersion;
-  }
+    public static function setApiVersion($apiVersion)
+    {
+        self::$apiVersion = $apiVersion;
+    }
 
-  /**
+    /**
    * @return boolean
    */
-  public static function getVerifySslCerts()
-  {
-    return self::$verifySslCerts;
-  }
+    public static function getVerifySslCerts()
+    {
+        return self::$verifySslCerts;
+    }
 
-  /**
+    /**
    * @param boolean $verify
    */
-  public static function setVerifySslCerts($verify)
-  {
-    self::$verifySslCerts = $verify;
-  }
+    public static function setVerifySslCerts($verify)
+    {
+        self::$verifySslCerts = $verify;
+    }
 }

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -4,56 +4,56 @@ namespace Stripe;
 
 class Subscription extends ApiResource
 {
-  /**
+    /**
    * @return string The API URL for this Stripe subscription.
    */
-  public function instanceUrl()
-  {
-    $id = $this['id'];
-    $customer = $this['customer'];
-    if (!$id) {
-      throw new InvalidRequestError(
-          "Could not determine which URL to request: " .
-          "class instance has invalid ID: $id",
-          null
-      );
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        $customer = $this['customer'];
+        if (!$id) {
+            throw new InvalidRequestError(
+                "Could not determine which URL to request: " .
+                "class instance has invalid ID: $id",
+                null
+            );
+        }
+        $id = ApiRequestor::utf8($id);
+        $customer = ApiRequestor::utf8($customer);
+
+        $base = self::classUrl('Stripe\\Customer');
+        $customerExtn = urlencode($customer);
+        $extn = urlencode($id);
+        return "$base/$customerExtn/subscriptions/$extn";
     }
-    $id = ApiRequestor::utf8($id);
-    $customer = ApiRequestor::utf8($customer);
 
-    $base = self::classUrl('Stripe\\Customer');
-    $customerExtn = urlencode($customer);
-    $extn = urlencode($id);
-    return "$base/$customerExtn/subscriptions/$extn";
-  }
-
-  /**
+    /**
    * @param array|null $params
    * @return Subscription The deleted subscription.
    */
-  public function cancel($params=null)
-  {
-    $class = get_class();
-    return self::_scopedDelete($class, $params);
-  }
+    public function cancel($params = null)
+    {
+        $class = get_class();
+        return self::_scopedDelete($class, $params);
+    }
 
-  /**
+    /**
    * @return Subscription The saved subscription.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
+    /**
    * @return Subscription The updated subscription.
    */
-  public function deleteDiscount()
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/discount';
-    list($response, $apiKey) = $requestor->request('delete', $url);
-    $this->refreshFrom(array('discount' => null), $apiKey, true);
-  }
+    public function deleteDiscount()
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/discount';
+        list($response, $apiKey) = $requestor->request('delete', $url);
+        $this->refreshFrom(array('discount' => null), $apiKey, true);
+    }
 }

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -4,27 +4,27 @@ namespace Stripe;
 
 class Token extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the token to retrieve.
    * @param string|null $apiKey
    *
    * @return Token
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Coupon The created token.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 }

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -4,61 +4,60 @@ namespace Stripe;
 
 class Transfer extends ApiResource
 {
-  /**
+    /**
    * @param string $id The ID of the transfer to retrieve.
    * @param string|null $apiKey
    *
    * @return Transfer
    */
-  public static function retrieve($id, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $apiKey);
-  }
+    public static function retrieve($id, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return array An array of Transfers.
    */
-  public static function all($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $apiKey);
-  }
+    public static function all($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @param array|null $params
    * @param string|null $apiKey
    *
    * @return Transfer The created transfer.
    */
-  public static function create($params=null, $apiKey=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $apiKey);
-  }
+    public static function create($params = null, $apiKey = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $apiKey);
+    }
 
-  /**
+    /**
    * @return Transfer The canceled transfer.
    */
-  public function cancel()
-  {
-    $requestor = new ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/cancel';
-    list($response, $apiKey) = $requestor->request('post', $url);
-    $this->refreshFrom($response, $apiKey);
-    return $this;
-  }
+    public function cancel()
+    {
+        $requestor = new ApiRequestor($this->_apiKey);
+        $url = $this->instanceUrl() . '/cancel';
+        list($response, $apiKey) = $requestor->request('post', $url);
+        $this->refreshFrom($response, $apiKey);
+        return $this;
+    }
 
-  /**
+    /**
    * @return Transfer The saved transfer.
    */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
-
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 }

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -4,91 +4,94 @@ namespace Stripe;
 
 abstract class Util
 {
-  /**
+    /**
    * Whether the provided array (or other) is a list rather than a dictionary.
    *
    * @param array|mixed $array
    * @return boolean True if the given object is a list.
    */
-  public static function isList($array)
-  {
-    if (!is_array($array))
-      return false;
+    public static function isList($array)
+    {
+        if (!is_array($array)) {
+            return false;
+        }
 
-    // TODO: generally incorrect, but it's correct given Stripe's response
-    foreach (array_keys($array) as $k) {
-      if (!is_numeric($k))
-        return false;
+      // TODO: generally incorrect, but it's correct given Stripe's response
+        foreach (array_keys($array) as $k) {
+            if (!is_numeric($k)) {
+                return false;
+            }
+        }
+        return true;
     }
-    return true;
-  }
 
-  /**
+    /**
    * Recursively converts the PHP Stripe object to an array.
    *
    * @param array $values The PHP Stripe object to convert.
    * @return array
    */
-  public static function convertStripeObjectToArray($values)
-  {
-    $results = array();
-    foreach ($values as $k => $v) {
-      // FIXME: this is an encapsulation violation
-      if ($k[0] == '_') {
-        continue;
-      }
-      if ($v instanceof Object) {
-        $results[$k] = $v->__toArray(true);
-      } else if (is_array($v)) {
-        $results[$k] = self::convertStripeObjectToArray($v);
-      } else {
-        $results[$k] = $v;
-      }
+    public static function convertStripeObjectToArray($values)
+    {
+        $results = array();
+        foreach ($values as $k => $v) {
+          // FIXME: this is an encapsulation violation
+            if ($k[0] == '_') {
+                continue;
+            }
+            if ($v instanceof Object) {
+                $results[$k] = $v->__toArray(true);
+            } elseif (is_array($v)) {
+                $results[$k] = self::convertStripeObjectToArray($v);
+            } else {
+                $results[$k] = $v;
+            }
+        }
+        return $results;
     }
-    return $results;
-  }
 
-  /**
+    /**
    * Converts a response from the Stripe API to the corresponding PHP object.
    *
    * @param array $resp The response from the Stripe API.
    * @param string $apiKey
    * @return Object|array
    */
-  public static function convertToStripeObject($resp, $apiKey)
-  {
-    $types = array(
-      'card' => 'Stripe\\Card',
-      'charge' => 'Stripe\\Charge',
-      'coupon' => 'Stripe\\Coupon',
-      'customer' => 'Stripe\\Customer',
-      'list' => 'Stripe\\Collection',
-      'invoice' => 'Stripe\\Invoice',
-      'invoiceitem' => 'Stripe\\InvoiceItem',
-      'event' => 'Stripe\\Event',
-      'transfer' => 'Stripe\\Transfer',
-      'plan' => 'Stripe\\Plan',
-      'recipient' => 'Stripe\\Recipient',
-      'refund' => 'Stripe\\Refund',
-      'subscription' => 'Stripe\\Subscription',
-      'fee_refund' => 'Stripe\\ApplicationFeeRefund'
-    );
-    if (self::isList($resp)) {
-      $mapped = array();
-      foreach ($resp as $i)
-        array_push($mapped, self::convertToStripeObject($i, $apiKey));
-      return $mapped;
-    } else if (is_array($resp)) {
-      if (isset($resp['object'])
-          && is_string($resp['object'])
-          && isset($types[$resp['object']])) {
-        $class = $types[$resp['object']];
-      } else {
-        $class = 'Stripe\\Object';
-      }
-      return Object::scopedConstructFrom($class, $resp, $apiKey);
-    } else {
-      return $resp;
+    public static function convertToStripeObject($resp, $apiKey)
+    {
+        $types = array(
+        'card' => 'Stripe\\Card',
+        'charge' => 'Stripe\\Charge',
+        'coupon' => 'Stripe\\Coupon',
+        'customer' => 'Stripe\\Customer',
+        'list' => 'Stripe\\Collection',
+        'invoice' => 'Stripe\\Invoice',
+        'invoiceitem' => 'Stripe\\InvoiceItem',
+        'event' => 'Stripe\\Event',
+        'transfer' => 'Stripe\\Transfer',
+        'plan' => 'Stripe\\Plan',
+        'recipient' => 'Stripe\\Recipient',
+        'refund' => 'Stripe\\Refund',
+        'subscription' => 'Stripe\\Subscription',
+        'fee_refund' => 'Stripe\\ApplicationFeeRefund'
+        );
+        if (self::isList($resp)) {
+            $mapped = array();
+            foreach ($resp as $i) {
+                array_push($mapped, self::convertToStripeObject($i, $apiKey));
+            }
+            return $mapped;
+        } elseif (is_array($resp)) {
+            if (isset($resp['object'])
+            && is_string($resp['object'])
+            && isset($types[$resp['object']])) {
+                $class = $types[$resp['object']];
+            } else {
+                $class = 'Stripe\\Object';
+            }
+            return Object::scopedConstructFrom($class, $resp, $apiKey);
+        } else {
+            return $resp;
+        }
     }
-  }
 }

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -4,15 +4,15 @@ namespace Stripe;
 
 class AccountTest extends TestCase
 {
-  public function testRetrieve()
-  {
-    self::authorizeFromEnv();
-    $d = Account::retrieve();
-    $this->assertSame($d->id, "cuD9Rwx8pgmRZRpVe02lsuR9cwp2Bzf7");
-    $this->assertSame($d->email, "test+bindings@stripe.com");
-    // @codingStandardsIgnoreStart
-    $this->assertSame($d->charges_enabled, false);
-    $this->assertSame($d->details_submitted, false);
-    // @codingStandardsIgnoreEnd
-  }
+    public function testRetrieve()
+    {
+        self::authorizeFromEnv();
+        $d = Account::retrieve();
+        $this->assertSame($d->id, "cuD9Rwx8pgmRZRpVe02lsuR9cwp2Bzf7");
+        $this->assertSame($d->email, "test+bindings@stripe.com");
+      // @codingStandardsIgnoreStart
+        $this->assertSame($d->charges_enabled, false);
+        $this->assertSame($d->details_submitted, false);
+      // @codingStandardsIgnoreEnd
+    }
 }

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -4,85 +4,85 @@ namespace Stripe;
 
 class ApiRequestorTest extends TestCase
 {
-  public function testEncode()
-  {
-    $a = array(
-      'my' => 'value',
-      'that' => array('your' => 'example'),
-      'bar' => 1,
-      'baz' => null
-    );
+    public function testEncode()
+    {
+        $a = array(
+        'my' => 'value',
+        'that' => array('your' => 'example'),
+        'bar' => 1,
+        'baz' => null
+        );
 
-    $enc = APIRequestor::encode($a);
-    $this->assertSame($enc, 'my=value&that%5Byour%5D=example&bar=1');
+        $enc = APIRequestor::encode($a);
+        $this->assertSame($enc, 'my=value&that%5Byour%5D=example&bar=1');
 
-    $a = array('that' => array('your' => 'example', 'foo' => null));
-    $enc = APIRequestor::encode($a);
-    $this->assertSame($enc, 'that%5Byour%5D=example');
+        $a = array('that' => array('your' => 'example', 'foo' => null));
+        $enc = APIRequestor::encode($a);
+        $this->assertSame($enc, 'that%5Byour%5D=example');
 
-    $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
-    $enc = APIRequestor::encode($a);
-    $this->assertSame($enc, 'that=example&foo%5B%5D=bar&foo%5B%5D=baz');
+        $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
+        $enc = APIRequestor::encode($a);
+        $this->assertSame($enc, 'that=example&foo%5B%5D=bar&foo%5B%5D=baz');
 
-    $a = array(
+        $a = array(
         'my' => 'value',
         'that' => array('your' => array('cheese', 'whiz', null)),
         'bar' => 1,
         'baz' => null
-    );
+        );
 
-    $enc = APIRequestor::encode($a);
-    $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
+        $enc = APIRequestor::encode($a);
+        $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
               . '&that%5Byour%5D%5B%5D=whiz&bar=1';
-    $this->assertSame($enc, $expected);
-  }
-
-  public function testUtf8()
-  {
-    // UTF-8 string
-    $x = "\xc3\xa9";
-    $this->assertSame(ApiRequestor::utf8($x), $x);
-
-    // Latin-1 string
-    $x = "\xe9";
-    $this->assertSame(ApiRequestor::utf8($x), "\xc3\xa9");
-
-    // Not a string
-    $x = TRUE;
-    $this->assertSame(ApiRequestor::utf8($x), $x);
-  }
-
-  public function testEncodeObjects()
-  {
-    // We have to do some work here because this is normally
-    // private. This is just for testing! Also it only works on PHP >=
-    // 5.3
-    if (version_compare(PHP_VERSION, '5.3.2', '>=')) {
-      $reflector = new \ReflectionClass('Stripe\\ApiRequestor');
-      $method = $reflector->getMethod('_encodeObjects');
-      $method->setAccessible(true);
-
-      $a = array('customer' => new Customer('abcd'));
-      $enc = $method->invoke(null, $a);
-      $this->assertSame($enc, array('customer' => 'abcd'));
-
-      // Preserves UTF-8
-      $v = array('customer' => "☃");
-      $enc = $method->invoke(null, $v);
-      $this->assertSame($enc, $v);
-
-      // Encodes latin-1 -> UTF-8
-      $v = array('customer' => "\xe9");
-      $enc = $method->invoke(null, $v);
-      $this->assertSame($enc, array('customer' => "\xc3\xa9"));
+        $this->assertSame($enc, $expected);
     }
-  }
 
-  public function testBlacklistedPEMCert()
-  {
-    $cert =
-      // {{{ Revoked certificate from api.stripe.com
-'-----BEGIN CERTIFICATE-----
+    public function testUtf8()
+    {
+      // UTF-8 string
+        $x = "\xc3\xa9";
+        $this->assertSame(ApiRequestor::utf8($x), $x);
+
+      // Latin-1 string
+        $x = "\xe9";
+        $this->assertSame(ApiRequestor::utf8($x), "\xc3\xa9");
+
+      // Not a string
+        $x = true;
+        $this->assertSame(ApiRequestor::utf8($x), $x);
+    }
+
+    public function testEncodeObjects()
+    {
+      // We have to do some work here because this is normally
+      // private. This is just for testing! Also it only works on PHP >=
+      // 5.3
+        if (version_compare(PHP_VERSION, '5.3.2', '>=')) {
+            $reflector = new \ReflectionClass('Stripe\\ApiRequestor');
+            $method = $reflector->getMethod('_encodeObjects');
+            $method->setAccessible(true);
+
+            $a = array('customer' => new Customer('abcd'));
+            $enc = $method->invoke(null, $a);
+            $this->assertSame($enc, array('customer' => 'abcd'));
+
+          // Preserves UTF-8
+            $v = array('customer' => "☃");
+            $enc = $method->invoke(null, $v);
+            $this->assertSame($enc, $v);
+
+          // Encodes latin-1 -> UTF-8
+            $v = array('customer' => "\xe9");
+            $enc = $method->invoke(null, $v);
+            $this->assertSame($enc, array('customer' => "\xc3\xa9"));
+        }
+    }
+
+    public function testBlacklistedPEMCert()
+    {
+        $cert =
+        // {{{ Revoked certificate from api.stripe.com
+        '-----BEGIN CERTIFICATE-----
 MIIGoDCCBYigAwIBAgIQATGh1aL1Q3mXYwp7zTQ8+zANBgkqhkiG9w0BAQUFADBm
 MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
 d3cuZGlnaWNlcnQuY29tMSUwIwYDVQQDExxEaWdpQ2VydCBIaWdoIEFzc3VyYW5j
@@ -120,7 +120,7 @@ SBs2soRGVXHr3AczRKLW3G+IbIpUc3vilOul/PXWHutfzz7/asxXSTk/siVKROQ8
 3PGuaL8B8TZVbTOPYoJHdPzeRxL8Rbg8sDogHR+jkqwwyhUCfuzVbOjWFJU1DKvr
 CBoD8xKYd5r7CYf1Du+nNMmDmrE=
 -----END CERTIFICATE-----';
-  // }}}
-    $this->assertTrue(APIRequestor::isBlackListed($cert));
-  }
+    // }}}
+        $this->assertTrue(APIRequestor::isBlackListed($cert));
+    }
 }

--- a/tests/ApplicationFeeRefundTest.php
+++ b/tests/ApplicationFeeRefundTest.php
@@ -4,15 +4,15 @@ namespace Stripe;
 
 class ApplicationFeeRefundTest extends TestCase
 {
-  public function testUrls()
-  {
-    $refund = new ApplicationFeeRefund();
-    $refund->id = 'refund_id';
-    $refund->fee = 'fee_id';
+    public function testUrls()
+    {
+        $refund = new ApplicationFeeRefund();
+        $refund->id = 'refund_id';
+        $refund->fee = 'fee_id';
 
-    $this->assertSame(
-        $refund->instanceUrl(),
-        '/v1/application_fees/fee_id/refunds/refund_id'
-    );
-  }
+        $this->assertSame(
+            $refund->instanceUrl(),
+            '/v1/application_fees/fee_id/refunds/refund_id'
+        );
+    }
 }

--- a/tests/ApplicationFeeTest.php
+++ b/tests/ApplicationFeeTest.php
@@ -4,18 +4,19 @@ namespace Stripe;
 
 class ApplicationFeeTest extends TestCase
 {
-  public function testUrls()
-  {
-    $applicationFee = new ApplicationFee('abcd/efgh');
-    $this->assertSame(
-        $applicationFee->instanceUrl(), '/v1/application_fees/abcd%2Fefgh'
-    );
-  }
+    public function testUrls()
+    {
+        $applicationFee = new ApplicationFee('abcd/efgh');
+        $this->assertSame(
+            $applicationFee->instanceUrl(),
+            '/v1/application_fees/abcd%2Fefgh'
+        );
+    }
 
-  public function testList()
-  {
-    self::authorizeFromEnv();
-    $d = ApplicationFee::all();
-    $this->assertSame($d->url, '/v1/application_fees');
-  }
+    public function testList()
+    {
+        self::authorizeFromEnv();
+        $d = ApplicationFee::all();
+        $this->assertSame($d->url, '/v1/application_fees');
+    }
 }

--- a/tests/AuthenticationErrorTest.php
+++ b/tests/AuthenticationErrorTest.php
@@ -4,13 +4,13 @@ namespace Stripe;
 
 class AuthenticationErrorTest extends TestCase
 {
-  public function testInvalidCredentials()
-  {
-    Stripe::setApiKey('invalid');
-    try {
-      Customer::create();
-    } catch (AuthenticationError $e) {
-      $this->assertSame(401, $e->getHttpStatus());
+    public function testInvalidCredentials()
+    {
+        Stripe::setApiKey('invalid');
+        try {
+            Customer::create();
+        } catch (AuthenticationError $e) {
+            $this->assertSame(401, $e->getHttpStatus());
+        }
     }
-  }
 }

--- a/tests/BalanceTest.php
+++ b/tests/BalanceTest.php
@@ -4,12 +4,12 @@ namespace Stripe;
 
 class BalanceTest extends TestCase
 {
-  public function testRetrieve()
-  {
-    self::authorizeFromEnv();
-    $d = Balance::retrieve();
-    $this->assertSame($d->object, "balance");
-    $this->assertTrue(Util::isList($d->available));
-    $this->assertTrue(Util::isList($d->pending));
-  }
+    public function testRetrieve()
+    {
+        self::authorizeFromEnv();
+        $d = Balance::retrieve();
+        $this->assertSame($d->object, "balance");
+        $this->assertTrue(Util::isList($d->available));
+        $this->assertTrue(Util::isList($d->pending));
+    }
 }

--- a/tests/BalanceTransactionTest.php
+++ b/tests/BalanceTransactionTest.php
@@ -4,10 +4,10 @@ namespace Stripe;
 
 class BalanceTransactionTest extends TestCase
 {
-  public function testList()
-  {
-    self::authorizeFromEnv();
-    $d = BalanceTransaction::all();
-    $this->assertSame($d->url, '/v1/balance/history');
-  }
+    public function testList()
+    {
+        self::authorizeFromEnv();
+        $d = BalanceTransaction::all();
+        $this->assertSame($d->url, '/v1/balance/history');
+    }
 }

--- a/tests/CardErrorTest.php
+++ b/tests/CardErrorTest.php
@@ -4,38 +4,38 @@ namespace Stripe;
 
 class CardErrorTest extends TestCase
 {
-  public function testDecline()
-  {
-    self::authorizeFromEnv();
+    public function testDecline()
+    {
+        self::authorizeFromEnv();
 
-    $card = array(
-      'number' => '4000000000000002',
-      'exp_month' => '3',
-      'exp_year' => '2020'
-    );
+        $card = array(
+        'number' => '4000000000000002',
+        'exp_month' => '3',
+        'exp_year' => '2020'
+        );
 
-    $charge = array(
-      'amount' => 100,
-      'currency' => 'usd',
-      'card' => $card
-    );
+        $charge = array(
+        'amount' => 100,
+        'currency' => 'usd',
+        'card' => $card
+        );
 
-    try {
-      Charge::create($charge);
-    } catch (CardError $e) {
-      $this->assertSame(402, $e->getHttpStatus());
-      $actual = $e->getJsonBody();
-      $this->assertSame(
-          array(
+        try {
+            Charge::create($charge);
+        } catch (CardError $e) {
+            $this->assertSame(402, $e->getHttpStatus());
+            $actual = $e->getJsonBody();
+            $this->assertSame(
+                array(
                 'error' => array(
                     'message' => 'Your card was declined.',
                     'type' => 'card_error',
                     'code' => 'card_declined',
                     'charge' => $actual['error']['charge'],
                 ),
-            ),
-          $actual
-      );
+                ),
+                $actual
+            );
+        }
     }
-  }
 }

--- a/tests/ChargeTest.php
+++ b/tests/ChargeTest.php
@@ -4,153 +4,154 @@ namespace Stripe;
 
 class ChargeTest extends TestCase
 {
-  public function testUrls()
-  {
-    $this->assertSame(Charge::classUrl('Stripe\\Charge'), '/v1/charges');
-    $charge = new Charge('abcd/efgh');
-    $this->assertSame($charge->instanceUrl(), '/v1/charges/abcd%2Fefgh');
-  }
+    public function testUrls()
+    {
+        $this->assertSame(Charge::classUrl('Stripe\\Charge'), '/v1/charges');
+        $charge = new Charge('abcd/efgh');
+        $this->assertSame($charge->instanceUrl(), '/v1/charges/abcd%2Fefgh');
+    }
 
-  public function testCreate()
-  {
-    self::authorizeFromEnv();
+    public function testCreate()
+    {
+        self::authorizeFromEnv();
 
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
 
-    $c = Charge::create(
-        array(
-          'amount' => 100,
-          'currency' => 'usd',
-          'card' => $card
-        )
-    );
-    $this->assertTrue($c->paid);
-    $this->assertFalse($c->refunded);
-  }
-
-  public function testRetrieve()
-  {
-    self::authorizeFromEnv();
-
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
-
-    $c = Charge::create(
-        array(
+        $c = Charge::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'card' => $card
-        )
-    );
-    $d = Charge::retrieve($c->id);
-    $this->assertSame($d->id, $c->id);
-  }
+            )
+        );
+        $this->assertTrue($c->paid);
+        $this->assertFalse($c->refunded);
+    }
 
-  public function testUpdateMetadata()
-  {
-    self::authorizeFromEnv();
+    public function testRetrieve()
+    {
+        self::authorizeFromEnv();
 
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
 
-    $charge = Charge::create(
-        array(
+        $c = Charge::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'card' => $card
-        )
-    );
+            )
+        );
+        $d = Charge::retrieve($c->id);
+        $this->assertSame($d->id, $c->id);
+    }
 
-    $charge->metadata['test'] = 'foo bar';
-    $charge->save();
+    public function testUpdateMetadata()
+    {
+        self::authorizeFromEnv();
 
-    $updatedCharge = Charge::retrieve($charge->id);
-    $this->assertSame('foo bar', $updatedCharge->metadata['test']);
-  }
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
 
-  public function testUpdateMetadataAll()
-  {
-    self::authorizeFromEnv();
-
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
-
-    $charge = Charge::create(
-        array(
+        $charge = Charge::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'card' => $card
-        )
-    );
+            )
+        );
 
-    $charge->metadata = array('test' => 'foo bar');
-    $charge->save();
+        $charge->metadata['test'] = 'foo bar';
+        $charge->save();
 
-    $updatedCharge = Charge::retrieve($charge->id);
-    $this->assertSame('foo bar', $updatedCharge->metadata['test']);
-  }
+        $updatedCharge = Charge::retrieve($charge->id);
+        $this->assertSame('foo bar', $updatedCharge->metadata['test']);
+    }
 
-  public function testMarkAsFraudulent()
-  {
-    self::authorizeFromEnv();
+    public function testUpdateMetadataAll()
+    {
+        self::authorizeFromEnv();
 
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
 
-    $charge = Charge::create(
-        array(
+        $charge = Charge::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'card' => $card
-        )
-    );
+            )
+        );
 
-    $charge->refunds->create();
-    $charge->markAsFraudulent();
+        $charge->metadata = array('test' => 'foo bar');
+        $charge->save();
 
-    $updatedCharge = Charge::retrieve($charge->id);
-    $this->assertSame(
-        'fraudulent', $updatedCharge['fraud_details']['user_report']
-    );
-  }
+        $updatedCharge = Charge::retrieve($charge->id);
+        $this->assertSame('foo bar', $updatedCharge->metadata['test']);
+    }
 
-  public function markAsSafe()
-  {
-    self::authorizeFromEnv();
+    public function testMarkAsFraudulent()
+    {
+        self::authorizeFromEnv();
 
-    $card = array(
-      'number' => '4242424242424242',
-      'exp_month' => 5,
-      'exp_year' => 2015
-    );
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
 
-    $charge = Charge::create(
-        array(
+        $charge = Charge::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'card' => $card
-        )
-    );
+            )
+        );
 
-    $charge->markAsSafe();
+        $charge->refunds->create();
+        $charge->markAsFraudulent();
 
-    $updatedCharge = Charge::retrieve($charge->id);
-    $this->assertSame('safe', $updatedCharge['fraud_details']['user_report']);
-  }
+        $updatedCharge = Charge::retrieve($charge->id);
+        $this->assertSame(
+            'fraudulent',
+            $updatedCharge['fraud_details']['user_report']
+        );
+    }
+
+    public function markAsSafe()
+    {
+        self::authorizeFromEnv();
+
+        $card = array(
+        'number' => '4242424242424242',
+        'exp_month' => 5,
+        'exp_year' => 2015
+        );
+
+        $charge = Charge::create(
+            array(
+            'amount' => 100,
+            'currency' => 'usd',
+            'card' => $card
+            )
+        );
+
+        $charge->markAsSafe();
+
+        $updatedCharge = Charge::retrieve($charge->id);
+        $this->assertSame('safe', $updatedCharge['fraud_details']['user_report']);
+    }
 }

--- a/tests/CouponTest.php
+++ b/tests/CouponTest.php
@@ -4,26 +4,26 @@ namespace Stripe;
 
 class CouponTest extends TestCase
 {
-  public function testSave()
-  {
-    self::authorizeFromEnv();
-    $id = 'test_coupon-' . self::randomString();
-    $c = Coupon::create(
-        array(
+    public function testSave()
+    {
+        self::authorizeFromEnv();
+        $id = 'test_coupon-' . self::randomString();
+        $c = Coupon::create(
+            array(
             'percent_off' => 25,
             'duration' => 'repeating',
             'duration_in_months' => 5,
             'id' => $id,
-        )
-    );
-    $this->assertSame($id, $c->id);
+            )
+        );
+        $this->assertSame($id, $c->id);
     // @codingStandardsIgnoreStart
-    $this->assertSame(25, $c->percent_off);
+        $this->assertSame(25, $c->percent_off);
     // @codingStandardsIgnoreEnd
-    $c->metadata['foo'] = 'bar';
-    $c->save();
+        $c->metadata['foo'] = 'bar';
+        $c->save();
 
-    $stripeCoupon = Coupon::retrieve($id);
-    $this->assertEquals($c->metadata, $stripeCoupon->metadata);
-  }
+        $stripeCoupon = Coupon::retrieve($id);
+        $this->assertEquals($c->metadata, $stripeCoupon->metadata);
+    }
 }

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -4,211 +4,210 @@ namespace Stripe;
 
 class CustomerTest extends TestCase
 {
-  public function testDeletion()
-  {
-    $customer = self::createTestCustomer();
-    $customer->delete();
+    public function testDeletion()
+    {
+        $customer = self::createTestCustomer();
+        $customer->delete();
 
-    $this->assertTrue($customer->deleted);
-    $this->assertNull($customer['active_card']);
-  }
+        $this->assertTrue($customer->deleted);
+        $this->assertNull($customer['active_card']);
+    }
 
-  public function testSave()
-  {
-    $customer = self::createTestCustomer();
+    public function testSave()
+    {
+        $customer = self::createTestCustomer();
 
-    $customer->email = 'gdb@stripe.com';
-    $customer->save();
-    $this->assertSame($customer->email, 'gdb@stripe.com');
+        $customer->email = 'gdb@stripe.com';
+        $customer->save();
+        $this->assertSame($customer->email, 'gdb@stripe.com');
 
-    $stripeCustomer = Customer::retrieve($customer->id);
-    $this->assertSame($customer->email, $stripeCustomer->email);
+        $stripeCustomer = Customer::retrieve($customer->id);
+        $this->assertSame($customer->email, $stripeCustomer->email);
 
-    Stripe::setApiKey(null);
-    $customer = Customer::create(null, self::API_KEY);
-    $customer->email = 'gdb@stripe.com';
-    $customer->save();
+        Stripe::setApiKey(null);
+        $customer = Customer::create(null, self::API_KEY);
+        $customer->email = 'gdb@stripe.com';
+        $customer->save();
 
-    self::authorizeFromEnv();
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame($updatedCustomer->email, 'gdb@stripe.com');
-  }
+        self::authorizeFromEnv();
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame($updatedCustomer->email, 'gdb@stripe.com');
+    }
 
-  /**
+    /**
    * @expectedException Stripe\InvalidRequestError
    */
-  public function testBogusAttribute()
-  {
-    $customer = self::createTestCustomer();
-    $customer->bogus = 'bogus';
-    $customer->save();
-  }
+    public function testBogusAttribute()
+    {
+        $customer = self::createTestCustomer();
+        $customer->bogus = 'bogus';
+        $customer->save();
+    }
 
-  /**
+    /**
    * @expectedException InvalidArgumentException
    */
-  public function testUpdateDescriptionEmpty()
-  {
-    $customer = self::createTestCustomer();
-    $customer->description = '';
-  }
+    public function testUpdateDescriptionEmpty()
+    {
+        $customer = self::createTestCustomer();
+        $customer->description = '';
+    }
 
-  public function testUpdateDescriptionNull()
-  {
-    $customer = self::createTestCustomer(array('description' => 'foo bar'));
-    $customer->description = NULL;
+    public function testUpdateDescriptionNull()
+    {
+        $customer = self::createTestCustomer(array('description' => 'foo bar'));
+        $customer->description = null;
 
-    $customer->save();
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame(NULL, $updatedCustomer->description);
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame(null, $updatedCustomer->description);
+    }
 
-  public function testUpdateMetadata()
-  {
-    $customer = self::createTestCustomer();
+    public function testUpdateMetadata()
+    {
+        $customer = self::createTestCustomer();
 
-    $customer->metadata['test'] = 'foo bar';
-    $customer->save();
+        $customer->metadata['test'] = 'foo bar';
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame('foo bar', $updatedCustomer->metadata['test']);
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame('foo bar', $updatedCustomer->metadata['test']);
+    }
 
-  public function testDeleteMetadata()
-  {
-    $customer = self::createTestCustomer();
+    public function testDeleteMetadata()
+    {
+        $customer = self::createTestCustomer();
 
-    $customer->metadata = NULL;
-    $customer->save();
+        $customer->metadata = null;
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame(0, count($updatedCustomer->metadata->keys()));
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame(0, count($updatedCustomer->metadata->keys()));
+    }
 
-  public function testUpdateSomeMetadata()
-  {
-    $customer = self::createTestCustomer();
-    $customer->metadata['shoe size'] = '7';
-    $customer->metadata['shirt size'] = 'XS';
-    $customer->save();
+    public function testUpdateSomeMetadata()
+    {
+        $customer = self::createTestCustomer();
+        $customer->metadata['shoe size'] = '7';
+        $customer->metadata['shirt size'] = 'XS';
+        $customer->save();
 
-    $customer->metadata['shoe size'] = '9';
-    $customer->save();
+        $customer->metadata['shoe size'] = '9';
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame('XS', $updatedCustomer->metadata['shirt size']);
-    $this->assertSame('9', $updatedCustomer->metadata['shoe size']);
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame('XS', $updatedCustomer->metadata['shirt size']);
+        $this->assertSame('9', $updatedCustomer->metadata['shoe size']);
+    }
 
-  public function testUpdateAllMetadata()
-  {
-    $customer = self::createTestCustomer();
-    $customer->metadata['shoe size'] = '7';
-    $customer->metadata['shirt size'] = 'XS';
-    $customer->save();
+    public function testUpdateAllMetadata()
+    {
+        $customer = self::createTestCustomer();
+        $customer->metadata['shoe size'] = '7';
+        $customer->metadata['shirt size'] = 'XS';
+        $customer->save();
 
-    $customer->metadata = array('shirt size' => 'XL');
-    $customer->save();
+        $customer->metadata = array('shirt size' => 'XL');
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $this->assertSame('XL', $updatedCustomer->metadata['shirt size']);
-    $this->assertFalse(isset($updatedCustomer->metadata['shoe size']));
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $this->assertSame('XL', $updatedCustomer->metadata['shirt size']);
+        $this->assertFalse(isset($updatedCustomer->metadata['shoe size']));
+    }
 
-  /**
+    /**
    * @expectedException Stripe\InvalidRequestError
    */
-  public function testUpdateInvalidMetadata()
-  {
-    $customer = self::createTestCustomer();
-    $customer->metadata = 'something';
-    $customer->save();
-  }
+    public function testUpdateInvalidMetadata()
+    {
+        $customer = self::createTestCustomer();
+        $customer->metadata = 'something';
+        $customer->save();
+    }
 
-  public function testCancelSubscription()
-  {
-    $planID = 'gold-' . self::randomString();
-    self::retrieveOrCreatePlan($planID);
+    public function testCancelSubscription()
+    {
+        $planID = 'gold-' . self::randomString();
+        self::retrieveOrCreatePlan($planID);
 
-    $customer = self::createTestCustomer(
-        array(
+        $customer = self::createTestCustomer(
+            array(
             'plan' => $planID,
-        )
-    );
+            )
+        );
 
-    $customer->cancelSubscription(array('at_period_end' => true));
-    $this->assertSame($customer->subscription->status, 'active');
-    $this->assertTrue($customer->subscription->cancel_at_period_end);
-    $customer->cancelSubscription();
-    $this->assertSame($customer->subscription->status, 'canceled');
-  }
+        $customer->cancelSubscription(array('at_period_end' => true));
+        $this->assertSame($customer->subscription->status, 'active');
+        $this->assertTrue($customer->subscription->cancel_at_period_end);
+        $customer->cancelSubscription();
+        $this->assertSame($customer->subscription->status, 'canceled');
+    }
 
-  public function testCustomerAddCard()
-  {
-    $token = Token::create(
-        array("card" => array(
-          "number" => "4242424242424242",
-          "exp_month" => 5,
-          "exp_year" => date('Y') + 3,
-          "cvc" => "314"
-        ))
-    );
+    public function testCustomerAddCard()
+    {
+        $token = Token::create(
+            array("card" => array(
+            "number" => "4242424242424242",
+            "exp_month" => 5,
+            "exp_year" => date('Y') + 3,
+            "cvc" => "314"
+            ))
+        );
 
-    $customer = $this->createTestCustomer();
-    $createdCard = $customer->cards->create(array("card" => $token->id));
-    $customer->save();
+        $customer = $this->createTestCustomer();
+        $createdCard = $customer->cards->create(array("card" => $token->id));
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $updatedCards = $updatedCustomer->cards->all();
-    $this->assertSame(count($updatedCards["data"]), 2);
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $updatedCards = $updatedCustomer->cards->all();
+        $this->assertSame(count($updatedCards["data"]), 2);
 
-  }
+    }
 
-  public function testCustomerUpdateCard()
-  {
-    $customer = $this->createTestCustomer();
-    $customer->save();
+    public function testCustomerUpdateCard()
+    {
+        $customer = $this->createTestCustomer();
+        $customer->save();
 
-    $cards = $customer->cards->all();
-    $this->assertSame(count($cards["data"]), 1);
+        $cards = $customer->cards->all();
+        $this->assertSame(count($cards["data"]), 1);
 
-    $card = $cards['data'][0];
-    $card->name = "Jane Austen";
-    $card->save();
+        $card = $cards['data'][0];
+        $card->name = "Jane Austen";
+        $card->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $updatedCards = $updatedCustomer->cards->all();
-    $this->assertSame($updatedCards["data"][0]->name, "Jane Austen");
-  }
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $updatedCards = $updatedCustomer->cards->all();
+        $this->assertSame($updatedCards["data"][0]->name, "Jane Austen");
+    }
 
-  public function testCustomerDeleteCard()
-  {
-    $token = Token::create(
-        array("card" => array(
-          "number" => "4242424242424242",
-          "exp_month" => 5,
-          "exp_year" => date('Y') + 3,
-          "cvc" => "314"
-        ))
-    );
+    public function testCustomerDeleteCard()
+    {
+        $token = Token::create(
+            array("card" => array(
+            "number" => "4242424242424242",
+            "exp_month" => 5,
+            "exp_year" => date('Y') + 3,
+            "cvc" => "314"
+            ))
+        );
 
-    $customer = $this->createTestCustomer();
-    $createdCard = $customer->cards->create(array("card" => $token->id));
-    $customer->save();
+        $customer = $this->createTestCustomer();
+        $createdCard = $customer->cards->create(array("card" => $token->id));
+        $customer->save();
 
-    $updatedCustomer = Customer::retrieve($customer->id);
-    $updatedCards = $updatedCustomer->cards->all();
-    $this->assertSame(count($updatedCards["data"]), 2);
+        $updatedCustomer = Customer::retrieve($customer->id);
+        $updatedCards = $updatedCustomer->cards->all();
+        $this->assertSame(count($updatedCards["data"]), 2);
 
-    $deleteStatus =
-      $updatedCustomer->cards->retrieve($createdCard->id)->delete();
-    $this->assertTrue($deleteStatus->deleted);
-    $updatedCustomer->save();
+        $deleteStatus =
+        $updatedCustomer->cards->retrieve($createdCard->id)->delete();
+        $this->assertTrue($deleteStatus->deleted);
+        $updatedCustomer->save();
 
-    $postDeleteCustomer = Customer::retrieve($customer->id);
-    $postDeleteCards = $postDeleteCustomer->cards->all();
-    $this->assertSame(count($postDeleteCards["data"]), 1);
-  }
-
+        $postDeleteCustomer = Customer::retrieve($customer->id);
+        $postDeleteCards = $postDeleteCustomer->cards->all();
+        $this->assertSame(count($postDeleteCards["data"]), 1);
+    }
 }

--- a/tests/DiscountTest.php
+++ b/tests/DiscountTest.php
@@ -4,28 +4,28 @@ namespace Stripe;
 
 class DiscountTest extends TestCase
 {
-  public function testDeletion()
-  {
-    self::authorizeFromEnv();
-    $id = 'test-coupon-' . self::randomString();
-    $coupon = Coupon::create(
-        array(
+    public function testDeletion()
+    {
+        self::authorizeFromEnv();
+        $id = 'test-coupon-' . self::randomString();
+        $coupon = Coupon::create(
+            array(
             'percent_off' => 25,
             'duration' => 'repeating',
             'duration_in_months' => 5,
             'id' => $id,
-        )
-    );
-    $customer = self::createTestCustomer(array('coupon' => $id));
+            )
+        );
+        $customer = self::createTestCustomer(array('coupon' => $id));
 
-    $this->assertTrue(isset($customer->discount));
-    $this->assertTrue(isset($customer->discount->coupon));
-    $this->assertSame($id, $customer->discount->coupon->id);
+        $this->assertTrue(isset($customer->discount));
+        $this->assertTrue(isset($customer->discount->coupon));
+        $this->assertSame($id, $customer->discount->coupon->id);
 
-    $customer->deleteDiscount();
-    $this->assertFalse(isset($customer->discount));
+        $customer->deleteDiscount();
+        $this->assertFalse(isset($customer->discount));
 
-    $customer = Customer::retrieve($customer->id);
-    $this->assertFalse(isset($customer->discount));
-  }
+        $customer = Customer::retrieve($customer->id);
+        $this->assertFalse(isset($customer->discount));
+    }
 }

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -4,21 +4,21 @@ namespace Stripe;
 
 class ErrorTest extends TestCase
 {
-  public function testCreation()
-  {
-    try {
-      throw new Error(
-          "hello",
-          500,
-          "{'foo':'bar'}",
-          array('foo' => 'bar')
-      );
-      $this->fail("Did not raise error");
-    } catch (Error $e) {
-      $this->assertSame("hello", $e->getMessage());
-      $this->assertSame(500, $e->getHttpStatus());
-      $this->assertSame("{'foo':'bar'}", $e->getHttpBody());
-      $this->assertSame(array('foo' => 'bar'), $e->getJsonBody());
+    public function testCreation()
+    {
+        try {
+            throw new Error(
+                "hello",
+                500,
+                "{'foo':'bar'}",
+                array('foo' => 'bar')
+            );
+            $this->fail("Did not raise error");
+        } catch (Error $e) {
+            $this->assertSame("hello", $e->getMessage());
+            $this->assertSame(500, $e->getHttpStatus());
+            $this->assertSame("{'foo':'bar'}", $e->getHttpBody());
+            $this->assertSame(array('foo' => 'bar'), $e->getJsonBody());
+        }
     }
-  }
 }

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -4,37 +4,37 @@ namespace Stripe;
 
 class FileUploadTest extends TestCase
 {
-  public function testCreateFile()
-  {
-    $fp = fopen(dirname(__FILE__).'/../data/test.png', 'r');
-    self::authorizeFromEnv();
-    $file = FileUpload::create(
-        array(
+    public function testCreateFile()
+    {
+        $fp = fopen(dirname(__FILE__).'/../data/test.png', 'r');
+        self::authorizeFromEnv();
+        $file = FileUpload::create(
+            array(
             'purpose' => 'dispute_evidence',
             'file' => $fp,
-        )
-    );
-    fclose($fp);
-    $this->assertSame(95, $file->size);
-    $this->assertSame('image/png', $file->mimetype);
-  }
-
-  public function testCreateCurlFile()
-  {
-    if (!class_exists('\CurlFile')) {
-      // Older PHP versions don't support this
-      return;
+            )
+        );
+        fclose($fp);
+        $this->assertSame(95, $file->size);
+        $this->assertSame('image/png', $file->mimetype);
     }
 
-    $file = new \CurlFile(dirname(__FILE__).'/../data/test.png');
-    self::authorizeFromEnv();
-    $file = FileUpload::create(
-        array(
+    public function testCreateCurlFile()
+    {
+        if (!class_exists('\CurlFile')) {
+          // Older PHP versions don't support this
+            return;
+        }
+
+        $file = new \CurlFile(dirname(__FILE__).'/../data/test.png');
+        self::authorizeFromEnv();
+        $file = FileUpload::create(
+            array(
             'purpose' => 'dispute_evidence',
             'file' => $file,
-        )
-    );
-    $this->assertSame(95, $file->size);
-    $this->assertSame('image/png', $file->mimetype);
-  }
+            )
+        );
+        $this->assertSame(95, $file->size);
+        $this->assertSame('image/png', $file->mimetype);
+    }
 }

--- a/tests/InvalidRequestErrorTest.php
+++ b/tests/InvalidRequestErrorTest.php
@@ -4,23 +4,23 @@ namespace Stripe;
 
 class InvalidRequestErrorTest extends TestCase
 {
-  public function testInvalidObject()
-  {
-    self::authorizeFromEnv();
-    try {
-      Customer::retrieve('invalid');
-    } catch (InvalidRequestError $e) {
-      $this->assertSame(404, $e->getHttpStatus());
+    public function testInvalidObject()
+    {
+        self::authorizeFromEnv();
+        try {
+            Customer::retrieve('invalid');
+        } catch (InvalidRequestError $e) {
+            $this->assertSame(404, $e->getHttpStatus());
+        }
     }
-  }
 
-  public function testBadData()
-  {
-    self::authorizeFromEnv();
-    try {
-      Charge::create();
-    } catch (InvalidRequestError $e) {
-      $this->assertSame(400, $e->getHttpStatus());
+    public function testBadData()
+    {
+        self::authorizeFromEnv();
+        try {
+            Charge::create();
+        } catch (InvalidRequestError $e) {
+            $this->assertSame(400, $e->getHttpStatus());
+        }
     }
-  }
 }

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -4,64 +4,63 @@ namespace Stripe;
 
 class InvoiceTest extends TestCase
 {
-  public function testUpcoming()
-  {
-    self::authorizeFromEnv();
-    $customer = self::createTestCustomer();
+    public function testUpcoming()
+    {
+        self::authorizeFromEnv();
+        $customer = self::createTestCustomer();
 
-    InvoiceItem::create(
-        array(
+        InvoiceItem::create(
+            array(
             'customer'  => $customer->id,
             'amount'    => 0,
             'currency'  => 'usd',
-        )
-    );
+            )
+        );
 
-    $invoice = Invoice::upcoming(
-        array(
+        $invoice = Invoice::upcoming(
+            array(
             'customer' => $customer->id,
-        )
-    );
-    $this->assertSame($invoice->customer, $customer->id);
-    $this->assertSame($invoice->attempted, false);
-  }
+            )
+        );
+        $this->assertSame($invoice->customer, $customer->id);
+        $this->assertSame($invoice->attempted, false);
+    }
 
-  public function testItemsAccessWithParameter()
-  {
-    self::authorizeFromEnv();
-    $customer = self::createTestCustomer();
+    public function testItemsAccessWithParameter()
+    {
+        self::authorizeFromEnv();
+        $customer = self::createTestCustomer();
 
-    InvoiceItem::create(
-        array(
+        InvoiceItem::create(
+            array(
             'customer'  => $customer->id,
             'amount'    => 100,
             'currency'  => 'usd',
-        )
-    );
+            )
+        );
 
-    $invoice = Invoice::upcoming(
-        array(
+        $invoice = Invoice::upcoming(
+            array(
             'customer' => $customer->id,
-        )
-    );
+            )
+        );
 
-    $lines = $invoice->lines->all(
-        array(
-          'limit' => 10,
-        )
-    );
+        $lines = $invoice->lines->all(
+            array(
+            'limit' => 10,
+            )
+        );
 
-    $this->assertSame(count($lines->data), 1);
-    $this->assertSame($lines->data[0]->amount, 100);
-  }
+        $this->assertSame(count($lines->data), 1);
+        $this->assertSame($lines->data[0]->amount, 100);
+    }
 
-  // This is really just making sure that this operation does not trigger any
-  // warnings, as it's highly nested.
-  public function testAll()
-  {
-    self::authorizeFromEnv();
-    $invoices = Invoice::all();
-    $this->assertTrue(count($invoices) > 0);
-  }
-
+    // This is really just making sure that this operation does not trigger any
+    // warnings, as it's highly nested.
+    public function testAll()
+    {
+        self::authorizeFromEnv();
+        $invoices = Invoice::all();
+        $this->assertTrue(count($invoices) > 0);
+    }
 }

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -4,40 +4,40 @@ namespace Stripe;
 
 class ObjectTest extends TestCase
 {
-  public function testArrayAccessorsSemantics()
-  {
-    $s = new Object();
-    $s['foo'] = 'a';
-    $this->assertSame($s['foo'], 'a');
-    $this->assertTrue(isset($s['foo']));
-    unset($s['foo']);
-    $this->assertFalse(isset($s['foo']));
-  }
+    public function testArrayAccessorsSemantics()
+    {
+        $s = new Object();
+        $s['foo'] = 'a';
+        $this->assertSame($s['foo'], 'a');
+        $this->assertTrue(isset($s['foo']));
+        unset($s['foo']);
+        $this->assertFalse(isset($s['foo']));
+    }
 
-  public function testNormalAccessorsSemantics()
-  {
-    $s = new Object();
-    $s->foo = 'a';
-    $this->assertSame($s->foo, 'a');
-    $this->assertTrue(isset($s->foo));
-    unset($s->foo);
-    $this->assertFalse(isset($s->foo));
-  }
+    public function testNormalAccessorsSemantics()
+    {
+        $s = new Object();
+        $s->foo = 'a';
+        $this->assertSame($s->foo, 'a');
+        $this->assertTrue(isset($s->foo));
+        unset($s->foo);
+        $this->assertFalse(isset($s->foo));
+    }
 
-  public function testArrayAccessorsMatchNormalAccessors()
-  {
-    $s = new Object();
-    $s->foo = 'a';
-    $this->assertSame($s['foo'], 'a');
+    public function testArrayAccessorsMatchNormalAccessors()
+    {
+        $s = new Object();
+        $s->foo = 'a';
+        $this->assertSame($s['foo'], 'a');
 
-    $s['bar'] = 'b';
-    $this->assertSame($s->bar, 'b');
-  }
+        $s['bar'] = 'b';
+        $this->assertSame($s->bar, 'b');
+    }
 
-  public function testKeys()
-  {
-    $s = new Object();
-    $s->foo = 'a';
-    $this->assertSame($s->keys(), array('foo'));
-  }
+    public function testKeys()
+    {
+        $s = new Object();
+        $s->foo = 'a';
+        $this->assertSame($s->keys(), array('foo'));
+    }
 }

--- a/tests/PlanTest.php
+++ b/tests/PlanTest.php
@@ -4,52 +4,52 @@ namespace Stripe;
 
 class PlanTest extends TestCase
 {
-  public function testDeletion()
-  {
-    self::authorizeFromEnv();
-    $p = Plan::create(
-        array(
+    public function testDeletion()
+    {
+        self::authorizeFromEnv();
+        $p = Plan::create(
+            array(
             'amount' => 2000,
             'interval' => 'month',
             'currency' => 'usd',
             'name' => 'Plan',
             'id' => 'gold-' . self::randomString()
-        )
-    );
-    $p->delete();
-    $this->assertTrue($p->deleted);
-  }
-
-  public function testFalseyId()
-  {
-    try {
-      $retrievedPlan = Plan::retrieve('0');
-    } catch (InvalidRequestError $e) {
-      // Can either succeed or 404, all other errors are bad
-      if ($e->httpStatus !== 404) {
-        $this->fail();
-      }
+            )
+        );
+        $p->delete();
+        $this->assertTrue($p->deleted);
     }
-  }
 
-  public function testSave()
-  {
-    self::authorizeFromEnv();
-    $planID = 'gold-' . self::randomString();
-    $p = Plan::create(
-        array(
+    public function testFalseyId()
+    {
+        try {
+            $retrievedPlan = Plan::retrieve('0');
+        } catch (InvalidRequestError $e) {
+          // Can either succeed or 404, all other errors are bad
+            if ($e->httpStatus !== 404) {
+                $this->fail();
+            }
+        }
+    }
+
+    public function testSave()
+    {
+        self::authorizeFromEnv();
+        $planID = 'gold-' . self::randomString();
+        $p = Plan::create(
+            array(
             'amount'   => 2000,
             'interval' => 'month',
             'currency' => 'usd',
             'name'     => 'Plan',
             'id'       => $planID
-        )
-    );
-    $p->name = 'A new plan name';
-    $p->save();
-    $this->assertSame($p->name, 'A new plan name');
+            )
+        );
+        $p->name = 'A new plan name';
+        $p->save();
+        $this->assertSame($p->name, 'A new plan name');
 
-    $stripePlan = Plan::retrieve($planID);
-    $this->assertSame($p->name, $stripePlan->name);
-  }
+        $stripePlan = Plan::retrieve($planID);
+        $this->assertSame($p->name, $stripePlan->name);
+    }
 }

--- a/tests/RecipientTest.php
+++ b/tests/RecipientTest.php
@@ -4,115 +4,115 @@ namespace Stripe;
 
 class RecipientTest extends TestCase
 {
-  public function testDeletion()
-  {
-    $recipient = self::createTestRecipient();
-    $recipient->delete();
+    public function testDeletion()
+    {
+        $recipient = self::createTestRecipient();
+        $recipient->delete();
 
-    $this->assertTrue($recipient->deleted);
-  }
-
-  public function testSave()
-  {
-    $recipient = self::createTestRecipient();
-
-    $recipient->email = 'gdb@stripe.com';
-    $recipient->save();
-    $this->assertSame($recipient->email, 'gdb@stripe.com');
-
-    $stripeRecipient = Recipient::retrieve($recipient->id);
-    $this->assertSame($recipient->email, $stripeRecipient->email);
-  }
-
-  public function testBogusAttribute()
-  {
-    $recipient = self::createTestRecipient();
-    $recipient->bogus = 'bogus';
-
-    $caught = null;
-    try {
-      $recipient->save();
-    } catch (InvalidRequestError $exception) {
-      $caught = $exception;
+        $this->assertTrue($recipient->deleted);
     }
 
-    $this->assertTrue($caught instanceof InvalidRequestError);
-  }
+    public function testSave()
+    {
+        $recipient = self::createTestRecipient();
 
-  public function testRecipientAddCard()
-  {
-    $token = Token::create(
-        array("card" => array(
-          "number" => "4000056655665556",
-          "exp_month" => 5,
-          "exp_year" => date('Y') + 3,
-          "cvc" => "314"
-        ))
-    );
+        $recipient->email = 'gdb@stripe.com';
+        $recipient->save();
+        $this->assertSame($recipient->email, 'gdb@stripe.com');
 
-    $recipient = $this->createTestRecipient();
-    $createdCard = $recipient->cards->create(array("card" => $token->id));
-    $recipient->save();
+        $stripeRecipient = Recipient::retrieve($recipient->id);
+        $this->assertSame($recipient->email, $stripeRecipient->email);
+    }
 
-    $updatedRecipient = Recipient::retrieve($recipient->id);
-    $updatedCards = $updatedRecipient->cards->all();
-    $this->assertSame(count($updatedCards["data"]), 1);
+    public function testBogusAttribute()
+    {
+        $recipient = self::createTestRecipient();
+        $recipient->bogus = 'bogus';
 
-  }
+        $caught = null;
+        try {
+            $recipient->save();
+        } catch (InvalidRequestError $exception) {
+            $caught = $exception;
+        }
 
-  public function testRecipientUpdateCard()
-  {
-    $token = Token::create(
-        array("card" => array(
-          "number" => "4000056655665556",
-          "exp_month" => 5,
-          "exp_year" => date('Y') + 3,
-          "cvc" => "314"
-        ))
-    );
+        $this->assertTrue($caught instanceof InvalidRequestError);
+    }
 
-    $recipient = $this->createTestRecipient();
-    $createdCard = $recipient->cards->create(array("card" => $token->id));
-    $recipient->save();
+    public function testRecipientAddCard()
+    {
+        $token = Token::create(
+            array("card" => array(
+            "number" => "4000056655665556",
+            "exp_month" => 5,
+            "exp_year" => date('Y') + 3,
+            "cvc" => "314"
+            ))
+        );
 
-    $createdCards = $recipient->cards->all();
-    $this->assertSame(count($createdCards["data"]), 1);
+        $recipient = $this->createTestRecipient();
+        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $recipient->save();
 
-    $card = $createdCards['data'][0];
-    $card->name = "Jane Austen";
-    $card->save();
+        $updatedRecipient = Recipient::retrieve($recipient->id);
+        $updatedCards = $updatedRecipient->cards->all();
+        $this->assertSame(count($updatedCards["data"]), 1);
 
-    $updatedRecipient = Recipient::retrieve($recipient->id);
-    $updatedCards = $updatedRecipient->cards->all();
-    $this->assertSame($updatedCards["data"][0]->name, "Jane Austen");
-  }
+    }
 
-  public function testRecipientDeleteCard()
-  {
-    $token = Token::create(
-        array("card" => array(
-          "number" => "4000056655665556",
-          "exp_month" => 5,
-          "exp_year" => date('Y') + 3,
-          "cvc" => "314"
-        ))
-    );
+    public function testRecipientUpdateCard()
+    {
+        $token = Token::create(
+            array("card" => array(
+            "number" => "4000056655665556",
+            "exp_month" => 5,
+            "exp_year" => date('Y') + 3,
+            "cvc" => "314"
+            ))
+        );
 
-    $recipient = $this->createTestRecipient();
-    $createdCard = $recipient->cards->create(array("card" => $token->id));
-    $recipient->save();
+        $recipient = $this->createTestRecipient();
+        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $recipient->save();
 
-    $updatedRecipient = Recipient::retrieve($recipient->id);
-    $updatedCards = $updatedRecipient->cards->all();
-    $this->assertSame(count($updatedCards["data"]), 1);
+        $createdCards = $recipient->cards->all();
+        $this->assertSame(count($createdCards["data"]), 1);
 
-    $deleteStatus =
-      $updatedRecipient->cards->retrieve($createdCard->id)->delete();
-    $this->assertTrue($deleteStatus->deleted);
-    $updatedRecipient->save();
+        $card = $createdCards['data'][0];
+        $card->name = "Jane Austen";
+        $card->save();
 
-    $postDeleteRecipient = Recipient::retrieve($recipient->id);
-    $postDeleteCards = $postDeleteRecipient->cards->all();
-    $this->assertSame(count($postDeleteCards["data"]), 0);
-  }
+        $updatedRecipient = Recipient::retrieve($recipient->id);
+        $updatedCards = $updatedRecipient->cards->all();
+        $this->assertSame($updatedCards["data"][0]->name, "Jane Austen");
+    }
+
+    public function testRecipientDeleteCard()
+    {
+        $token = Token::create(
+            array("card" => array(
+            "number" => "4000056655665556",
+            "exp_month" => 5,
+            "exp_year" => date('Y') + 3,
+            "cvc" => "314"
+            ))
+        );
+
+        $recipient = $this->createTestRecipient();
+        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $recipient->save();
+
+        $updatedRecipient = Recipient::retrieve($recipient->id);
+        $updatedCards = $updatedRecipient->cards->all();
+        $this->assertSame(count($updatedCards["data"]), 1);
+
+        $deleteStatus =
+        $updatedRecipient->cards->retrieve($createdCard->id)->delete();
+        $this->assertTrue($deleteStatus->deleted);
+        $updatedRecipient->save();
+
+        $postDeleteRecipient = Recipient::retrieve($recipient->id);
+        $postDeleteCards = $postDeleteRecipient->cards->all();
+        $this->assertSame(count($postDeleteCards["data"]), 0);
+    }
 }

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -5,34 +5,34 @@ namespace Stripe;
 class RefundTest extends TestCase
 {
 
-  public function testCreate()
-  {
-    $charge = self::createTestCharge();
-    $ref = $charge->refunds->create(array('amount' => 100));
-    $this->assertSame(100, $ref->amount);
-    $this->assertSame($charge->id, $ref->charge);
-  }
+    public function testCreate()
+    {
+        $charge = self::createTestCharge();
+        $ref = $charge->refunds->create(array('amount' => 100));
+        $this->assertSame(100, $ref->amount);
+        $this->assertSame($charge->id, $ref->charge);
+    }
 
-  public function testUpdateAndRetrieve()
-  {
-    $charge = self::createTestCharge();
-    $ref = $charge->refunds->create(array('amount' => 100));
-    $ref->metadata["key"] = "value";
-    $ref->save();
-    $ref = $charge->refunds->retrieve($ref->id);
-    $this->assertSame("value", $ref->metadata["key"], "value");
-  }
+    public function testUpdateAndRetrieve()
+    {
+        $charge = self::createTestCharge();
+        $ref = $charge->refunds->create(array('amount' => 100));
+        $ref->metadata["key"] = "value";
+        $ref->save();
+        $ref = $charge->refunds->retrieve($ref->id);
+        $this->assertSame("value", $ref->metadata["key"], "value");
+    }
 
-  public function testList()
-  {
-    $charge = self::createTestCharge();
-    $refA = $charge->refunds->create(array('amount' => 50));
-    $refB = $charge->refunds->create(array('amount' => 50));
+    public function testList()
+    {
+        $charge = self::createTestCharge();
+        $refA = $charge->refunds->create(array('amount' => 50));
+        $refB = $charge->refunds->create(array('amount' => 50));
 
-    $all = $charge->refunds->all();
-    $this->assertSame(false, $all['has_more']);
-    $this->assertSame(2, count($all->data));
-    $this->assertSame($refB->id, $all->data[0]->id);
-    $this->assertSame($refA->id, $all->data[1]->id);
-  }
+        $all = $charge->refunds->all();
+        $this->assertSame(false, $all['has_more']);
+        $this->assertSame(2, count($all->data));
+        $this->assertSame($refB->id, $all->data[0]->id);
+        $this->assertSame($refA->id, $all->data[1]->id);
+    }
 }

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -5,58 +5,58 @@ namespace Stripe;
 class SubscriptionTest extends TestCase
 {
 
-  public function testCreateUpdateCancel()
-  {
-    $planID = 'gold-' . self::randomString();
-    self::retrieveOrCreatePlan($planID);
+    public function testCreateUpdateCancel()
+    {
+        $planID = 'gold-' . self::randomString();
+        self::retrieveOrCreatePlan($planID);
 
-    $customer = self::createTestCustomer();
+        $customer = self::createTestCustomer();
 
-    $sub = $customer->subscriptions->create(array('plan' => $planID));
+        $sub = $customer->subscriptions->create(array('plan' => $planID));
 
-    $this->assertSame($sub->status, 'active');
-    $this->assertSame($sub->plan->id, $planID);
+        $this->assertSame($sub->status, 'active');
+        $this->assertSame($sub->plan->id, $planID);
 
-    $sub->quantity = 2;
-    $sub->save();
+        $sub->quantity = 2;
+        $sub->save();
 
-    $sub = $customer->subscriptions->retrieve($sub->id);
-    $this->assertSame($sub->status, 'active');
-    $this->assertSame($sub->plan->id, $planID);
-    $this->assertSame($sub->quantity, 2);
+        $sub = $customer->subscriptions->retrieve($sub->id);
+        $this->assertSame($sub->status, 'active');
+        $this->assertSame($sub->plan->id, $planID);
+        $this->assertSame($sub->quantity, 2);
 
-    $sub->cancel(array('at_period_end' => true));
+        $sub->cancel(array('at_period_end' => true));
 
-    $sub = $customer->subscriptions->retrieve($sub->id);
-    $this->assertSame($sub->status, 'active');
-    // @codingStandardsIgnoreStart
-    $this->assertTrue($sub->cancel_at_period_end);
-    // @codingStandardsIgnoreEnd
-  }
+        $sub = $customer->subscriptions->retrieve($sub->id);
+        $this->assertSame($sub->status, 'active');
+      // @codingStandardsIgnoreStart
+        $this->assertTrue($sub->cancel_at_period_end);
+      // @codingStandardsIgnoreEnd
+    }
 
-  public function testDeleteDiscount()
-  {
-    $planID = 'gold-' . self::randomString();
-    self::retrieveOrCreatePlan($planID);
+    public function testDeleteDiscount()
+    {
+        $planID = 'gold-' . self::randomString();
+        self::retrieveOrCreatePlan($planID);
 
-    $couponID = '25off-' . self::randomString();
-    self::retrieveOrCreateCoupon($couponID);
+        $couponID = '25off-' . self::randomString();
+        self::retrieveOrCreateCoupon($couponID);
 
-    $customer = self::createTestCustomer();
+        $customer = self::createTestCustomer();
 
-    $sub = $customer->subscriptions->create(
-        array(
+        $sub = $customer->subscriptions->create(
+            array(
             'plan' => $planID,
             'coupon' => $couponID
-        )
-    );
+            )
+        );
 
-    $this->assertSame($sub->status, 'active');
-    $this->assertSame($sub->plan->id, $planID);
-    $this->assertSame($sub->discount->coupon->id, $couponID);
+        $this->assertSame($sub->status, 'active');
+        $this->assertSame($sub->plan->id, $planID);
+        $this->assertSame($sub->discount->coupon->id, $couponID);
 
-    $sub->deleteDiscount();
-    $sub = $customer->subscriptions->retrieve($sub->id);
-    $this->assertNull($sub->discount);
-  }
+        $sub->deleteDiscount();
+        $sub = $customer->subscriptions->retrieve($sub->id);
+        $this->assertNull($sub->discount);
+    }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -4,10 +4,10 @@ namespace Stripe;
 
 class TokenTest extends TestCase
 {
-  public function testUrls()
-  {
-    $this->assertSame(Token::classUrl('Stripe\\Token'), '/v1/tokens');
-    $token = new Token('abcd/efgh');
-    $this->assertSame($token->instanceUrl(), '/v1/tokens/abcd%2Fefgh');
-  }
+    public function testUrls()
+    {
+        $this->assertSame(Token::classUrl('Stripe\\Token'), '/v1/tokens');
+        $token = new Token('abcd/efgh');
+        $this->assertSame($token->instanceUrl(), '/v1/tokens/abcd%2Fefgh');
+    }
 }

--- a/tests/TransferTest.php
+++ b/tests/TransferTest.php
@@ -4,117 +4,117 @@ namespace Stripe;
 
 class TransferTest extends TestCase
 {
-  public function testCreate()
-  {
-    $recipient = self::createTestRecipient();
+    public function testCreate()
+    {
+        $recipient = self::createTestRecipient();
 
-    self::authorizeFromEnv();
-    $transfer = Transfer::create(
-        array(
-          'amount' => 100,
-          'currency' => 'usd',
-          'recipient' => $recipient->id
-        )
-    );
-    $this->assertSame('pending', $transfer->status);
-  }
-
-  public function testRetrieve()
-  {
-    $recipient = self::createTestRecipient();
-
-    self::authorizeFromEnv();
-    $transfer = Transfer::create(
-        array(
-          'amount' => 100,
-          'currency' => 'usd',
-          'recipient' => $recipient->id
-        )
-    );
-    $reloaded = Transfer::retrieve($transfer->id);
-    $this->assertSame($reloaded->id, $transfer->id);
-  }
-
-  /**
-   * @expectedException Stripe\InvalidRequestError
-   */
-  public function testCancel()
-  {
-    $recipient = self::createTestRecipient();
-
-    self::authorizeFromEnv();
-    $transfer = Transfer::create(
-        array(
-          'amount' => 100,
-          'currency' => 'usd',
-          'recipient' => $recipient->id
-        )
-    );
-    $reloaded = Transfer::retrieve($transfer->id);
-    $this->assertSame($reloaded->id, $transfer->id);
-
-    $reloaded->cancel();
-  }
-
-  public function testTransferUpdateMetadata()
-  {
-    $recipient = self::createTestRecipient();
-
-    self::authorizeFromEnv();
-    $transfer = Transfer::create(
-        array(
+        self::authorizeFromEnv();
+        $transfer = Transfer::create(
+            array(
             'amount' => 100,
             'currency' => 'usd',
             'recipient' => $recipient->id
-        )
-    );
+            )
+        );
+        $this->assertSame('pending', $transfer->status);
+    }
 
-    $transfer->metadata['test'] = 'foo bar';
-    $transfer->save();
+    public function testRetrieve()
+    {
+        $recipient = self::createTestRecipient();
 
-    $updatedTransfer = Transfer::retrieve($transfer->id);
-    $this->assertSame('foo bar', $updatedTransfer->metadata['test']);
-  }
+        self::authorizeFromEnv();
+        $transfer = Transfer::create(
+            array(
+            'amount' => 100,
+            'currency' => 'usd',
+            'recipient' => $recipient->id
+            )
+        );
+        $reloaded = Transfer::retrieve($transfer->id);
+        $this->assertSame($reloaded->id, $transfer->id);
+    }
 
-  public function testTransferUpdateMetadataAll()
-  {
-    $recipient = self::createTestRecipient();
+    /**
+   * @expectedException Stripe\InvalidRequestError
+   */
+    public function testCancel()
+    {
+        $recipient = self::createTestRecipient();
 
-    self::authorizeFromEnv();
-    $transfer = Transfer::create(
-        array(
-          'amount' => 100,
-          'currency' => 'usd',
-          'recipient' => $recipient->id
-        )
-    );
+        self::authorizeFromEnv();
+        $transfer = Transfer::create(
+            array(
+            'amount' => 100,
+            'currency' => 'usd',
+            'recipient' => $recipient->id
+            )
+        );
+        $reloaded = Transfer::retrieve($transfer->id);
+        $this->assertSame($reloaded->id, $transfer->id);
 
-    $transfer->metadata = array('test' => 'foo bar');
-    $transfer->save();
+        $reloaded->cancel();
+    }
 
-    $updatedTransfer = Transfer::retrieve($transfer->id);
-    $this->assertSame('foo bar', $updatedTransfer->metadata['test']);
-  }
+    public function testTransferUpdateMetadata()
+    {
+        $recipient = self::createTestRecipient();
 
-  public function testRecipientUpdateMetadata()
-  {
-    $recipient = self::createTestRecipient();
+        self::authorizeFromEnv();
+        $transfer = Transfer::create(
+            array(
+            'amount' => 100,
+            'currency' => 'usd',
+            'recipient' => $recipient->id
+            )
+        );
 
-    $recipient->metadata['test'] = 'foo bar';
-    $recipient->save();
+        $transfer->metadata['test'] = 'foo bar';
+        $transfer->save();
 
-    $updatedRecipient = Recipient::retrieve($recipient->id);
-    $this->assertSame('foo bar', $updatedRecipient->metadata['test']);
-  }
+        $updatedTransfer = Transfer::retrieve($transfer->id);
+        $this->assertSame('foo bar', $updatedTransfer->metadata['test']);
+    }
 
-  public function testRecipientUpdateMetadataAll()
-  {
-    $recipient = self::createTestRecipient();
+    public function testTransferUpdateMetadataAll()
+    {
+        $recipient = self::createTestRecipient();
 
-    $recipient->metadata = array('test' => 'foo bar');
-    $recipient->save();
+        self::authorizeFromEnv();
+        $transfer = Transfer::create(
+            array(
+            'amount' => 100,
+            'currency' => 'usd',
+            'recipient' => $recipient->id
+            )
+        );
 
-    $updatedRecipient = Recipient::retrieve($recipient->id);
-    $this->assertSame('foo bar', $updatedRecipient->metadata['test']);
-  }
+        $transfer->metadata = array('test' => 'foo bar');
+        $transfer->save();
+
+        $updatedTransfer = Transfer::retrieve($transfer->id);
+        $this->assertSame('foo bar', $updatedTransfer->metadata['test']);
+    }
+
+    public function testRecipientUpdateMetadata()
+    {
+        $recipient = self::createTestRecipient();
+
+        $recipient->metadata['test'] = 'foo bar';
+        $recipient->save();
+
+        $updatedRecipient = Recipient::retrieve($recipient->id);
+        $this->assertSame('foo bar', $updatedRecipient->metadata['test']);
+    }
+
+    public function testRecipientUpdateMetadataAll()
+    {
+        $recipient = self::createTestRecipient();
+
+        $recipient->metadata = array('test' => 'foo bar');
+        $recipient->save();
+
+        $updatedRecipient = Recipient::retrieve($recipient->id);
+        $this->assertSame('foo bar', $updatedRecipient->metadata['test']);
+    }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,27 +4,27 @@ namespace Stripe;
 
 class UtilTest extends TestCase
 {
-  public function testIsList()
-  {
-    $list = array(5, 'nstaoush', array());
-    $this->assertTrue(Util::isList($list));
+    public function testIsList()
+    {
+        $list = array(5, 'nstaoush', array());
+        $this->assertTrue(Util::isList($list));
 
-    $notlist = array(5, 'nstaoush', array(), 'bar' => 'baz');
-    $this->assertFalse(Util::isList($notlist));
-  }
+        $notlist = array(5, 'nstaoush', array(), 'bar' => 'baz');
+        $this->assertFalse(Util::isList($notlist));
+    }
 
-  public function testThatPHPHasValueSemanticsForArrays()
-  {
-    $original = array('php-arrays' => 'value-semantics');
-    $derived = $original;
-    $derived['php-arrays'] = 'reference-semantics';
+    public function testThatPHPHasValueSemanticsForArrays()
+    {
+        $original = array('php-arrays' => 'value-semantics');
+        $derived = $original;
+        $derived['php-arrays'] = 'reference-semantics';
 
-    $this->assertSame('value-semantics', $original['php-arrays']);
-  }
+        $this->assertSame('value-semantics', $original['php-arrays']);
+    }
 
-  public function testConvertStripeObjectToArrayIncludesId()
-  {
-    $customer = self::createTestCustomer();
-    $this->assertTrue(array_key_exists("id", $customer->__toArray(true)));
-  }
+    public function testConvertStripeObjectToArrayIncludesId()
+    {
+        $customer = self::createTestCustomer();
+        $this->assertTrue(array_key_exists("id", $customer->__toArray(true)));
+    }
 }


### PR DESCRIPTION
Since Zend is even moving away from their own standard, it seems like stripe should do the same.  

The `-n` in the `build.php` is a flag to ignore warnings. This allows the code to keep the underscore prefixes for methods and properties without failing the build