### PR TITLE
Make StripeObject not switch NULLs to empty strings when it shouldn't

### DIFF
--- a/tests/StripeObjectTest.php
+++ b/tests/StripeObjectTest.php
@@ -115,7 +115,9 @@ class StripeObjectTest extends TestCase
         $this->assertSame($s->metadata, array('bar' => 3));
         $s->metadata = null;
 
-        $this->assertSame($s->serializeParameters()['metadata'], '');
+        $serialized = $s->serializeParameters();
+
+        $this->assertSame($serialized['metadata'], '');
     }
 
     public function testReplaceNonNullableNullDoesNotSerialize()

--- a/tests/StripeObjectTest.php
+++ b/tests/StripeObjectTest.php
@@ -105,4 +105,26 @@ class StripeObjectTest extends TestCase
         $s->metadata = array('baz', 'qux');
         $this->assertSame($s->metadata, array('baz', 'qux'));
     }
+
+    public function testReplaceNewNestedNullSerializesToString()
+    {
+        StripeObject::init(); // Populate the $nestedUpdatableAttributes Set
+        $s = new StripeObject();
+
+        $s->metadata = array('bar' => 3);
+        $this->assertSame($s->metadata, array('bar' => 3));
+        $s->metadata = null;
+
+        $this->assertSame($s->serializeParameters()['metadata'], '');
+    }
+
+    public function testReplaceNonNullableNullDoesNotSerialize()
+    {
+        StripeObject::init(); // Populate the $nestedUpdatableAttributes Set
+        $s = new StripeObject();
+
+        $s->address = null;
+
+        $this->assertEmpty($s->serializeParameters());
+    }
 }


### PR DESCRIPTION
So this is a bit of a weird one.

Basically, if I try to add an additional `additional_owners` entry:

```
$account = \Stripe\Account::retrieve($account_id);

$count = count($account->legal_entity->additional_owners);
$account->legal_entity->additional_owners[$count] = array(
  'first_name' => 'Frank',
  'last_name' => 'Lastnameson'
);

$account->save();
```

I get this:

```Fatal error: Uncaught Stripe\Error\InvalidRequest: You passed an empty string for 'legal_entity[additional_owners][1][dob]'. We assume empty values are an attempt to unset a parameter; however 'legal_entity[additional_owners][1][dob]' cannot be unset. You should remove 'legal_entity[additional_owners][1][dob]' from your request or supply a non-empty value. in /Users/jlomas/fiddling/php/vendor/stripe/stripe-php/lib/ApiRequestor.php:110 from API request 'req_ABCDDc8cQM5NDy'```

Because what actually gets assembled/POSTed to Stripe is this:

```{
  "legal_entity": {
    "additional_owners": {
      "1": {
        "address": "",
        "dob": "",
        "verification": "",
        "first_name": "Frank",
        "last_name": "Lastnameson"
      }
    }
  }
}
```

...because `address`, `dob` and `verification` are considered [updatable (nullable) nested properties by the library](https://github.com/stripe/stripe-php/blob/master/lib/StripeObject.php#L29-L35), but are not considered as such by the API.

I'm not sure if these property names collide with something else in the API that _is_ nullable though - thus why it is a weird one.

r? @brandur-stripe
cc @stripe/api-libraries