### PR TITLE
Adding a count() implementation for StripeObjects

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -3,6 +3,7 @@
 namespace Stripe;
 
 use ArrayAccess;
+use Countable;
 use InvalidArgumentException;
 
 /**
@@ -10,7 +11,7 @@ use InvalidArgumentException;
  *
  * @package Stripe
  */
-class StripeObject implements ArrayAccess, JsonSerializable
+class StripeObject implements ArrayAccess, JsonSerializable, Countable
 {
     /**
      * @var Util\Set Attributes that should not be sent to the API because
@@ -288,6 +289,11 @@ class StripeObject implements ArrayAccess, JsonSerializable
         } else {
             return $this->_values;
         }
+    }
+
+    public function count()
+    {
+        return count($this->_values);
     }
 }
 

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -295,6 +295,7 @@ class AccountTest extends TestCase
 
         $account->legal_entity->additional_owners[1] = array('first_name' => 'Jane');
         $account->save();
+        $this->assertSame(2, count($account->legal_entity->additional_owners));
         $this->assertSame('Jane', $account->legal_entity->additional_owners[1]->first_name);
     }
 }


### PR DESCRIPTION
This PR adds the Countable interface as well as a `count()` implementation to `StripeObjects.php`. Right now `count()` on a StripeObject property always returned `1` due to the way we handle values in it.

There was at least one example in our documentation that was failing due to this as we require to count the number of `legal_entity.additional_owners` in a managed account before adding a new one to the right index.

r? @brandur-stripe 
cc @stripe/api-libraries 