### PR TITLE
Unused variable

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -154,7 +154,6 @@ abstract class ApiResource extends StripeObject
     protected static function _create($params = null, $options = null)
     {
         self::_validateParams($params);
-        $base = static::baseUrl();
         $url = static::classUrl();
 
         list($response, $opts) = static::_staticRequest('post', $url, $params, $options);


### PR DESCRIPTION
the $base variable is not used in the scope of the function.