### PR TITLE
Fix TransferReversal to have the proper class

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -82,6 +82,7 @@ abstract class Util
             'file' => 'Stripe\\FileUpload',
             'token' => 'Stripe\\Token',
             'transfer' => 'Stripe\\Transfer',
+            'transfer_reversal' => 'Stripe\\TransferReversal',
             'order' => 'Stripe\\Order',
             'order_return' => 'Stripe\\OrderReturn',
             'plan' => 'Stripe\\Plan',


### PR DESCRIPTION
Before that fix, accessing a TransferReversal gave you a StripeObject.

r? @brandur