### PR TITLE
Adds support for detaching sources from customers

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -93,7 +93,7 @@ abstract class ApiResource extends StripeObject
         return static::resourceUrl($this['id']);
     }
 
-    private static function _validateParams($params = null)
+    protected static function _validateParams($params = null)
     {
         if ($params && !is_array($params)) {
             $message = "You must pass an array as the first argument to Stripe API "

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -66,6 +66,41 @@ class Source extends ApiResource
 
     /**
      * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return Source The deleted source.
+     */
+    public function delete($params = null, $options = null)
+    {
+        self::_validateParams($params);
+
+        $id = $this['id'];
+        if (!$id) {
+            $class = get_class($this);
+            $msg = "Could not determine which URL to request: $class instance "
+             . "has invalid ID: $id";
+            throw new Error\InvalidRequest($msg, null);
+        }
+
+        if ($this['customer']) {
+            $base = Customer::classUrl();
+            $parentExtn = urlencode(Util\Util::utf8($this['customer']));
+            $extn = urlencode(Util\Util::utf8($id));
+            $url = "$base/$parentExtn/sources/$extn";
+
+            list($response, $opts) = $this->_request('delete', $url, $params, $options);
+            $this->refreshFrom($response, $opts);
+            return $this;
+        } else {
+            $message = "Source objects cannot be deleted, they can only be "
+               . "detached from customer objects. This source object does not "
+               . "appear to be currently attached to a customer object.";
+            throw new Error\Api($message);
+        }
+    }
+
+    /**
+     * @param array|null $params
      * @param array|string|null $options
      *
      * @return BankAccount The verified bank account.

--- a/tests/SourceTest.php
+++ b/tests/SourceTest.php
@@ -137,6 +137,53 @@ class SourceTest extends TestCase
         $this->assertSame($source->owner['address']['country'], "Test Country");
     }
 
+    public function testDeleteAttached()
+    {
+        $response = array(
+            'id' => 'src_foo',
+            'object' => 'source',
+            'customer' => 'cus_bar',
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/sources/src_foo',
+            array(),
+            $response
+        );
+
+        unset($response['customer']);
+        $this->mockRequest(
+            'DELETE',
+            '/v1/customers/cus_bar/sources/src_foo',
+            array(),
+            $response
+        );
+
+        $source = Source::retrieve('src_foo');
+        $source->delete();
+        $this->assertFalse(array_key_exists('customer', $source));
+    }
+
+    /**
+     * @expectedException Stripe\Error\Api
+     */
+    public function testDeleteUnattached()
+    {
+        $response = array(
+            'id' => 'src_foo',
+            'object' => 'source',
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/sources/src_foo',
+            array(),
+            $response
+        );
+
+        $source = Source::retrieve('src_foo');
+        $source->delete();
+    }
+
     public function testVerify()
     {
         $response = array(


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @will-stripe

Adds support for detaching sources from customers.

I changed the visibility of `_validateParams` so that derived classes can use it in order to be consistent with the implementation of `_delete` in `ApiResource` (though the API request to detach sources from customers does not expect any parameters).
