### PR TITLE
`Stripe\Util\Util::convertStripeObjectToArray` not recursively converting Stripe objects

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -2,6 +2,8 @@
 
 namespace Stripe\Util;
 
+use Stripe\Object;
+
 abstract class Util
 {
     /**

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -40,4 +40,33 @@ class ObjectTest extends TestCase
         $s->foo = 'a';
         $this->assertSame($s->keys(), array('foo'));
     }
+
+    public function testToArray()
+    {
+        $s = new Object();
+        $s->foo = 'a';
+
+        $converted = $s->__toArray();
+
+        $this->assertInternalType('array', $converted);
+        $this->assertArrayHasKey('foo', $converted);
+        $this->assertEquals('a', $converted['foo']);
+    }
+
+    public function testRecursiveToArray()
+    {
+        $s = new Object();
+        $z = new Object();
+
+        $s->child = $z;
+        $z->foo = 'a';
+
+        $converted = $s->__toArray(true);
+
+        $this->assertInternalType('array', $converted);
+        $this->assertArrayHasKey('child', $converted);
+        $this->assertInternalType('array', $converted['child']);
+        $this->assertArrayHasKey('foo', $converted['child']);
+        $this->assertEquals('a', $converted['child']['foo']);
+    }
 }


### PR DESCRIPTION
The `\Stripe\Util\Util` class needs to import the `\Stripe\Object` class, as it can not be resolved "naturally" because it's not in the same namespace. (Referenced on [lib/Util/Util:42](https://github.com/stripe/stripe-php/blob/3a7cba2261f97f70b2ca429b62fb1426480851b3/lib/Util/Util.php#L42))

This causes `Util::convertStripeObjectToArray` to fail on recursive objects, which in turn causes `Object::__toArray`, `Object::__toJSON`, and `Object::__toString` all to fail.

To fix the issue, I imported the `\Stripe\Object` into the `\Stripe\Util\Util` class.