### PR TITLE
Properly check if json_decode failed

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -254,11 +254,11 @@ class ApiRequestor
 
     private function _interpretResponse($rbody, $rcode, $rheaders)
     {
-        try {
-            $resp = json_decode($rbody, true);
-        } catch (Exception $e) {
+        $resp = json_decode($rbody, true);
+        $jsonError = json_last_error();
+        if ($resp === null && $jsonError !== JSON_ERROR_NONE) {
             $msg = "Invalid response body from API: $rbody "
-              . "(HTTP response code was $rcode)";
+              . "(HTTP response code was $rcode, json_last_error() was $jsonError)";
             throw new Error\Api($msg, $rcode, $rbody);
         }
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @bkrausz-stripe @ankurk91

Implements the fix suggested by @bkrausz-stripe [here](https://github.com/stripe/stripe-php/pull/324#issuecomment-281799778).