### PR TITLE
Add curl option to encourage earlier curl versions to negotiate TLS 1.2

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -102,6 +102,13 @@ class CurlClient implements ClientInterface
         if (!Stripe::$verifySslCerts) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
+        // Opt into TLS 1.x support on older versions of curl. This causes some
+        // curl versions, notably on RedHat, to upgrade the connection to TLS
+        // 1.2, from the default TLS 1.0.
+        if (!defined('CURL_SSLVERSION_TLSv1')) {
+            define('CURL_SSLVERSION_TLSv1', 1); // constant not defined in PHP < 5.5
+        }
+        $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1;
 
         curl_setopt_array($curl, $opts);
         $rbody = curl_exec($curl);

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -102,6 +102,10 @@ class CurlClient implements ClientInterface
         if (!Stripe::$verifySslCerts) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
+        // @codingStandardsIgnoreStart
+        // PSR2 requires all constants be upper case. Sadly, the CURL_SSLVERSION
+        // constants to not abide by those rules.
+        //
         // Opt into TLS 1.x support on older versions of curl. This causes some
         // curl versions, notably on RedHat, to upgrade the connection to TLS
         // 1.2, from the default TLS 1.0.
@@ -109,6 +113,7 @@ class CurlClient implements ClientInterface
             define('CURL_SSLVERSION_TLSv1', 1); // constant not defined in PHP < 5.5
         }
         $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1;
+        // @codingStandardsIgnoreEnd
 
         curl_setopt_array($curl, $opts);
         $rbody = curl_exec($curl);


### PR DESCRIPTION
This causes curl on RedHat to upgrade from TLS 1.0 to TLS 1.2 by default.
r? @kyleconroy 