### PR TITLE
Updated docblock return type

### DIFF
--- a/lib/Stripe/Plan.php
+++ b/lib/Stripe/Plan.php
@@ -50,7 +50,7 @@ class Stripe_Plan extends Stripe_ApiResource
    * @param array|null $params
    * @param string|null $apiKey
    *
-   * @return array An array of Stripe_Plans.
+   * @return Stripe_Plan[] An array of Stripe_Plans.
    */
   public static function all($params=null, $apiKey=null)
   {


### PR DESCRIPTION
This will provide autocomplete support in popular IDEs such as PHPStorm.

When iterating over the returned plans, each $plan will recognised as a `Stripe_Plan` with the available methods.