### PR TITLE
Adding refund() support to BitcoinReceiver

### DIFF
--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -63,4 +63,18 @@ class BitcoinReceiver extends ExternalAccount
     {
         return self::_create($params, $opts);
     }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return BitcoinReceiver The refunded Bitcoin Receiver item.
+     */
+    public function refund($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/refund';
+        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
 }

--- a/tests/BitcoinReceiverTest.php
+++ b/tests/BitcoinReceiverTest.php
@@ -103,4 +103,18 @@ class BitcoinReceiverTest extends TestCase
         $updatedReceiver = BitcoinReceiver::retrieve($receiver->id);
         $this->assertEquals($receiver["description"], $updatedReceiver["description"]);
     }
+
+    public function testRefund()
+    {
+        self::authorizeFromEnv();
+        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
+
+        $receiver = BitcoinReceiver::retrieve($receiver->id);
+        $this->assertNull($receiver->refund_address);
+
+        $refundAddress = "REFUNDHERE";
+        $receiver->refund(array("refund_address" => $refundAddress));
+
+        $this->assertSame($refundAddress, $receiver->refund_address);
+    }
 }


### PR DESCRIPTION
These changes add SDK support for refunding bitcoin receivers directly. This is needed because sometimes receivers end up with the wrong amount of money or the payment couldn't be completed for some other reason. This also includes a simple test, though I discovered that the BitcoinReceiver object doesn't include any indication of its own refund state (maybe something to add to a future API?).