### PR TITLE
Add request IDs to all errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,3 @@ In order to run tests first install [PHPUnit](http://packagist.org/packages/phpu
 To run the test suite:
 
     ./vendor/bin/phpunit
-

--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -18,10 +18,10 @@ abstract class Base extends Exception
         $this->httpBody = $httpBody;
         $this->jsonBody = $jsonBody;
         $this->httpHeaders = $httpHeaders;
-        $this->requestID = null;
+        $this->requestId = null;
 
         if ($httpHeaders && isset($httpHeaders['Request-Id'])) {
-          $this->requestId = $httpHeaders['Request-Id'];
+            $this->requestId = $httpHeaders['Request-Id'];
         }
     }
 
@@ -50,4 +50,11 @@ abstract class Base extends Exception
         return $this->requestId;
     }
 
+    public function __toString()
+    {
+        $id = $this->requestId ? " from API request '{$this->requestId}'": "";
+        $message = explode("\n", parent::__toString());
+        $message[0] .= $id;
+        return implode("\n", $message);
+    }
 }

--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -10,12 +10,19 @@ abstract class Base extends Exception
         $message,
         $httpStatus = null,
         $httpBody = null,
-        $jsonBody = null
+        $jsonBody = null,
+        $httpHeaders = null
     ) {
         parent::__construct($message);
         $this->httpStatus = $httpStatus;
         $this->httpBody = $httpBody;
         $this->jsonBody = $jsonBody;
+        $this->httpHeaders = $httpHeaders;
+        $this->requestID = null;
+
+        if ($httpHeaders && isset($httpHeaders['Request-Id'])) {
+          $this->requestId = $httpHeaders['Request-Id'];
+        }
     }
 
     public function getHttpStatus()
@@ -32,4 +39,15 @@ abstract class Base extends Exception
     {
         return $this->jsonBody;
     }
+
+    public function getHttpHeaders()
+    {
+        return $this->httpHeaders;
+    }
+
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+
 }

--- a/lib/Error/Card.php
+++ b/lib/Error/Card.php
@@ -10,9 +10,10 @@ class Card extends Base
         $code,
         $httpStatus,
         $httpBody,
-        $jsonBody
+        $jsonBody,
+        $httpHeaders = null
     ) {
-        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody, $httpHeaders);
         $this->param = $param;
         $this->code = $code;
     }

--- a/lib/Error/InvalidRequest.php
+++ b/lib/Error/InvalidRequest.php
@@ -9,9 +9,10 @@ class InvalidRequest extends Base
         $param,
         $httpStatus = null,
         $httpBody = null,
-        $jsonBody = null
+        $jsonBody = null,
+        $httpHeaders = null
     ) {
-        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody, $httpHeaders);
         $this->param = $param;
     }
 }

--- a/lib/Error/RateLimit.php
+++ b/lib/Error/RateLimit.php
@@ -9,8 +9,9 @@ class RateLimit extends InvalidRequest
         $param,
         $httpStatus = null,
         $httpBody = null,
-        $jsonBody = null
+        $jsonBody = null,
+        $httpHeaders = null
     ) {
-        parent::__construct($message, $httpStatus, $httpBody, $jsonBody);
+        parent::__construct($message, $httpStatus, $httpBody, $jsonBody, $httpHeaders);
     }
 }

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -12,7 +12,7 @@ interface ClientInterface
      * @param boolean $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CurlFile)
      * @throws Error\Api & Error\ApiConnection
-     * @return array($rawBody, $httpStatusCode)
+     * @return array($rawBody, $httpStatusCode, $httpHeader)
      */
     public function request($method, $absUrl, $headers, $params, $hasFile);
 }

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -47,12 +47,21 @@ class CurlClient implements ClientInterface
             throw new Error\Api("Unrecognized method $method");
         }
 
+        // Create a callback to capture HTTP headers for the response
+        $rheaders = array();
+        $headerCallback = function ($curl, $header_line) use (&$rheaders) {
+          list($key, $value) = explode(":", trim($header_line), 1);
+          $rheaders[trim($key)] = trim($value);
+          return strlen($header_line);
+        };
+
         $absUrl = Util\Util::utf8($absUrl);
         $opts[CURLOPT_URL] = $absUrl;
         $opts[CURLOPT_RETURNTRANSFER] = true;
         $opts[CURLOPT_CONNECTTIMEOUT] = 30;
         $opts[CURLOPT_TIMEOUT] = 80;
         $opts[CURLOPT_RETURNTRANSFER] = true;
+        $opts[CURLOPT_HEADERFUNCTION] = $headerCallback;
         $opts[CURLOPT_HTTPHEADER] = $headers;
         if (!Stripe::$verifySslCerts) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
@@ -89,7 +98,7 @@ class CurlClient implements ClientInterface
 
         $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
-        return array($rbody, $rcode);
+        return array($rbody, $rcode, $rheaders);
     }
 
     /**

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -50,9 +50,13 @@ class CurlClient implements ClientInterface
         // Create a callback to capture HTTP headers for the response
         $rheaders = array();
         $headerCallback = function ($curl, $header_line) use (&$rheaders) {
-          list($key, $value) = explode(":", trim($header_line), 1);
-          $rheaders[trim($key)] = trim($value);
-          return strlen($header_line);
+            // Ignore the HTTP request line (HTTP/1.1 200 OK)
+            if (strpos($header_line, ":") === false) {
+                return strlen($header_line);
+            }
+            list($key, $value) = explode(":", trim($header_line), 2);
+            $rheaders[trim($key)] = trim($value);
+            return strlen($header_line);
         };
 
         $absUrl = Util\Util::utf8($absUrl);

--- a/tests/CardErrorTest.php
+++ b/tests/CardErrorTest.php
@@ -4,6 +4,12 @@ namespace Stripe;
 
 class CardErrorTest extends TestCase
 {
+
+    public function assertStartsWith($haystack, $needle) {
+      // search backwards starting from haystack length characters from the end
+      return $needle === "" || strrpos($haystack, $needle, -strlen($haystack)) !== FALSE;
+    }
+
     public function testDecline()
     {
         self::authorizeFromEnv();
@@ -24,6 +30,7 @@ class CardErrorTest extends TestCase
             Charge::create($charge);
         } catch (Error\Card $e) {
             $this->assertSame(402, $e->getHttpStatus());
+            $this->assertStartsWith("req_", $e->getRequestId());
             $actual = $e->getJsonBody();
             $this->assertSame(
                 array('error' => array(

--- a/tests/CardErrorTest.php
+++ b/tests/CardErrorTest.php
@@ -4,12 +4,6 @@ namespace Stripe;
 
 class CardErrorTest extends TestCase
 {
-
-    public function assertStartsWith($haystack, $needle) {
-      // search backwards starting from haystack length characters from the end
-      return $needle === "" || strrpos($haystack, $needle, -strlen($haystack)) !== FALSE;
-    }
-
     public function testDecline()
     {
         self::authorizeFromEnv();
@@ -30,7 +24,7 @@ class CardErrorTest extends TestCase
             Charge::create($charge);
         } catch (Error\Card $e) {
             $this->assertSame(402, $e->getHttpStatus());
-            $this->assertStartsWith("req_", $e->getRequestId());
+            $this->assertTrue(strpos($e->getRequestId(), "req_") === 0, $e->getRequestId());
             $actual = $e->getJsonBody();
             $this->assertSame(
                 array('error' => array(

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -19,6 +19,26 @@ class ErrorTest extends TestCase
             $this->assertSame(500, $e->getHttpStatus());
             $this->assertSame("{'foo':'bar'}", $e->getHttpBody());
             $this->assertSame(array('foo' => 'bar'), $e->getJsonBody());
+            $this->assertSame(null, $e->getHttpHeaders());
+            $this->assertSame(null, $e->getRequestId());
         }
     }
+
+    public function testResponseHeaders()
+    {
+        try {
+            throw new Error\Api(
+                "hello",
+                500,
+                "{'foo':'bar'}",
+                array('foo' => 'bar'),
+                array('Request-Id' => 'req_bar')
+            );
+            $this->fail("Did not raise error");
+        } catch (Error\Api $e) {
+            $this->assertSame(array('Request-Id' => 'req_bar'), $e->getHttpHeaders());
+            $this->assertSame('req_bar', $e->getRequestId());
+        }
+    }
+
 }

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -40,5 +40,4 @@ class ErrorTest extends TestCase
             $this->assertSame('req_bar', $e->getRequestId());
         }
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $mock->expects($this->at($this->call++))
              ->method('request')
              ->with(strtolower($method), 'https://api.stripe.com' . $path, $this->anything(), $params, false)
-             ->willReturn(array(json_encode($return), 200));
+             ->willReturn(array(json_encode($return), 200, array()));
     }
 
     private function setUpMockRequest()


### PR DESCRIPTION
```php
$e = new Stripe\Error\Api();
$e->getHttpHeaders();
$e->getRequestId();
```