### PR TITLE
Adds support for verify source endpoint

### DIFF
--- a/lib/Source.php
+++ b/lib/Source.php
@@ -41,4 +41,18 @@ class Source extends ApiResource
     {
         return self::_create($params, $opts);
     }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return BankAccount The verified bank account.
+     */
+    public function verify($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/verify';
+        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
 }


### PR DESCRIPTION
r? @will-stripe
cc @stripe/api-libraries @stan-stripe

This PR adds support for the /verify endpoint for sources, for use with ACH debit and other source types that require a verification. I also added tests for sources.