### PR TITLE
Backport setAppInfo to legacy version of the bindings

### DIFF
--- a/lib/Stripe/Stripe.php
+++ b/lib/Stripe/Stripe.php
@@ -24,6 +24,9 @@ abstract class Stripe
   public static $verifySslCerts = true;
   const VERSION = '1.18.0';
 
+  // @var array The application's information (name, version, URL)
+  public static $appInfo = null;
+
   /**
    * @return string The API key used for requests.
    */
@@ -73,5 +76,28 @@ abstract class Stripe
   public static function setVerifySslCerts($verify)
   {
     self::$verifySslCerts = $verify;
+  }
+
+  /**
+   * @return array | null The application's information
+   */
+  public static function getAppInfo()
+  {
+      return self::$appInfo;
+  }
+
+  /**
+   * @param string $appName The application's name
+   * @param string $appVersion The application's version
+   * @param string $appUrl The application's URL
+   */
+  public static function setAppInfo($appName, $appVersion = null, $appUrl = null)
+  {
+      if (self::$appInfo === null) {
+          self::$appInfo = array();
+      }
+      self::$appInfo['name'] = $appName;
+      self::$appInfo['version'] = $appVersion;
+      self::$appInfo['url'] = $appUrl;
   }
 }

--- a/test/Stripe/ApiRequestorTest.php
+++ b/test/Stripe/ApiRequestorTest.php
@@ -121,4 +121,29 @@ CBoD8xKYd5r7CYf1Du+nNMmDmrE=
   // }}}
     $this->assertTrue(Stripe_APIRequestor::isBlackListed($cert));
   }
+
+  public function testDefaultHeaders()
+  {
+      $reflector = new \ReflectionClass('Stripe_ApiRequestor');
+      $method = $reflector->getMethod('_defaultHeaders');
+      $method->setAccessible(true);
+
+      // no way to stub static methods with PHPUnit 4.x :(
+      Stripe::setAppInfo('MyTestApp', '1.2.34', 'https://mytestapp.example');
+      $apiKey = 'sk_test_notarealkey';
+
+      $headers = $method->invoke(null, $apiKey);
+
+      $ua = json_decode($headers['X-Stripe-Client-User-Agent']);
+      $this->assertSame($ua->application->name, 'MyTestApp');
+      $this->assertSame($ua->application->version, '1.2.34');
+      $this->assertSame($ua->application->url, 'https://mytestapp.example');
+
+      $this->assertSame(
+          $headers['User-Agent'],
+          'Stripe/v1 PhpBindings/' . Stripe::VERSION . ' MyTestApp/1.2.34 (https://mytestapp.example)'
+      );
+
+      $this->assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
+  }
 }


### PR DESCRIPTION
We have a lot of third-party plugins/platforms that use the legacy version. The main reason is to support old PHP installations. We still want them to explicitly showcase who they are so that we can better help their users.

This is a first attempt at bringing the functionality in for a potential release as 1.18.1.

I'm still not convinced we should release this and instead we should nudge plugin developers to use the latest and more reliable version but at least the functionality is available if we do need to merge it in the future.

As a note: tests on 1.18.0 are failing locally on a lot of files even without my changes making it hard to make the merge safe but at least my test works and I've confirmed on a request that it does the right thing.

@stripe/api-libraries  what do you think?