### PR TITLE
Remove raw PANs from our test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ This legacy version may be included via `require_once("/path/to/stripe-php/lib/S
 
 ```php
 Stripe::setApiKey('d8e8fca2dc0f896fd7cb4cb0031ba249');
-$myCard = array('number' => '4242424242424242', 'exp_month' => 8, 'exp_year' => 2018);
-$charge = Stripe_Charge::create(array('card' => $myCard, 'amount' => 2000, 'currency' => 'usd'));
+$charge = Stripe_Charge::create(array('source' => 'tok_XXXXXXXX', 'amount' => 2000, 'currency' => 'usd'));
 echo $charge;
 ```
 

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -99,8 +99,7 @@ abstract class ApiResource extends StripeObject
             $message = "You must pass an array as the first argument to Stripe API "
                . "method calls.  (HINT: an example call to create a charge "
                . "would be: \"Stripe\\Charge::create(array('amount' => 100, "
-               . "'currency' => 'usd', 'card' => array('number' => "
-               . "4242424242424242, 'exp_month' => 5, 'exp_year' => 2015)))\")";
+               . "'currency' => 'usd', 'source' => 'tok_1234'))\")";
             throw new Error\Api($message);
         }
     }

--- a/tests/CardErrorTest.php
+++ b/tests/CardErrorTest.php
@@ -8,16 +8,10 @@ class CardErrorTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4000000000000002',
-            'exp_month' => '3',
-            'exp_year' => '2020'
-        );
-
         $charge = array(
             'amount' => 100,
             'currency' => 'usd',
-            'card' => $card
+            'source' => 'tok_chargeDeclined'
         );
 
         try {

--- a/tests/ChargeTest.php
+++ b/tests/ChargeTest.php
@@ -15,17 +15,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $c = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
         $this->assertTrue($c->paid);
@@ -36,17 +30,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $c = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             ),
             array(
                 'idempotency_key' => self::generateRandomString(),
@@ -61,17 +49,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $c = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
         $d = Charge::retrieve($c->id);
@@ -83,17 +65,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $charge = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
 
@@ -108,17 +84,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $charge = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
 
@@ -134,17 +104,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $charge = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
 
@@ -182,17 +146,11 @@ class ChargeTest extends TestCase
     {
         self::authorizeFromEnv();
 
-        $card = array(
-            'number' => '4242424242424242',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $charge = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'card' => 'tok_visa'
             )
         );
 

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -146,17 +146,8 @@ class CustomerTest extends TestCase
 
     public function testCustomerAddCard()
     {
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4242424242424242",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
-
         $customer = $this->createTestCustomer();
-        $createdCard = $customer->sources->create(array("card" => $token->id));
+        $createdCard = $customer->sources->create(array("card" => 'tok_visa'));
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);
@@ -183,17 +174,8 @@ class CustomerTest extends TestCase
 
     public function testCustomerDeleteCard()
     {
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4242424242424242",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
-
         $customer = $this->createTestCustomer();
-        $createdCard = $customer->sources->create(array("card" => $token->id));
+        $createdCard = $customer->sources->create(array("card" => 'tok_visa'));
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);
@@ -212,17 +194,9 @@ class CustomerTest extends TestCase
     public function testCustomerAddSource()
     {
         self::authorizeFromEnv();
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4242424242424242",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
 
         $customer = $this->createTestCustomer();
-        $createdSource = $customer->sources->create(array("source" => $token->id));
+        $createdSource = $customer->sources->create(array("source" => 'tok_visa'));
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);
@@ -250,17 +224,9 @@ class CustomerTest extends TestCase
     public function testCustomerDeleteSource()
     {
         self::authorizeFromEnv();
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4242424242424242",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
 
         $customer = $this->createTestCustomer();
-        $createdSource = $customer->sources->create(array("source" => $token->id));
+        $createdSource = $customer->sources->create(array("source" => 'tok_visa'));
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);

--- a/tests/DisputeTest.php
+++ b/tests/DisputeTest.php
@@ -13,17 +13,11 @@ class DisputeTest extends TestCase
 
     private function createDisputedCharge()
     {
-        $card = array(
-            'number' => '4000000000000259',
-            'exp_month' => 5,
-            'exp_year' => date('Y') + 1
-        );
-
         $c = Charge::create(
             array(
                 'amount' => 100,
                 'currency' => 'usd',
-                'card' => $card
+                'source' => 'tok_createDispute'
             )
         );
         $c = Charge::retrieve($c->id);

--- a/tests/PayoutTest.php
+++ b/tests/PayoutTest.php
@@ -21,12 +21,7 @@ class PayoutTest extends TestCase
             $charge = \Stripe\Charge::create(array(
                 'currency' => 'usd',
                 'amount' => '10000',
-                'source' => array(
-                    'object' => 'card',
-                    'number' => '4000000000000077',
-                    'exp_month' => '09',
-                    'exp_year' => date('Y') + 3,
-                ),
+                'source' => 'tok_bypassPending',
                 'destination' => array(
                     'account' => $account->id
                 )

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -142,14 +142,7 @@ class ProductSKUOrderTest extends TestCase
         $stripeOrder = Order::retrieve($order->id);
         $this->assertSame($order->metadata->foo, "bar");
 
-        $order->pay(array(
-            'source' => array(
-                'object' => 'card',
-                'number' => '4242424242424242',
-                'exp_month' => '05',
-                'exp_year' => '2017'
-            ),
-        ));
+        $order->pay(array('source' => 'tok_visa'));
         $this->assertSame($order->status, 'paid');
 
         $orderReturn = $order->returnOrder();

--- a/tests/RecipientTest.php
+++ b/tests/RecipientTest.php
@@ -36,17 +36,8 @@ class RecipientTest extends TestCase
 
     public function testRecipientAddCard()
     {
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4000056655665556",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
-
         $recipient = $this->createTestRecipient();
-        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $createdCard = $recipient->cards->create(array("card" => 'tok_visa_debit'));
         $recipient->save();
 
         $updatedRecipient = Recipient::retrieve($recipient->id);
@@ -56,17 +47,8 @@ class RecipientTest extends TestCase
 
     public function testRecipientUpdateCard()
     {
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4000056655665556",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
-
         $recipient = $this->createTestRecipient();
-        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $createdCard = $recipient->cards->create(array("card" => 'tok_visa_debit'));
         $recipient->save();
 
         $createdCards = $recipient->cards->all();
@@ -83,17 +65,8 @@ class RecipientTest extends TestCase
 
     public function testRecipientDeleteCard()
     {
-        $token = Token::create(
-            array("card" => array(
-                "number" => "4000056655665556",
-                "exp_month" => 5,
-                "exp_year" => date('Y') + 3,
-                "cvc" => "314"
-            ))
-        );
-
         $recipient = $this->createTestRecipient();
-        $createdCard = $recipient->cards->create(array("card" => $token->id));
+        $createdCard = $recipient->cards->create(array("card" => 'tok_visa_debit'));
         $recipient->save();
 
         $updatedRecipient = Recipient::retrieve($recipient->id);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -65,11 +65,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 'amount' => 2000,
                 'currency' => 'usd',
                 'description' => 'Charge for test@example.com',
-                'card' => array(
-                    'number' => '4242424242424242',
-                    'exp_month' => 5,
-                    'exp_year' => date('Y') + 3,
-                ),
+                'card' => 'tok_visa',
             )
         );
     }
@@ -103,11 +99,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
         return Customer::create(
             $attributes + array(
-                'card' => array(
-                    'number' => '4242424242424242',
-                    'exp_month' => 5,
-                    'exp_year' => date('Y') + 3,
-                ),
+                'card' => 'tok_visa',
             )
         );
     }


### PR DESCRIPTION
This PR aims to use the new test tokens such as `tok_visa` instead or hardcoding raw PANs in the test suite.

There's one last PAN we can't remove for disputes as it hasn't been released yet.

r? @brandur-stripe 