### PR TITLE
Switch arrays-of-hashes to be explicitly indexed

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -207,10 +207,12 @@ class CurlClient implements ClientInterface
                 continue;
             }
 
-            if ($prefix && $k && !is_int($k)) {
-                $k = $prefix."[".$k."]";
-            } elseif ($prefix) {
-                $k = $prefix."[]";
+            if ($prefix) {
+                if ($k !== null && (!is_int($k) || is_array($v))) {
+                    $k = $prefix."[".$k."]";
+                } else {
+                    $k = $prefix."[]";
+                }
             }
 
             if (is_array($v)) {

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -129,6 +129,48 @@ class AccountTest extends TestCase
         $this->assertSame('Bob', $account->legal_entity->first_name);
     }
 
+    public function testCreateAdditionalOwners()
+    {
+        $request = array(
+            'managed' => true,
+            'country' => 'GB',
+            'legal_entity' => array(
+                'additional_owners' => array(
+                    0 => array(
+                        'dob' => array(
+                            'day' => 12,
+                            'month' => 5,
+                            'year' => 1970,
+                        ),
+                        'first_name' => 'xgvukvfrde',
+                        'last_name' => 'rtcyvubhy',
+                    ),
+                    1 => array(
+                        'dob' => array(
+                            'day' => 8,
+                            'month' => 4,
+                            'year' => 1979,
+                        ),
+                        'first_name' => 'yutreuk',
+                        'last_name' => 'dfcgvhbjihmv',
+                    ),
+                ),
+            ),
+        );
+
+        $acct = Account::create($request);
+        $response = $acct->__toArray(true);
+
+        $req_ao = $request['legal_entity']['additional_owners'];
+        $resp_ao = $response['legal_entity']['additional_owners'];
+
+        $this->assertSame($req_ao[0]['dob'], $resp_ao[0]['dob']);
+        $this->assertSame($req_ao[1]['dob'], $resp_ao[1]['dob']);
+
+        $this->assertSame($req_ao[0]['first_name'], $resp_ao[0]['first_name']);
+        $this->assertSame($req_ao[1]['first_name'], $resp_ao[1]['first_name']);
+    }
+
     public function testUpdateAdditionalOwners()
     {
         $response = $this->managedAccountResponse('acct_ABC');

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -59,5 +59,9 @@ class CurlClientTest extends TestCase
         $enc = CurlClient::encode(array('foo' => array(), 'bar' => 'baz'));
         $expected = 'bar=baz';
         $this->assertSame($expected, $enc);
+
+        $a = array('foo' => array(array('bar' => 'baz'), array('bar' => 'bin')));
+        $enc = CurlClient::encode($a);
+        $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
     }
 }


### PR DESCRIPTION
r? @brandur 

If you have an array of arrays, it's safe to assume that you will support explicit indexing. This avoids the breakage where arrays of strings were sent the wrong way.

The underlying issue is that Sinatra's implicit array deserialization doesn't work with recursive arrays. So while this works:

`foo[][bar]=a&foo[][baz]=b&foo[][bar]=c&foo[][baz]=d` => `foo = [{bar: 'a', baz: 'b'}, {bar: 'c', baz: 'd'}]`

Nested arrays of array do not:

`foo[][bar][baz]=a&foo[][bar][bin]=b&foo[][bar][baz]=c&foo[][bar][bin]=d` => Something weird but certainly not what you want.

Fixes #227