### PR TITLE
Added support for auto pagination

### DIFF
--- a/init.php
+++ b/init.php
@@ -4,6 +4,7 @@
 require(dirname(__FILE__) . '/lib/Stripe.php');
 
 // Utilities
+require(dirname(__FILE__) . '/lib/Util/AutoPagingIterator.php');
 require(dirname(__FILE__) . '/lib/Util/RequestOptions.php');
 require(dirname(__FILE__) . '/lib/Util/Set.php');
 require(dirname(__FILE__) . '/lib/Util/Util.php');

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -129,7 +129,13 @@ abstract class ApiResource extends StripeObject
 
         list($response, $opts) = static::_staticRequest('get', $url, $params, $options);
         $obj = Util\Util::convertToStripeObject($response->json, $opts);
+        if (!is_a($obj, 'Stripe\\Collection')) {
+            $class = get_class($obj);
+            $message = "Expected type \"Stripe\\Collection\", got \"$class\" instead";
+            throw new Error\Api($message);
+        }
         $obj->setLastResponse($response);
+        $obj->setRequestParams($params);
         return $obj;
     }
 

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -4,11 +4,19 @@ namespace Stripe;
 
 class Collection extends ApiResource
 {
+    protected $_requestParams = array();
+
+    public function setRequestParams($params)
+    {
+        $this->_requestParams = $params;
+    }
+
     public function all($params = null, $opts = null)
     {
         list($url, $params) = $this->extractPathAndUpdateParams($params);
 
         list($response, $opts) = $this->_request('get', $url, $params, $opts);
+        $this->_requestParams = $params;
         return Util\Util::convertToStripeObject($response, $opts);
     }
 
@@ -17,6 +25,7 @@ class Collection extends ApiResource
         list($url, $params) = $this->extractPathAndUpdateParams($params);
 
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->_requestParams = $params;
         return Util\Util::convertToStripeObject($response, $opts);
     }
 
@@ -32,7 +41,19 @@ class Collection extends ApiResource
             $params,
             $opts
         );
+        $this->_requestParams = $params;
         return Util\Util::convertToStripeObject($response, $opts);
+    }
+
+    /**
+     * @return AutoPagingIterator An iterator that can be used to iterate
+     *    across all objects across all pages. As page boundaries are
+     *    encountered, the next page will be fetched automatically for
+     *    continued iteration.
+     */
+    public function autoPagingIterator()
+    {
+        return new Util\AutoPagingIterator($this, $this->_requestParams);
     }
 
     private function extractPathAndUpdateParams($params)

--- a/lib/Util/AutoPagingIterator.php
+++ b/lib/Util/AutoPagingIterator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Stripe\Util;
+
+class AutoPagingIterator implements \Iterator
+{
+    private $lastId = null;
+    private $page = null;
+    private $params = array();
+
+    public function __construct($collection, $params)
+    {
+        $this->page = $collection;
+        $this->params = $params;
+    }
+
+    public function rewind()
+    {
+        // Actually rewinding would require making a copy of the original page.
+    }
+
+    public function current()
+    {
+        $item = current($this->page->data);
+        $this->lastId = $item !== false ? $item['id'] : null;
+        return $item;
+    }
+
+    public function key()
+    {
+        return key($this->page->data);
+    }
+
+    public function next()
+    {
+        $item = next($this->page->data);
+        if ($item === false) {
+            // If we've run out of data on the current page, try to fetch another one
+            if ($this->page['has_more']) {
+                $this->params = array_merge(
+                    $this->params ? $this->params : array(),
+                    array('starting_after' => $this->lastId)
+                );
+                $this->page = $this->page->all($this->params);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public function valid()
+    {
+        $key = key($this->page->data);
+        $valid = ($key !== null && $key !== false);
+        return $valid;
+    }
+}

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Stripe;
+
+class CollectionTest extends TestCase
+{
+    private function pageableModelResponse($ids, $hasMore)
+    {
+        $data = array();
+        foreach ($ids as $id) {
+            array_push($data, array(
+                'id' => $id,
+                'object' => 'pageablemodel'
+            ));
+        }
+        return array(
+            'object' => 'list',
+            'url' => '/v1/pageablemodels',
+            'data' => $data,
+            'has_more' => $hasMore
+        );
+    }
+
+    public function testAutoPagingOnePage()
+    {
+        $collection = Collection::constructFrom(
+            $this->pageableModelResponse(array('pm_123', 'pm_124'), false),
+            new Util\RequestOptions()
+        );
+
+        $seen = array();
+        foreach ($collection->autoPagingIterator() as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertSame($seen, array('pm_123', 'pm_124'));
+    }
+
+    public function testAutoPagingThreePages()
+    {
+        $collection = Collection::constructFrom(
+            $this->pageableModelResponse(array('pm_123', 'pm_124'), true),
+            new Util\RequestOptions()
+        );
+        $collection->setRequestParams(array('foo' => 'bar'));
+
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            array(
+                  'foo' => 'bar',
+                  'starting_after' => 'pm_124'
+            ),
+            $this->pageableModelResponse(array('pm_125', 'pm_126'), true)
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            array(
+                  'foo' => 'bar',
+                  'starting_after' => 'pm_126'
+            ),
+            $this->pageableModelResponse(array('pm_127'), false)
+        );
+
+        $seen = array();
+        foreach ($collection->autoPagingIterator() as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertSame($seen, array('pm_123', 'pm_124', 'pm_125', 'pm_126', 'pm_127'));
+    }
+}


### PR DESCRIPTION
This PR adds support for auto pagination. The following code:

```php
$charges = \Stripe\Charge::all();
foreach ($charges->autoPagingIterator() as $charge) {
    // Do something with $charge
}
```

will iterate over all charges. No more need to fiddle with pagination parameters! Yay!

The `autoPagingIterator()` method and its associated tests are basically a port of stripe-python's `auto_paging_iter()`.

r? @brandur. I'm not super happy with the `$_lastParams` attribute and accessors I had to add to `StripeObject`, maybe there's a better way to retrieve those? Happy to update the PR if so.
