### PR TITLE
Fix: Uncought exception in ApiRequestor.php

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -2,6 +2,8 @@
 
 namespace Stripe;
 
+use Exception;
+
 /**
  * Class ApiRequestor
  *


### PR DESCRIPTION
Add namespace so that Exception can be catched in [_interpretResponse](https://github.com/stripe/stripe-php/blob/master/lib/ApiRequestor.php#L259) method of this class.
