### PR TITLE
The key() method should return a unique value

### DIFF
--- a/lib/Util/AutoPagingIterator.php
+++ b/lib/Util/AutoPagingIterator.php
@@ -6,6 +6,7 @@ class AutoPagingIterator implements \Iterator
 {
     private $lastId = null;
     private $page = null;
+    private $pageOffset = 0;
     private $params = array();
 
     public function __construct($collection, $params)
@@ -23,12 +24,13 @@ class AutoPagingIterator implements \Iterator
     {
         $item = current($this->page->data);
         $this->lastId = $item !== false ? $item['id'] : null;
+
         return $item;
     }
 
     public function key()
     {
-        return key($this->page->data);
+        return key($this->page->data) + $this->pageOffset;
     }
 
     public function next()
@@ -36,6 +38,8 @@ class AutoPagingIterator implements \Iterator
         $item = next($this->page->data);
         if ($item === false) {
             // If we've run out of data on the current page, try to fetch another one
+            // and increase the offset the new page would start at
+            $this->pageOffset += count($this->page->data);
             if ($this->page['has_more']) {
                 $this->params = array_merge(
                     $this->params ? $this->params : array(),

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -70,4 +70,36 @@ class CollectionTest extends TestCase
 
         $this->assertSame($seen, array('pm_123', 'pm_124', 'pm_125', 'pm_126', 'pm_127'));
     }
+
+    public function testIteratorToArray()
+    {
+        $collection = Collection::constructFrom(
+            $this->pageableModelResponse(array('pm_123', 'pm_124'), true),
+            new Util\RequestOptions()
+        );
+
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            array(
+                  'starting_after' => 'pm_124'
+            ),
+            $this->pageableModelResponse(array('pm_125', 'pm_126'), true)
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/pageablemodels',
+            array(
+                  'starting_after' => 'pm_126'
+            ),
+            $this->pageableModelResponse(array('pm_127'), false)
+        );
+
+        $seen = array();
+        foreach (iterator_to_array($collection->autoPagingIterator()) as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertSame($seen, array('pm_123', 'pm_124', 'pm_125', 'pm_126', 'pm_127'));
+    }
 }


### PR DESCRIPTION
When you use iterator_to_array() it expects you to return keys by default.
Each item needs to have its own key to avoid overwriting another element.
We now keep track of the offset for each element we access based on the current page.

@olivierbellone what do you think of this fix?