### PR TITLE
Allow setting default CURLOPT_* on HTTP calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ echo $curl->getConnectTimeout(); // 5
 // use the Stripe API client as you normally would
 ```
 
+## Custom cURL Options (e.g. proxies)
+
+Need to set a proxy for your requests? Pass in the requisite `CURLOPT_*` array to the CurlClient constructor, using the same syntax as `curl_stopt_array()`. This will set the default cURL options for each HTTP request made by the SDK, though many more common options (e.g. timeouts; see above on how to set those) will be overridden by the client even if set here.
+
+```php
+// set up your tweaked Curl client
+$curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_PROXY => 'proxy.local:80'));
+// tell Stripe to use the tweaked client
+\Stripe\ApiRequestor::setHttpClient($curl);
+```
+
+Alternately, a callable can be passed to the CurlClient constructor that returns the above array based on request inputs. See `testDefaultOptions()` in `tests/CurlClientTest.php` for an example of this behavior. Note that the callable is called at the beginning of every API request, before the request is sent.
+
 ## Development
 
 Install dependencies:

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -23,7 +23,7 @@ class CurlClient implements ClientInterface
     /**
      * CurlClient constructor.
      *
-     * Pass in a callable to $defaultIptions that returns an array of CURLOPT_* values to start
+     * Pass in a callable to $defaultOptions that returns an array of CURLOPT_* values to start
      * off a request with, or an flat array with the same format used by curl_setopt_array() to
      * provide a static set of options. Note that many options are overridden later in the request
      * call, including timeouts, which can be set via setTimeout() and setConnectTimeout().

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -82,7 +82,7 @@ class CurlClient implements ClientInterface
 
         $opts = array();
         if (is_callable($this->defaultOptions)) { // call defaultOptions callback, set options to return value
-            $opts = call_user_func($this->defaultOptions, $method, $absUrl, $headers, $params, $hasFile);
+            $opts = call_user_func_array($this->defaultOptions, func_get_args());
             if (!is_array($opts)) {
                 throw new Error\Api("Non-array value returned by defaultOptions CurlClient callback");
             }

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -18,6 +18,31 @@ class CurlClient implements ClientInterface
         return self::$instance;
     }
 
+    protected $defaultOptions;
+
+    /**
+     * CurlClient constructor.
+     *
+     * Pass in a callable to $defaultIptions that returns an array of CURLOPT_* values to start
+     * off a request with, or an flat array with the same format used by curl_setopt_array() to
+     * provide a static set of options. Note that many options are overridden later in the request
+     * call, including timeouts, which can be set via setTimeout() and setConnectTimeout().
+     *
+     * Note that request() will silently ignore a non-callable, non-array $defaultOptions, and will
+     * throw an exception if $defaultOptions returns a non-array value.
+     *
+     * @param callable|null $defaultOptions
+     */
+    public function __construct($defaultOptions = null)
+    {
+        $this->defaultOptions = $defaultOptions;
+    }
+
+    public function getDefaultOptions()
+    {
+        return $this->defaultOptions;
+    }
+
     // USER DEFINED TIMEOUTS
 
     const DEFAULT_TIMEOUT = 80;
@@ -54,7 +79,17 @@ class CurlClient implements ClientInterface
     {
         $curl = curl_init();
         $method = strtolower($method);
+
         $opts = array();
+        if (is_callable($this->defaultOptions)) { // call defaultOptions callback, set options to return value
+            $opts = call_user_func($this->defaultOptions, $method, $absUrl, $headers, $params, $hasFile);
+            if (!is_array($opts)) {
+                throw new Error\Api("Non-array value returned by defaultOptions CurlClient callback");
+            }
+        } elseif (is_array($this->defaultOptions)) { // set default curlopts from array
+            $opts = $this->defaultOptions;
+        }
+
         if ($method == 'get') {
             if ($hasFile) {
                 throw new Error\Api(

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -31,7 +31,7 @@ class CurlClient implements ClientInterface
      * Note that request() will silently ignore a non-callable, non-array $defaultOptions, and will
      * throw an exception if $defaultOptions returns a non-array value.
      *
-     * @param callable|null $defaultOptions
+     * @param array|callable|null $defaultOptions
      */
     public function __construct($defaultOptions = null)
     {

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -32,7 +32,7 @@ class CurlClientTest extends TestCase
 
         // make sure closure-based options work properly, including argument passing
         $ref = null;
-        $withClosure = new CurlClient(function($method, $absUrl, $headers, $params, $hasFile) use (&$ref) {
+        $withClosure = new CurlClient(function ($method, $absUrl, $headers, $params, $hasFile) use (&$ref) {
             $ref = func_get_args();
             return array();
         });
@@ -41,11 +41,10 @@ class CurlClientTest extends TestCase
         $this->assertSame($ref, array('get', 'https://httpbin.org/status/200', array(), array(), false));
 
         // this is the last test case that will run, since it'll throw an exception at the end
-        $withBadClosure = new CurlClient(function() {
+        $withBadClosure = new CurlClient(function () {
             return 'thisShouldNotWork';
         });
-        $this->setExpectedException(
-            'Stripe\Error\Api', "Non-array value returned by defaultOptions CurlClient callback");
+        $this->setExpectedException('Stripe\Error\Api', "Non-array value returned by defaultOptions CurlClient callback");
         $withBadClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
     }
 

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -23,6 +23,32 @@ class CurlClientTest extends TestCase
         $this->assertSame(0, $curl->getConnectTimeout());
     }
 
+    public function testDefaultOptions()
+    {
+        // make sure options array loads/saves properly
+        $optionsArray = array(CURLOPT_PROXY => 'localhost:80');
+        $withOptionsArray = new CurlClient($optionsArray);
+        $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+
+        // make sure closure-based options work properly, including argument passing
+        $ref = null;
+        $withClosure = new CurlClient(function($method, $absUrl, $headers, $params, $hasFile) use (&$ref) {
+            $ref = func_get_args();
+            return array();
+        });
+
+        $withClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
+        $this->assertSame($ref, array('get', 'https://httpbin.org/status/200', array(), array(), false));
+
+        // this is the last test case that will run, since it'll throw an exception at the end
+        $withBadClosure = new CurlClient(function() {
+            return 'thisShouldNotWork';
+        });
+        $this->setExpectedException(
+            'Stripe\Error\Api', "Non-array value returned by defaultOptions CurlClient callback");
+        $withBadClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
+    }
+
     public function testEncode()
     {
         $a = array(


### PR DESCRIPTION
Can be supplied as a static array or as a callable, which will be
invoked with the same arguments the request method is invoked with, and
should return an array (same format as curl_setopt_array()).