### PR TITLE
Fixed null reference return

### DIFF
--- a/lib/Object.php
+++ b/lib/Object.php
@@ -92,6 +92,8 @@ class Object implements ArrayAccess
     }
     public function &__get($k)
     {
+        // function should return a reference, using $nullval to return a reference to null
+        $nullval = null;
         if (array_key_exists($k, $this->_values)) {
             return $this->_values[$k];
         } else if ($this->_transientValues->includes($k)) {
@@ -104,11 +106,11 @@ class Object implements ArrayAccess
                     . "probably as a result of a save(). The attributes currently "
                     . "available on this object are: $attrs";
             error_log($message);
-            return null;
+            return $nullval;
         } else {
             $class = get_class($this);
             error_log("Stripe Notice: Undefined property of $class instance: $k");
-            return null;
+            return $nullval;
         }
     }
 

--- a/tests/ObjectTest.php
+++ b/tests/ObjectTest.php
@@ -69,4 +69,16 @@ class ObjectTest extends TestCase
         $this->assertArrayHasKey('foo', $converted['child']);
         $this->assertEquals('a', $converted['child']['foo']);
     }
+
+    public function testNonexistentProperty()
+    {
+        $s = new Object();
+        $this->assertNull($s->nonexistent);
+    }
+
+    public function testPropertyDoesNotExists()
+    {
+        $s = new Object();
+        $this->assertNull($s['nonexistent']);
+    }
 }


### PR DESCRIPTION
This PR fix a E_NOTICE 'Only variable references should be returned by reference' when trying to access an inexistent property using the object notation (```$s->myprop```)
It also add unit tests to cover this case