### PR TITLE
Force cURL to use TLS 1.2 when TLS 1.2 is supported but not used by default

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -163,6 +163,7 @@ class CurlClient implements ClientInterface
         $opts[CURLOPT_TIMEOUT] = $this->timeout;
         $opts[CURLOPT_HEADERFUNCTION] = $headerCallback;
         $opts[CURLOPT_HTTPHEADER] = $headers;
+        $opts[CURLOPT_SSLVERSION] = CURL_SSLVERSION_TLSv1_2;
         if (!Stripe::$verifySslCerts) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }


### PR DESCRIPTION
Since July 2016, Stripe requires TLS 1.2 for all connections.
I suggest to force cURL to use TLS 1.2 on those servers where TLS 1.2 is supported but not used by default.