### PR TITLE
Fixed error messages to remove mentions of support@stripe.com

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -121,9 +121,9 @@ class ApiRequestor
 
         if (!$myApiKey) {
             $msg = 'No API key provided.  (HINT: set your API key using '
-              . '"Stripe::setApiKey(<API-KEY>)".  You can generate API keys from '
-              . 'the Stripe web interface.  See https://stripe.com/api for '
-              . 'details, or email support@stripe.com if you have any questions.';
+              . '"Stripe::setApiKey(<API-KEY>)".  You can find your API keys '
+              . 'in your Stripe dashboard: '
+              . 'https://dashboard.stripe.com/account/apikeys.';
             throw new Error\Authentication($msg);
         }
 

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -163,20 +163,17 @@ class CurlClient implements ClientInterface
                 $msg = "Could not connect to Stripe ($url).  Please check your "
                  . "internet connection and try again.  If this problem persists, "
                  . "you should check Stripe's service status at "
-                 . "https://twitter.com/stripestatus, or";
+                 . "https://status.stripe.com.";
                 break;
             case CURLE_SSL_CACERT:
             case CURLE_SSL_PEER_CERTIFICATE:
                 $msg = "Could not verify Stripe's SSL certificate.  Please make sure "
                  . "that your network is not intercepting certificates.  "
-                 . "(Try going to $url in your browser.)  "
-                 . "If this problem persists,";
+                 . "(Try going to $url in your browser.)";
                 break;
             default:
-                $msg = "Unexpected error communicating with Stripe.  "
-                 . "If this problem persists,";
+                $msg = "Unexpected error communicating with Stripe.";
         }
-        $msg .= " let us know at support@stripe.com.";
 
         $msg .= "\n\n(Network error [errno $errno]: $message)";
         throw new Error\ApiConnection($msg);


### PR DESCRIPTION
This PR fixes error messages that mention support@stripe.com. Users sometimes surface the error messages to customers, and customers are understandably confused when told to contact Stripe's support.

Users should already know how to contact support anyway so they shouldn't be affected by this.