### PR TITLE
Fixes tests on master by using multiple plans

### DIFF
--- a/tests/SubscriptionItemTest.php
+++ b/tests/SubscriptionItemTest.php
@@ -4,18 +4,19 @@ namespace Stripe;
 
 class SubscriptionItemTest extends TestCase
 {
-
     public function testCreateUpdateRetrieveListCancel()
     {
-        $planID = 'gold-' . self::generateRandomString(20);
-        self::retrieveOrCreatePlan($planID);
+        $plan0ID = 'gold-' . self::generateRandomString(20);
+        self::retrieveOrCreatePlan($plan0ID);
 
         $customer = self::createTestCustomer();
-        $sub = Subscription::create(array('plan' => $planID, 'customer' => $customer->id));
+        $sub = Subscription::create(array('plan' => $plan0ID, 'customer' => $customer->id));
 
-        $subItem = SubscriptionItem::create(array('plan' => $planID, 'subscription' => $sub->id));
+        $plan1ID = 'gold-' . self::generateRandomString(20);
+        self::retrieveOrCreatePlan($plan1ID);
 
-        $this->assertSame($subItem->plan->id, $planID);
+        $subItem = SubscriptionItem::create(array('plan' => $plan1ID, 'subscription' => $sub->id));
+        $this->assertSame($subItem->plan->id, $plan1ID);
 
         $subItem->quantity = 2;
         $subItem->save();

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -75,30 +75,33 @@ class SubscriptionTest extends TestCase
 
     public function testCreateUpdateListCancelWithItems()
     {
-        $planID = 'gold-' . self::generateRandomString(20);
-        self::retrieveOrCreatePlan($planID);
+        $plan0ID = 'gold-' . self::generateRandomString(20);
+        self::retrieveOrCreatePlan($plan0ID);
 
         $customer = self::createTestCustomer();
 
         $sub = Subscription::create(array(
           'customer' => $customer->id,
           'items' => array(
-            array('plan' => $planID),
+            array('plan' => $plan0ID),
           ),
         ));
 
         $this->assertSame(count($sub->items->data), 1);
-        $this->assertSame($sub->items->data[0]->plan->id, $planID);
+        $this->assertSame($sub->items->data[0]->plan->id, $plan0ID);
+
+        $plan1ID = 'gold-' . self::generateRandomString(20);
+        self::retrieveOrCreatePlan($plan1ID);
 
         $sub = Subscription::update($sub->id, array(
           'items' => array(
-            array('plan' => $planID),
+            array('plan' => $plan1ID),
           ),
         ));
 
         $this->assertSame(count($sub->items->data), 2);
-        $this->assertSame($sub->items->data[0]->plan->id, $planID);
-        $this->assertSame($sub->items->data[1]->plan->id, $planID);
+        $this->assertSame($sub->items->data[0]->plan->id, $plan0ID);
+        $this->assertSame($sub->items->data[1]->plan->id, $plan1ID);
     }
 
     public function testDeleteDiscount()


### PR DESCRIPTION
As described in #315, it seems that some server side logic changed so
that multiple plans of the same ID under the same subscription are no
longer allowed. A couple tests we had depended on that behavior though,
and so when that changed, master broke.

Here we use a similar testing strategy, but just use a new plan when we
need to do an update.

Fixes #315.