### PR TITLE
Rename `StripeDeclineCode` to `DeclineCode`

### DIFF
--- a/lib/Error/Card.php
+++ b/lib/Error/Card.php
@@ -21,7 +21,12 @@ class Card extends Base
         // trying to do our best not to change the public interface of this class'
         // constructor. We should consider changing its implementation on the
         // next major version bump of this library.
-        $this->stripeDeclineCode = isset($jsonBody["error"]["decline_code"]) ? $jsonBody["error"]["decline_code"] : null;
+        $this->declineCode = isset($jsonBody["error"]["decline_code"]) ? $jsonBody["error"]["decline_code"] : null;
+    }
+
+    public function getDeclineCode()
+    {
+        return $this->declineCode;
     }
 
     public function getStripeCode()
@@ -32,10 +37,5 @@ class Card extends Base
     public function getStripeParam()
     {
         return $this->stripeParam;
-    }
-
-    public function getStripeDeclineCode()
-    {
-        return $this->stripeDeclineCode;
     }
 }


### PR DESCRIPTION
Follows up with a small tweak to #280. This interface is unreleased so
this is not a breaking change.