### PR TITLE
Remove RandomString, increase PHP unit test entropy

### DIFF
--- a/tests/CouponTest.php
+++ b/tests/CouponTest.php
@@ -7,7 +7,7 @@ class CouponTest extends TestCase
     public function testSave()
     {
         self::authorizeFromEnv();
-        $id = 'test_coupon-' . self::randomString();
+        $id = 'test_coupon-' . self::generateRandomString(8);
         $c = Coupon::create(
             array(
                 'percent_off' => 25,

--- a/tests/CouponTest.php
+++ b/tests/CouponTest.php
@@ -7,7 +7,7 @@ class CouponTest extends TestCase
     public function testSave()
     {
         self::authorizeFromEnv();
-        $id = 'test_coupon-' . self::generateRandomString(8);
+        $id = 'test_coupon-' . self::generateRandomString(20);
         $c = Coupon::create(
             array(
                 'percent_off' => 25,

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -128,7 +128,7 @@ class CustomerTest extends TestCase
 
     public function testCancelSubscription()
     {
-        $planID = 'gold-' . self::generateRandomString(8);
+        $planID = 'gold-' . self::generateRandomString(20);
         self::retrieveOrCreatePlan($planID);
 
         $customer = self::createTestCustomer(

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -128,7 +128,7 @@ class CustomerTest extends TestCase
 
     public function testCancelSubscription()
     {
-        $planID = 'gold-' . self::randomString();
+        $planID = 'gold-' . self::generateRandomString(8);
         self::retrieveOrCreatePlan($planID);
 
         $customer = self::createTestCustomer(

--- a/tests/DiscountTest.php
+++ b/tests/DiscountTest.php
@@ -7,7 +7,7 @@ class DiscountTest extends TestCase
     public function testDeletion()
     {
         self::authorizeFromEnv();
-        $id = 'test-coupon-' . self::generateRandomString(8);
+        $id = 'test-coupon-' . self::generateRandomString(20);
         $coupon = Coupon::create(
             array(
                 'percent_off' => 25,

--- a/tests/DiscountTest.php
+++ b/tests/DiscountTest.php
@@ -7,7 +7,7 @@ class DiscountTest extends TestCase
     public function testDeletion()
     {
         self::authorizeFromEnv();
-        $id = 'test-coupon-' . self::randomString();
+        $id = 'test-coupon-' . self::generateRandomString(8);
         $coupon = Coupon::create(
             array(
                 'percent_off' => 25,

--- a/tests/PlanTest.php
+++ b/tests/PlanTest.php
@@ -12,7 +12,7 @@ class PlanTest extends TestCase
             'interval' => 'month',
             'currency' => 'usd',
             'name' => 'Plan',
-            'id' => 'gold-' . self::randomString()
+            'id' => 'gold-' . self::generateRandomString(8)
         ));
         $p->delete();
         $this->assertTrue($p->deleted);
@@ -33,7 +33,7 @@ class PlanTest extends TestCase
     public function testSave()
     {
         self::authorizeFromEnv();
-        $planID = 'gold-' . self::randomString();
+        $planID = 'gold-' . self::generateRandomString(8);
         $p = Plan::create(array(
             'amount'   => 2000,
             'interval' => 'month',

--- a/tests/PlanTest.php
+++ b/tests/PlanTest.php
@@ -12,7 +12,7 @@ class PlanTest extends TestCase
             'interval' => 'month',
             'currency' => 'usd',
             'name' => 'Plan',
-            'id' => 'gold-' . self::generateRandomString(8)
+            'id' => 'gold-' . self::generateRandomString(20)
         ));
         $p->delete();
         $this->assertTrue($p->deleted);
@@ -33,7 +33,7 @@ class PlanTest extends TestCase
     public function testSave()
     {
         self::authorizeFromEnv();
-        $planID = 'gold-' . self::generateRandomString(8);
+        $planID = 'gold-' . self::generateRandomString(20);
         $p = Plan::create(array(
             'amount'   => 2000,
             'interval' => 'month',

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -7,7 +7,7 @@ class SubscriptionTest extends TestCase
 
     public function testCreateUpdateCancel()
     {
-        $planID = 'gold-' . self::generateRandomString(8);
+        $planID = 'gold-' . self::generateRandomString(20);
         self::retrieveOrCreatePlan($planID);
 
         $customer = self::createTestCustomer();
@@ -36,10 +36,10 @@ class SubscriptionTest extends TestCase
 
     public function testDeleteDiscount()
     {
-        $planID = 'gold-' . self::generateRandomString(8);
+        $planID = 'gold-' . self::generateRandomString(20);
         self::retrieveOrCreatePlan($planID);
 
-        $couponID = '25off-' . self::generateRandomString(8);
+        $couponID = '25off-' . self::generateRandomString(20);
         self::retrieveOrCreateCoupon($couponID);
 
         $customer = self::createTestCustomer();

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -7,7 +7,7 @@ class SubscriptionTest extends TestCase
 
     public function testCreateUpdateCancel()
     {
-        $planID = 'gold-' . self::randomString();
+        $planID = 'gold-' . self::generateRandomString(8);
         self::retrieveOrCreatePlan($planID);
 
         $customer = self::createTestCustomer();
@@ -36,10 +36,10 @@ class SubscriptionTest extends TestCase
 
     public function testDeleteDiscount()
     {
-        $planID = 'gold-' . self::randomString();
+        $planID = 'gold-' . self::generateRandomString(8);
         self::retrieveOrCreatePlan($planID);
 
-        $couponID = '25off-' . self::randomString();
+        $couponID = '25off-' . self::generateRandomString(8);
         self::retrieveOrCreateCoupon($couponID);
 
         $customer = self::createTestCustomer();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -128,16 +128,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Generate a random 8-character string. Useful for ensuring
-     * multiple test suite runs don't conflict.
-     * Deprecated: use generateRandomString(8) instead.
-     */
-    protected static function randomString()
-    {
-        return self::generateRandomString(8);
-    }
-
-    /**
      * Verify that a plan with a given ID exists, or create a new one if it does
      * not.
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -129,17 +129,12 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * Generate a random 8-character string. Useful for ensuring
-     * multiple test suite runs don't conflict
+     * multiple test suite runs don't conflict.
+     * Deprecated: use generateRandomString(8) instead.
      */
     protected static function randomString()
     {
-        $chars = 'abcdefghijklmnopqrstuvwxyz';
-        $str = '';
-        for ($i = 0; $i < 10; $i++) {
-            $str .= $chars[rand(0, strlen($chars)-1)];
-        }
-
-        return $str;
+        return self::generateRandomString(8);
     }
 
     /**


### PR DESCRIPTION
Apparently we have intermittent tests because we create so many coupons, and these things collide.

Remove low-entropy `randomString` method, replace it with a pre-existing `generateRandomString` method.

R? @bkrausz  (feel free to :arrow_right: without talking to me if :green_heart: )