### PR TITLE
Update README to include development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ composer install
 
 ## Tests
 
-Install dependencies as mentioned above (which will resolve [PHPUnit](http://packagist.org/packages/phpunit/phpunit)), then run the test suite:
+Install dependencies as mentioned above (which will resolve [PHPUnit](http://packagist.org/packages/phpunit/phpunit)), then you can run the test suite:
 
 ```bash
 ./vendor/bin/phpunit
+```
+
+Or to run an individual test file:
+
+```bash
+./vendor/bin/phpunit tests/UtilTest.php
 ```

--- a/README.md
+++ b/README.md
@@ -62,15 +62,17 @@ $charge = Stripe_Charge::create(array('card' => $myCard, 'amount' => 2000, 'curr
 echo $charge;
 ```
 
-## Tests
+## Development
 
-In order to run tests first install [PHPUnit](http://packagist.org/packages/phpunit/phpunit) via [Composer](http://getcomposer.org/):
+Install dependencies:
 
-```bash
-composer update --dev
+``` bash
+composer install
 ```
 
-To run the test suite:
+## Tests
+
+Install dependencies as mentioned above (which will resolve [PHPUnit](http://packagist.org/packages/phpunit/phpunit)), then run the test suite:
 
 ```bash
 ./vendor/bin/phpunit


### PR DESCRIPTION
Updates the `README` to be a little more clear on how to get started on
development with stripe-php. Also removes the `composer update --dev`
line as `--dev` is now considered deprecated:

    $ composer update --dev
    You are using the deprecated option "dev". Dev packages are installed by default now.
    Loading composer repositories with package information
    Updating dependencies (including require-dev)
    Nothing to install or update
    Generating autoload files