### PR TITLE
Allow user-defined override of timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ echo $charge;
 
 ## Custom Request Timeouts
 
-*NOTE:* If you're decreasing timeouts on non-read-only calls, make sure to use idempotency tokens to avoid executing the same transaction twice as a result of timeout retry logic.
+*NOTE:* We do not recommend decreasing the timeout for non-read-only calls (e.g. charge creation), since even if you locally timeout, the request on Stripe's side can still complete. If you are decreasing timeouts on these calls, make sure to use [idempotency tokens](https://stripe.com/docs/api/php#idempotent_requests) to avoid executing the same transaction twice as a result of timeout retry logic.
 
 To modify request timeouts (connect or total, in seconds) you'll need to tell the API client to use a CurlClient other than its default. You'll set the timeouts in that CurlClient.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ $charge = Stripe_Charge::create(array('card' => $myCard, 'amount' => 2000, 'curr
 echo $charge;
 ```
 
+## Custom Request Timeouts
+
+*NOTE:* If you're decreasing timeouts on non-read-only calls, make sure to use idempotency tokens to avoid executing the same transaction twice as a result of timeout retry logic.
+
+To modify request timeouts (connect or total, in seconds) you'll need to tell the API client to use a CurlClient other than its default. You'll set the timeouts in that CurlClient.
+
+```php
+// set up your tweaked Curl client
+$curl = new \Stripe\HttpClient\CurlClient();
+$curl->setTimeout(10); // default is \Stripe\HttpClient\CurlClient::DEFAULT_TIMEOUT
+$curl->setConnectTimeout(5); // default is \Stripe\HttpClient\CurlClient::DEFAULT_CONNECT_TIMEOUT
+
+echo $curl->getTimeout(); // 10
+echo $curl->getConnectTimeout(); // 5
+
+// tell Stripe to use the tweaked client
+\Stripe\ApiRequestor::setHttpClient($curl);
+
+// use the Stripe API client as you normally would
+```
+
 ## Development
 
 Install dependencies:

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -18,6 +18,33 @@ class CurlClient implements ClientInterface
         return self::$instance;
     }
 
+    // USER DEFINED TIMEOUTS
+
+    private static $timeout = 80;
+    private static $connectTimeout = 30;
+
+    public static function setTimeout($seconds)
+    {
+        self::$timeout = (int) min($seconds, 0);
+    }
+
+    public static function setConnectTimeout($seconds)
+    {
+        self::$connectTimeout = (int) min($seconds, 0);
+    }
+
+    public static function getTimeout()
+    {
+        return self::$timeout;
+    }
+
+    public static function getConnectTimeout()
+    {
+        return self::$connectTimeout;
+    }
+
+    // END OF USER DEFINED TIMEOUTS
+
     public function request($method, $absUrl, $headers, $params, $hasFile)
     {
         $curl = curl_init();
@@ -62,8 +89,8 @@ class CurlClient implements ClientInterface
         $absUrl = Util\Util::utf8($absUrl);
         $opts[CURLOPT_URL] = $absUrl;
         $opts[CURLOPT_RETURNTRANSFER] = true;
-        $opts[CURLOPT_CONNECTTIMEOUT] = 30;
-        $opts[CURLOPT_TIMEOUT] = 80;
+        $opts[CURLOPT_CONNECTTIMEOUT] = static::$connectTimeout;
+        $opts[CURLOPT_TIMEOUT] = static::$timeout;
         $opts[CURLOPT_RETURNTRANSFER] = true;
         $opts[CURLOPT_HEADERFUNCTION] = $headerCallback;
         $opts[CURLOPT_HTTPHEADER] = $headers;

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -20,8 +20,11 @@ class CurlClient implements ClientInterface
 
     // USER DEFINED TIMEOUTS
 
-    private static $timeout = 80;
-    private static $connectTimeout = 30;
+    const DEFAULT_TIMEOUT = 80;
+    const DEFAULT_CONNECT_TIMEOUT = 30;
+
+    private static $timeout = self::DEFAULT_TIMEOUT;
+    private static $connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
 
     public static function setTimeout($seconds)
     {

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -23,27 +23,29 @@ class CurlClient implements ClientInterface
     const DEFAULT_TIMEOUT = 80;
     const DEFAULT_CONNECT_TIMEOUT = 30;
 
-    private static $timeout = self::DEFAULT_TIMEOUT;
-    private static $connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
+    private $timeout = self::DEFAULT_TIMEOUT;
+    private $connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
 
-    public static function setTimeout($seconds)
+    public function setTimeout($seconds)
     {
-        self::$timeout = (int) min($seconds, 0);
+        $this->timeout = (int) max($seconds, 0);
+        return $this;
     }
 
-    public static function setConnectTimeout($seconds)
+    public function setConnectTimeout($seconds)
     {
-        self::$connectTimeout = (int) min($seconds, 0);
+        $this->connectTimeout = (int) max($seconds, 0);
+        return $this;
     }
 
-    public static function getTimeout()
+    public function getTimeout()
     {
-        return self::$timeout;
+        return $this->timeout;
     }
 
-    public static function getConnectTimeout()
+    public function getConnectTimeout()
     {
-        return self::$connectTimeout;
+        return $this->connectTimeout;
     }
 
     // END OF USER DEFINED TIMEOUTS
@@ -92,8 +94,8 @@ class CurlClient implements ClientInterface
         $absUrl = Util\Util::utf8($absUrl);
         $opts[CURLOPT_URL] = $absUrl;
         $opts[CURLOPT_RETURNTRANSFER] = true;
-        $opts[CURLOPT_CONNECTTIMEOUT] = static::$connectTimeout;
-        $opts[CURLOPT_TIMEOUT] = static::$timeout;
+        $opts[CURLOPT_CONNECTTIMEOUT] = $this->connectTimeout;
+        $opts[CURLOPT_TIMEOUT] = $this->timeout;
         $opts[CURLOPT_RETURNTRANSFER] = true;
         $opts[CURLOPT_HEADERFUNCTION] = $headerCallback;
         $opts[CURLOPT_HTTPHEADER] = $headers;

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -2,6 +2,8 @@
 
 namespace Stripe;
 
+use Stripe\HttpClient\CurlClient;
+
 class ApiRequestorTest extends TestCase
 {
     public function testEncodeObjects()
@@ -23,5 +25,19 @@ class ApiRequestorTest extends TestCase
         $v = array('customer' => "\xe9");
         $enc = $method->invoke(null, $v);
         $this->assertSame($enc, array('customer' => "\xc3\xa9"));
+    }
+
+    public function testHttpClientInjection()
+    {
+        $reflector = new \ReflectionClass('Stripe\\ApiRequestor');
+        $method = $reflector->getMethod('httpClient');
+        $method->setAccessible(true);
+
+        $curl = new CurlClient();
+        $curl->setTimeout(10);
+        ApiRequestor::setHttpClient($curl);
+
+        $injectedCurl = $method->invoke(new ApiRequestor());
+        $this->assertSame($injectedCurl, $curl);
     }
 }

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -6,6 +6,23 @@ use Stripe\HttpClient\CurlClient;
 
 class CurlClientTest extends TestCase
 {
+    public function testTimeout()
+    {
+        $curl = new CurlClient();
+        $this->assertSame(CurlClient::DEFAULT_TIMEOUT, $curl->getTimeout());
+        $this->assertSame(CurlClient::DEFAULT_CONNECT_TIMEOUT, $curl->getConnectTimeout());
+
+        // implicitly tests whether we're returning the CurlClient instance
+        $curl = $curl->setConnectTimeout(1)->setTimeout(10);
+        $this->assertSame(1, $curl->getConnectTimeout());
+        $this->assertSame(10, $curl->getTimeout());
+
+        $curl->setTimeout(-1);
+        $curl->setConnectTimeout(-999);
+        $this->assertSame(0, $curl->getTimeout());
+        $this->assertSame(0, $curl->getConnectTimeout());
+    }
+
     public function testEncode()
     {
         $a = array(


### PR DESCRIPTION
The default connect and response timeouts baked into the Stripe API Curl client are way too long (see https://github.com/stripe/stripe-ruby/issues/46 as wlel), exceeding the standard TTL for an ELB, for example, and are not configurable in any way by the user.

This PR, while a bit of a hack (I dislike static client configuration as little as the next dev), allows the user to override the CurlClient's default connect timeout and total timeout values to something more sane. Getters are also provided, in case you want to switch the timeout for a single call, then set it back to where it was later. Defaults are stored as constants for easier inspection.