### PR TITLE
Set the stripe_account globaly when working on managed account

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -146,6 +146,11 @@ class ApiRequestor
         if (Stripe::$apiVersion) {
             $defaultHeaders['Stripe-Version'] = Stripe::$apiVersion;
         }
+
+        if (Stripe::$accountId) {
+            $defaultHeaders['Stripe-Account'] = Stripe::$accountId;
+        }
+
         $hasFile = false;
         $hasCurlFile = class_exists('\CURLFile', false);
         foreach ($params as $k => $v) {

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -16,6 +16,9 @@ class Stripe
     // @var string|null The version of the Stripe API to use for requests.
     public static $apiVersion = null;
 
+    // @var string|null The account ID for connected accounts requests.
+    public static $accountId = null;
+
     // @var boolean Defaults to true.
     public static $verifySslCerts = true;
 
@@ -70,5 +73,21 @@ class Stripe
     public static function setVerifySslCerts($verify)
     {
         self::$verifySslCerts = $verify;
+    }
+
+    /**
+     * @return string | null The Stripe account ID for connected accounts requests.
+     */
+    public static function getAccountId()
+    {
+        return self::$accountId;
+    }
+
+    /**
+     * @param string $accountId The Stripe account ID to set for connected accounts requests
+     */
+    public static function setAccountId($accountId)
+    {
+        self::$accountId = $accountId;
     }
 }


### PR DESCRIPTION
This will automatically add Stripe-Account header and the value if  ```php \Stripe\Stripe::setAccountId() ``` has been used.

This can be very useful if you set your api key with a service provider, and have to deal with managed accounts on many requests.