### PR TITLE
Fix Transfer::reverse syntax error

### DIFF
--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -43,7 +43,7 @@ class Transfer extends ApiResource
     public function reverse($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/reversals';
-        list($response, $opts) = $this->request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $options);
         $this->refreshFrom($response, $opts);
         return $this;
     }


### PR DESCRIPTION
EMERGENCY: Fatal Error: Call to undefined method Stripe\Transfer::request()

Hi,

Found this error when trying to process refunds.
Let me know if this fix is OK.

Same fix as was for ffc451ac4700fecd89574647f31ad5b8615a8ef3 which was a Charge::request() fatal error.

Thanks

Ivan