### PR TITLE
Opt cURL requests into 1.2

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -168,7 +168,7 @@ class CurlClient implements ClientInterface
         // being able to use an old TLS version.
         //
         // Note: The int on the right is pulled from the source of OpenSSL 1.0.1a.
-        if (OPENSSL_VERSION_NUMBER >= 0x1000101f) {
+        if (OPENSSL_VERSION_NUMBER >= 0x1000100f) {
             if (!defined('CURL_SSLVERSION_TLSv1_2')) {
                 // Note the value 6 comes from its position in the enum that
                 // defines it in cURL's source code.

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -168,7 +168,7 @@ class CurlClient implements ClientInterface
         // being able to use an old TLS version.
         //
         // Note: The int on the right is pulled from the source of OpenSSL 1.0.1a.
-        if (OPENSSL_VERSION_NUMBER >= 0x1000101fL) {
+        if (OPENSSL_VERSION_NUMBER >= 0x1000101f) {
             if (!defined('CURL_SSLVERSION_TLSv1_2')) {
                 // Note the value 6 comes from its position in the enum that
                 // defines it in cURL's source code.

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -154,13 +154,21 @@ class CurlClient implements ClientInterface
         // PSR2 requires all constants be upper case. Sadly, the CURL_SSLVERSION
         // constants to not abide by those rules.
         //
-        // Opt into TLS 1.x support on older versions of curl. This causes some
-        // curl versions, notably on RedHat, to upgrade the connection to TLS
-        // 1.2, from the default TLS 1.0.
-        if (!defined('CURL_SSLVERSION_TLSv1')) {
-            define('CURL_SSLVERSION_TLSv1', 1); // constant not defined in PHP < 5.5
+        // Explicitly set secure connection to use TLS 1.2 now that the
+        // deprecation effort for 1.0 and 1.1 is well underway and TLS 1.2 is
+        // widespread enougth to be the only good option.
+        //
+        // We'd previously had this set to allow negotiating a range of 1.0 to
+        // 1.2 (CURL_SSLVERSION_TLSv1), but it seems that this will cause some
+        // combinations of systems and libraries to choose 1.0 or 1.1 even when
+        // 1.2 is available, and these requests may be blocked by us once they hit
+        // the Stripe API. See discussion on #276 for details.
+        if (!defined('CURL_SSLVERSION_TLSv1_2')) {
+            // Note the value 6 comes from its position in the enum that
+            // defines it in cURL's source code.
+            define('CURL_SSLVERSION_TLSv1_2', 6); // constant not defined in PHP < 5.5
         }
-        $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1;
+        $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1_2;
         // @codingStandardsIgnoreEnd
 
         curl_setopt_array($curl, $opts);


### PR DESCRIPTION
There seems to be some combinations of systems and libraries that given
the option for a range in 1.0 to 1.2 will choose TLS 1.0 or 1.1 and then
have their requests fail once they go to the Stripe API. This change
opts everyone into TLS 1.2, thus avoiding the problem.

There is a possibility that this could affect the upgrades for users on
versions of cURL that are so old that they don't have access to 1.2, but
we'll need to help these people upgrade anyway given that the
depreaction dates for obsolete version of TLS are in the not-too-distant
future. If we get any bugs reported in that category, we can consider reverting
or solving this another way.

I'm going to keep this open for a bit longer just to wait on a couple more
responses on other issues, but it seems like a not-unreasonable way forward
here given that some users are being forced to patch vendored Stripe code right
now (see #276).

Fixes #276.