### PR TITLE
Parse $opts as RequestOptions if it is an array

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -177,11 +177,15 @@ class StripeObject implements ArrayAccess, JsonSerializable
      * Refreshes this object using the provided values.
      *
      * @param array $values
-     * @param array $opts
+     * @param array|Util\RequestOptions $opts
      * @param boolean $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)
     {
+        if (is_array($opts)) {
+            $opts = Util\RequestOptions::parse($opts);
+        }
+
         $this->_opts = $opts;
 
         // Wipe old state before setting new.  This is useful for e.g. updating a


### PR DESCRIPTION
The PHPDoc of `refreshFrom` method assert that `$opts` should be an array, but `_opts` must be a `RequestOptions` object. If an array was passed, cast it to `RequestOptions`, otherwise, to be fully retro-compatible, use the passed object as-is.