### PR TITLE
Added support for CountrySpec to the bindings

### DIFF
--- a/init.php
+++ b/init.php
@@ -44,6 +44,7 @@ require(dirname(__FILE__) . '/lib/BitcoinTransaction.php');
 require(dirname(__FILE__) . '/lib/Card.php');
 require(dirname(__FILE__) . '/lib/Charge.php');
 require(dirname(__FILE__) . '/lib/Collection.php');
+require(dirname(__FILE__) . '/lib/CountrySpec.php');
 require(dirname(__FILE__) . '/lib/Coupon.php');
 require(dirname(__FILE__) . '/lib/Customer.php');
 require(dirname(__FILE__) . '/lib/Dispute.php');

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Stripe;
+
+class CountrySpec extends ApiResource
+{
+    /**
+     * This is a special case because the country specs endpoint has an
+     *    underscore in it. The parent `className` function strips underscores.
+     *
+     * @return string The name of the class.
+     */
+    public static function className()
+    {
+        return 'country_spec';
+    }
+
+    /**
+     * @param string $country The ISO country code of the country we retrieve the CountrySpec for.
+     * @param array|string|null $opts
+     *
+     * @return CountrySpec
+     */
+    public static function retrieve($country, $opts = null)
+    {
+        return self::_retrieve($country, $opts);
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return Collection of CountrySpecs
+     */
+    public static function all($params = null, $opts = null)
+    {
+        return self::_all($params, $opts);
+    }
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -68,6 +68,7 @@ abstract class Util
             'balance_transaction' => 'Stripe\\BalanceTransaction',
             'card' => 'Stripe\\Card',
             'charge' => 'Stripe\\Charge',
+            'country_spec' => 'Stripe\\CountrySpec',
             'coupon' => 'Stripe\\Coupon',
             'customer' => 'Stripe\\Customer',
             'dispute' => 'Stripe\\Dispute',

--- a/tests/CountrySpecTest.php
+++ b/tests/CountrySpecTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Stripe;
+
+class CountrySpecTest extends TestCase
+{
+    public function testRetrieve()
+    {
+        self::authorizeFromEnv();
+
+        $country = "US";
+        $d = CountrySpec::retrieve($country);
+        $this->assertSame($d->object, "country_spec");
+        $this->assertSame($d->id, $country);
+        $this->assertGreaterThan(0, count($d->supported_bank_account_currencies));
+        $this->assertGreaterThan(0, count($d->supported_payment_currencies));
+        $this->assertGreaterThan(0, count($d->supported_payment_methods));
+        $this->assertGreaterThan(0, count($d->verification_fields));
+    }
+
+    public function testList()
+    {
+        self::authorizeFromEnv();
+
+        $d = CountrySpec::all();
+        $this->assertSame($d->object, "list");
+        $this->assertGreaterThan(0, count($d->data));
+        $this->assertSame($d->data[0]->object, "country_spec");
+        $this->assertInstanceOf("Stripe\\CountrySpec", $d->data[0]);
+    }
+}


### PR DESCRIPTION
Added support for `CountrySpec` and basic tests.

r? @brandur 
cc @gregsabo @bkrausz  for awareness

I wasn't sure whether we wanted to hardcode some assumptions about US since we don't rely on mocked data in the bindings.