### PR TITLE
Pass opts to parent save method

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -46,7 +46,7 @@ class Account extends ApiResource
      */
     public function save($opts = null)
     {
-        return $this->_save();
+        return $this->_save($opts);
     }
 
     /**


### PR DESCRIPTION
If `opts` parameter was passed, pass it to parent `_save` method.