### PR TITLE
Update installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,10 @@ PHP 5.3.3 and later.
 
 ## Composer
 
-You can install the bindings via [Composer](http://getcomposer.org/). Add this to your `composer.json`:
-
-```json
-{
-  "require": {
-    "stripe/stripe-php": "3.*"
-  }
-}
-```
-
-Then install via:
+You can install the bindings via [Composer](http://getcomposer.org/). Run the following command:
 
 ```bash
-composer install
+composer require stripe/stripe-php
 ```
 
 To use the bindings, use Composer's [autoload](https://getcomposer.org/doc/00-intro.md#autoloading):


### PR DESCRIPTION
This allows users to install the library in one simple step.

```sh
$ composer require stripe/stripe-php
Using version ^3.4 for stripe/stripe-php
./composer.json has been updated
Loading composer repositories with package information
...
```