### PR TITLE
Fix for updating sources' owner attributes

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -31,7 +31,8 @@ class StripeObject implements ArrayAccess, JsonSerializable
             'tos_acceptance', 'personal_address',
             // will make the array into an AttachedObject: weird, but works for now
             'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly
-            'inventory'
+            'inventory',
+            'owner',
         ));
     }
 

--- a/tests/SourceTest.php
+++ b/tests/SourceTest.php
@@ -74,6 +74,69 @@ class SourceTest extends TestCase
         $this->assertSame($source->metadata['foo'], 'bar');
     }
 
+    public function testSaveOwner()
+    {
+        $response = array(
+            'id' => 'src_foo',
+            'object' => 'source',
+            'owner' => array(
+                'name' => null,
+                'address' => null,
+            ),
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/sources/src_foo',
+            array(),
+            $response
+        );
+
+        $response['owner'] = array(
+            'name' => "Stripey McStripe",
+            'address' => array(
+                'line1' => "Test Address",
+                'city' => "Test City",
+                'postal_code' => "12345",
+                'state' => "Test State",
+                'country' => "Test Country",
+            )
+        );
+        $this->mockRequest(
+            'POST',
+            '/v1/sources/src_foo',
+            array(
+                'owner' => array(
+                    'name' => "Stripey McStripe",
+                    'address' => array(
+                        'line1' => "Test Address",
+                        'city' => "Test City",
+                        'postal_code' => "12345",
+                        'state' => "Test State",
+                        'country' => "Test Country",
+                    ),
+                ),
+            ),
+            $response
+        );
+
+        $source = Source::retrieve('src_foo');
+        $source->owner['name'] = "Stripey McStripe";
+        $source->owner['address'] = array(
+            'line1' => "Test Address",
+            'city' => "Test City",
+            'postal_code' => "12345",
+            'state' => "Test State",
+            'country' => "Test Country",
+        );
+        $source->save();
+        $this->assertSame($source->owner['name'], "Stripey McStripe");
+        $this->assertSame($source->owner['address']['line1'], "Test Address");
+        $this->assertSame($source->owner['address']['city'], "Test City");
+        $this->assertSame($source->owner['address']['postal_code'], "12345");
+        $this->assertSame($source->owner['address']['state'], "Test State");
+        $this->assertSame($source->owner['address']['country'], "Test Country");
+    }
+
     public function testVerify()
     {
         $response = array(


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

Adds `owner` to the list of nested updatable attributes to allow for updating sources' `owner` attributes: https://stripe.com/docs/api#update_source-owner
