### PR TITLE
Peg the test suite's API version

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,11 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         ApiRequestor::setHttpClient(HttpClient\CurlClient::instance());
+
+        // Peg the API version so that it can be varied independently of the
+        // one set on the test account.
+        Stripe::setApiVersion('2017-02-14');
+
         $this->mock = null;
         $this->call = 0;
     }


### PR DESCRIPTION
Pegs the test suite's API version so that we can upgrade it
independently of the account's implicit version. It's also to check how
much breaks when we move to a relatively modern version of the API.

See also https://github.com/stripe/stripe-java/pull/360 and https://github.com/stripe/stripe-python/pull/298.