### PR TITLE
Peg randomly generated emails to @stripe.com

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -204,9 +204,9 @@ class TestCase extends \PHPUnit_Framework_TestCase
     /**
      * Generate a semi-random email.
      */
-    protected static function generateRandomEmail($domain = 'bar.com')
+    protected static function generateRandomEmail()
     {
-        return self::generateRandomString().'@'.$domain;
+        return 'dev-platform-bots+php-'.self::generateRandomString(12).'@stripe.com';
     }
 
     protected static function createTestBitcoinReceiver($email)


### PR DESCRIPTION
Pegs randomly generated emails for test accounts to
`dev-platform-bots+php<random>@stripe.com`. We don't want to send emails
to random domains, and we definitely don't want to be sending them to
`bar.com` which we don't own and is not an IETF-mandated example domain
or anything like that.

r? @remi-stripe 