### PR TITLE
Empty Expect: header to prevent 100-Continue responses

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -126,6 +126,9 @@ class CurlClient implements ClientInterface
             return strlen($header_line);
         };
 
+        // Send empty expect header to avoid 100-Continue responses
+        array_push($headers, 'Expect: ');
+
         $absUrl = Util\Util::utf8($absUrl);
         $opts[CURLOPT_URL] = $absUrl;
         $opts[CURLOPT_RETURNTRANSFER] = true;


### PR DESCRIPTION
I spent a few days recently debugging a series of seemingly inexplicable `Unexpected error communicating with Stripe. If this problem persists, let us know at support@stripe.com. (Network error [errno 52]: Empty reply from server)` errors we were noticing on our servers recently.

It seemed to happen repeatedly for certain users while other users were fine which ruled out any connectivity issue and nothing crazy turned up in a network packet capture but it turns out cURL by default sends an `Expect: 100-continue` header and for whatever reason, the subsequent request with the POST data never made it to the Stripe API.

There's a pretty good write-up here about the behavior: https://support.urbanairship.com/entries/59909909--Expect-100-Continue-Issues-and-Risks

We found setting `Expect:` as a header stopped the problem.