### PR TITLE
Better TLS (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ $curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_PROXY => 'proxy.local:80
 
 Alternately, a callable can be passed to the CurlClient constructor that returns the above array based on request inputs. See `testDefaultOptions()` in `tests/CurlClientTest.php` for an example of this behavior. Note that the callable is called at the beginning of every API request, before the request is sent.
 
+### SSL / TLS compatibility issues
+
+Stripe's API now requires that [all connections use TLS 1.2](https://stripe.com/blog/upgrading-tls). Some systems (most notably some older CentOS and RHEL versions) are capable of using TLS 1.2 but will use TLS 1.0 or 1.1 by default. In this case, you'd get an `invalid_request_error` with the following error message: "Stripe no longer supports API requests made with TLS 1.0. Please initiate HTTPS connections with TLS 1.2 or later. You can learn more about this at https://stripe.com/blog/upgrading-tls.".
+
+The recommended course of action is to [upgrade your cURL and OpenSSL packages](https://support.stripe.com/questions/how-do-i-upgrade-my-stripe-integration-from-tls-1-0-to-tls-1-2#php) so that TLS 1.2 is used by default, but if that is not possible, you might be able to solve the issue by setting the `CURLOPT_SSLVERSION` option to either `CURL_SSLVERSION_TLSv1` or `CURL_SSLVERSION_TLSv1_2`:
+
+```php
+$curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1));
+\Stripe\ApiRequestor::setHttpClient($curl);
+```
+
 ## Development
 
 Install dependencies:
@@ -127,3 +138,17 @@ Or to run an individual test file:
 ```bash
 ./vendor/bin/phpunit tests/UtilTest.php
 ```
+
+## Attention plugin developers
+
+Are you writing a plugin that integrates Stripe and embeds our library? Then please use the `setAppInfo` function to identify your plugin. For example:
+
+```php
+\Stripe\Stripe::setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info");
+```
+
+The method should be called once, before any request is sent to the API. The second and third parameters are optional.
+
+### SSL / TLS configuration option
+
+See the "SSL / TLS compatibility issues" paragraph above for full context. If you want to ensure that your plugin can be used on all systems, you should add a configuration option to let your users choose between different values for `CURLOPT_SSLVERSION`: none (default), `CURL_SSLVERSION_TLSv1` and `CURL_SSLVERSION_TLSv1_2`.

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -141,6 +141,7 @@ class ApiRequestor
 
         $langVersion = phpversion();
         $uname = php_uname();
+        $curlVersion = curl_version();
         $appInfo = Stripe::getAppInfo();
         $ua = array(
             'bindings_version' => Stripe::VERSION,
@@ -148,6 +149,8 @@ class ApiRequestor
             'lang_version' => $langVersion,
             'publisher' => 'stripe',
             'uname' => $uname,
+            'httplib' => 'curl ' . $curlVersion['version'],
+            'ssllib' => $curlVersion['ssl_version'],
         );
         if ($appInfo !== null) {
             $uaString .= ' ' . self::_formatAppInfo($appInfo);

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -6,6 +6,22 @@ use Stripe\Stripe;
 use Stripe\Error;
 use Stripe\Util;
 
+// cURL constants are not defined in PHP < 5.5
+
+// @codingStandardsIgnoreStart
+// PSR2 requires all constants be upper case. Sadly, the CURL_SSLVERSION
+// constants do not abide by those rules.
+
+// Note the values 1 and 6 come from their position in the enum that
+// defines them in cURL's source code.
+if (!defined('CURL_SSLVERSION_TLSv1')) {
+    define('CURL_SSLVERSION_TLSv1', 1);
+}
+if (!defined('CURL_SSLVERSION_TLSv1_2')) {
+    define('CURL_SSLVERSION_TLSv1_2', 6);
+}
+// @codingStandardsIgnoreEnd
+
 class CurlClient implements ClientInterface
 {
     private static $instance;
@@ -150,38 +166,6 @@ class CurlClient implements ClientInterface
         if (!Stripe::$verifySslCerts) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
-
-        // @codingStandardsIgnoreStart
-        // PSR2 requires all constants be upper case. Sadly, the CURL_SSLVERSION
-        // constants to not abide by those rules.
-        //
-        // Explicitly set a TLS version for cURL to use now that we're starting
-        // to block 1.0 and 1.1 requests.
-        //
-        // If users are on OpenSSL >= 1.0.1, we know that they support TLS 1.2,
-        // so set that explicitly because on some older Linux distros, clients may
-        // default to TLS 1.0 even when they have TLS 1.2 available.
-        //
-        // For users on much older versions of OpenSSL, set a valid range of
-        // TLS 1.0 to 1.2 (CURL_SSLVERSION_TLSv1). Note that this may result in
-        // their requests being blocked unless they're specially flagged into
-        // being able to use an old TLS version.
-        //
-        // Note: The int on the right is pulled from the source of OpenSSL 1.0.1a.
-        if (OPENSSL_VERSION_NUMBER >= 0x1000100f) {
-            if (!defined('CURL_SSLVERSION_TLSv1_2')) {
-                // Note the value 6 comes from its position in the enum that
-                // defines it in cURL's source code.
-                define('CURL_SSLVERSION_TLSv1_2', 6); // constant not defined in PHP < 5.5
-            }
-            $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1_2;
-        } else {
-            if (!defined('CURL_SSLVERSION_TLSv1')) {
-                define('CURL_SSLVERSION_TLSv1', 1); // constant not defined in PHP < 5.5
-            }
-            $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1;
-        }
-        // @codingStandardsIgnoreEnd
 
         curl_setopt_array($curl, $opts);
         $rbody = curl_exec($curl);

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -89,4 +89,12 @@ class CurlClientTest extends TestCase
         $enc = CurlClient::encode($a);
         $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
     }
+
+    public function testSslOption()
+    {
+        // make sure options array loads/saves properly
+        $optionsArray = array(CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1);
+        $withOptionsArray = new CurlClient($optionsArray);
+        $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+    }
 }


### PR DESCRIPTION
r? @brandur 
cc @stripe/api-libraries @remistr 

This PR aims to solve the various TLS issues that some of our users have encountered, usually caused by weird interactions between software versions (most notably curl and its underlying SSL library, typically but not always OpenSSL) and the way we configure TLS in the library.

To summarize:

- the library does not set `CURLOPT_SSLVERSION` at all anymore. From the [PHP docs](https://secure.php.net/manual/en/function.curl-setopt.php): "Your best bet is to not set this and let it use the default. "

- users who need to set this option (on some older RedHat / CentOS versions, the server is capable of using TLS 1.2 but will use TLS 1.0 unless `CURLOPT_SSLVERSION` is explicitly set to either `CURL_SSLVERSION_TLSv1` or `CURL_SSLVERSION_TLSv1_2`) can now do so by passing the option themselves (see README)

- curl constants definitions have been moved out of the `request()` method so that we don't check if the constants are already defined for every request

- the `X-Stripe-Client-User-Agent` header now includes curl version and the SSL library name and version

This update will unfortunately break some users' integrations (for those cases where the library happens to work now, but will require manually setting `CURLOPT_SSLVERSION` after the update), and so should be released with a major version bump.
