### PR TITLE
Fix fatal error when setting a $nestedUpdatableAttributes attr more than once

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -88,7 +88,7 @@ class StripeObject implements ArrayAccess, JsonSerializable
         }
 
         if (self::$nestedUpdatableAttributes->includes($k)
-                && isset($this->$k) && is_array($v)) {
+                && isset($this->$k) && $this->$k instanceof AttachedObject && is_array($v)) {
             $this->$k->replaceWith($v);
         } else {
             // TODO: may want to clear from $_transientValues (Won't be user-visible).

--- a/tests/StripeObjectTest.php
+++ b/tests/StripeObjectTest.php
@@ -94,4 +94,15 @@ class StripeObjectTest extends TestCase
 
         $this->assertEquals('{"foo":"a"}', json_encode($s->__toArray()));
     }
+
+    public function testReplaceNewNestedUpdatable()
+    {
+        StripeObject::init(); // Populate the $nestedUpdatableAttributes Set
+        $s = new StripeObject();
+
+        $s->metadata = array('bar');
+        $this->assertSame($s->metadata, array('bar'));
+        $s->metadata = array('baz', 'qux');
+        $this->assertSame($s->metadata, array('baz', 'qux'));
+    }
 }


### PR DESCRIPTION
Currently updating any nested attribute (which is not already set) more than once causes a fatal error because `StripeObject` assumes that it must be an `AttachedObject` when it's only an array. I've added an `instanceof` check to ensure this doesn't happen.