### PR TITLE
mbstring availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ If you do not wish to use Composer, you can download the [latest release](https:
 require_once('/path/to/stripe-php/init.php');
 ```
 
+## Dependencies
+
+The bindings require the following extension in order to work properly:
+
+- [`curl`](https://secure.php.net/manual/en/book.curl.php), although you can use your own non-cURL client if you prefer
+- [`json`](https://secure.php.net/manual/en/book.json.php)
+- [`mbstring`](https://secure.php.net/manual/en/book.mbstring.php) (Multibyte String)
+
+If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
+
 ## Getting Started
 
 Simple usage looks like:

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -6,6 +6,8 @@ use Stripe\StripeObject;
 
 abstract class Util
 {
+    private static $isMbstringAvailable = null;
+
     /**
      * Whether the provided array (or other) is a list rather than a dictionary.
      *
@@ -116,7 +118,18 @@ abstract class Util
      */
     public static function utf8($value)
     {
-        if (is_string($value) && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
+        if (self::$isMbstringAvailable === null) {
+            self::$isMbstringAvailable = function_exists('mb_detect_encoding');
+
+            if (!self::$isMbstringAvailable) {
+                trigger_error("It looks like the mbstring extension is not enabled. " .
+                    "UTF-8 strings will not properly be encoded. Ask your system " .
+                    "administrator to enable the mbstring extension, or write to " .
+                    "support@stripe.com if you have any questions.", E_USER_WARNING);
+            }
+        }
+
+        if (is_string($value) && self::$isMbstringAvailable && mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
             return utf8_encode($value);
         } else {
             return $value;


### PR DESCRIPTION
This is a tentative PR for #251.

Upon the first call to `utf8()`, it will check if mbstring is enabled, and trigger a warning if it isn't.

I have slight FUD that users will miss the warning however. What do you think? Maybe raise an exception / `die` rather than just a warning?

r? @bkrausz 
cc @stripe/api-libraries 