### PR TITLE
Fix Charge::refund syntax error

### DIFF
--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -56,7 +56,7 @@ class Charge extends ApiResource
     public function refund($params = null, $options = null)
     {
         $url = $this->instanceUrl() . '/refund';
-        list($response, $opts) = $this->request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $options);
         $this->refreshFrom($response, $opts);
         return $this;
     }


### PR DESCRIPTION
EMERGENCY: Fatal Error: Call to undefined method Stripe\Charge::request()