### PR TITLE
Fix the test suite

### DIFF
--- a/tests/BankAccountTest.php
+++ b/tests/BankAccountTest.php
@@ -13,7 +13,9 @@ class BankAccountTest extends TestCase
         $bankAccount = $customer->sources->create(array(
             'source' => array(
                 'object' => 'bank_account',
+                'account_holder_type' => 'individual',
                 'account_number' => '000123456789',
+                'name' => 'John Doe',
                 'routing_number' => '110000000',
                 'country' => 'US'
             )


### PR DESCRIPTION
Unfortunately, stripe-php also seems to run against the live API
service, and as one may expect, the passage of time means that master no
longer passes. This patch updates the broken test with new parameters
that are now expected in the API.