### PR TITLE
Added custom application information to the User-Agent headers

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -117,6 +117,51 @@ class ApiRequestor
         }
     }
 
+    private static function _formatAppInfo($appInfo)
+    {
+        if ($appInfo !== null) {
+            $string = $appInfo['name'];
+            if ($appInfo['version'] !== null) {
+                $string .= '/' . $appInfo['version'];
+            }
+            if ($appInfo['url'] !== null) {
+                $string .= ' (' . $appInfo['url'] . ')';
+            }
+            return $string;
+        } else {
+            return null;
+        }
+    }
+
+    private static function _defaultHeaders($apiKey)
+    {
+        $appInfo = Stripe::getAppInfo();
+
+        $uaString = 'Stripe/v1 PhpBindings/' . Stripe::VERSION;
+
+        $langVersion = phpversion();
+        $uname = php_uname();
+        $appInfo = Stripe::getAppInfo();
+        $ua = array(
+            'bindings_version' => Stripe::VERSION,
+            'lang' => 'php',
+            'lang_version' => $langVersion,
+            'publisher' => 'stripe',
+            'uname' => $uname,
+        );
+        if ($appInfo !== null) {
+            $uaString .= ' ' . self::_formatAppInfo($appInfo);
+            $ua['application'] = $appInfo;
+        }
+
+        $defaultHeaders = array(
+            'X-Stripe-Client-User-Agent' => json_encode($ua),
+            'User-Agent' => $uaString,
+            'Authorization' => 'Bearer ' . $apiKey,
+        );
+        return $defaultHeaders;
+    }
+
     private function _requestRaw($method, $url, $params, $headers)
     {
         $myApiKey = $this->_apiKey;
@@ -134,20 +179,7 @@ class ApiRequestor
 
         $absUrl = $this->_apiBase.$url;
         $params = self::_encodeObjects($params);
-        $langVersion = phpversion();
-        $uname = php_uname();
-        $ua = array(
-            'bindings_version' => Stripe::VERSION,
-            'lang' => 'php',
-            'lang_version' => $langVersion,
-            'publisher' => 'stripe',
-            'uname' => $uname,
-        );
-        $defaultHeaders = array(
-            'X-Stripe-Client-User-Agent' => json_encode($ua),
-            'User-Agent' => 'Stripe/v1 PhpBindings/' . Stripe::VERSION,
-            'Authorization' => 'Bearer ' . $myApiKey,
-        );
+        $defaultHeaders = $this->_defaultHeaders($myApiKey);
         if (Stripe::$apiVersion) {
             $defaultHeaders['Stripe-Version'] = Stripe::$apiVersion;
         }

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -27,6 +27,9 @@ class Stripe
     // @var boolean Defaults to true.
     public static $verifySslCerts = true;
 
+    // @var array The application's information (name, version, URL)
+    public static $appInfo = null;
+
     const VERSION = '3.21.0';
 
     /**
@@ -96,5 +99,28 @@ class Stripe
     public static function setAccountId($accountId)
     {
         self::$accountId = $accountId;
+    }
+
+    /**
+     * @return array | null The application's information
+     */
+    public static function getAppInfo()
+    {
+        return self::$appInfo;
+    }
+
+    /**
+     * @param string $appName The application's name
+     * @param string $appVersion The application's version
+     * @param string $appUrl The application's URL
+     */
+    public static function setAppInfo($appName, $appVersion = null, $appUrl = null)
+    {
+        if (self::$appInfo === null) {
+            self::$appInfo = array();
+        }
+        self::$appInfo['name'] = $appName;
+        self::$appInfo['version'] = $appVersion;
+        self::$appInfo['url'] = $appUrl;
     }
 }


### PR DESCRIPTION
r? @brandur 
cc @stripe/api-libraries 

This PR adds a `setAppInfo` method to the static `Stripe` class. The method takes three parameters:

- `$appName` (mandatory): the application's name
- `$appVersion` (optional): the application's version
- `$appUrl` (optional): the URL for the application's site

The method is meant to be used by plugin developers. After the method has been called, the headers sent with every request will be modified like this:

- `User-Agent` will have the additional information appended at the end, e.g. `Stripe/v1 PhpBindings/3.21.0` would become `Stripe/v1 PhpBindings/3.21.0 MyAwesomeApp/1.2.34 (https://myawesomeapp.example)`
- `X-Stripe-Client-User-Agent` will have an additional `application` key with the same string that's appended to `User-Agent`, e.g. `MyAwesomeApp/1.2.34 (https://myawesomeapp.example)`

For more context about the motivation behind this PR, see the DX-120 issue internally.
