### PR TITLE
Added `Request-ID` to API calls.

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -57,8 +57,10 @@ class ApiRequestor
         }
         list($rbody, $rcode, $rheaders, $myApiKey) =
         $this->_requestRaw($method, $url, $params, $headers);
-        $resp = $this->_interpretResponse($rbody, $rcode, $rheaders);
-        return array($resp, $myApiKey);
+
+        list($respBody, $requestId) = $resp = $this->_interpretResponse($rbody, $rcode, $rheaders);
+
+        return array($respBody, $myApiKey, $requestId);
     }
 
     /**
@@ -199,6 +201,7 @@ class ApiRequestor
     private function _interpretResponse($rbody, $rcode, $rheaders)
     {
         try {
+            $requestId = isset($rheaders["Request-Id"])?$rheaders["Request-Id"]:null;
             $resp = json_decode($rbody, true);
         } catch (Exception $e) {
             $msg = "Invalid response body from API: $rbody "
@@ -209,7 +212,8 @@ class ApiRequestor
         if ($rcode < 200 || $rcode >= 300) {
             $this->handleApiError($rbody, $rcode, $rheaders, $resp);
         }
-        return $resp;
+
+        return array($resp, $requestId);
     }
 
     public static function setHttpClient($client)

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -2,7 +2,7 @@
 
 namespace Stripe;
 
-abstract class ApiResource extends Object
+abstract class ApiResource extends StripeObject
 {
     private static $HEADERS_TO_PERSIST = array('Stripe-Account' => true, 'Stripe-Version' => true);
 

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -2,7 +2,7 @@
 
 namespace Stripe;
 
-abstract class ApiResource extends StripeObject
+abstract class ApiResource extends Object
 {
     private static $HEADERS_TO_PERSIST = array('Stripe-Account' => true, 'Stripe-Version' => true);
 
@@ -102,7 +102,7 @@ abstract class ApiResource extends StripeObject
     {
         $opts = Util\RequestOptions::parse($options);
         $requestor = new ApiRequestor($opts->apiKey, static::baseUrl());
-        list($response, $opts->apiKey) = $requestor->request($method, $url, $params, $opts->headers);
+        list($response, $opts->apiKey, $opts->requestId) = $requestor->request($method, $url, $params, $opts->headers);
         foreach ($opts->headers as $k => $v) {
             if (!array_key_exists($k, self::$HEADERS_TO_PERSIST)) {
                 unset($opts->headers[$k]);

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -107,6 +107,8 @@ class StripeObject implements ArrayAccess, JsonSerializable
                     . "available on this object are: $attrs";
             error_log($message);
             return $nullval;
+        } else if ($k === "_requestid"){
+          return $this->_opts->requestId;
         } else {
             $class = get_class($this);
             error_log("Stripe Notice: Undefined property of $class instance: $k");

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -8,11 +8,13 @@ class RequestOptions
 {
     public $headers;
     public $apiKey;
+    public $requestId;
 
     public function __construct($key = null, $headers = array())
     {
         $this->apiKey = $key;
         $this->headers = $headers;
+        $this->requestId = "";
     }
 
     /**


### PR DESCRIPTION
I needed to get access to the `Request-ID` that is [sent from the API](https://stripe.com/docs/api#request_ids) for a project I was working on.

In order to make this work I have made two small changes.

* The `Request-ID` is stored in the `RequestOptions` as `$requestId`.
* In order to access `$requestId` I have added added basic check to the magic method in StripeObject.

You can access it by getting `_requestid` from any stripe object.

I hope this comes in handy for someone!