### PR TITLE
Allow a PSR-3 logger to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ $curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_PROXY => 'proxy.local:80
 
 Alternately, a callable can be passed to the CurlClient constructor that returns the above array based on request inputs. See `testDefaultOptions()` in `tests/CurlClientTest.php` for an example of this behavior. Note that the callable is called at the beginning of every API request, before the request is sent.
 
+### Configuring a Logger
+
+The library does minimal logging, but it can be configured
+with a [`PSR-3` compatible logger][psr3] so that messages
+end up there instead of `error_log`:
+
+```php
+\Stripe\Stripe::setLogger($logger);
+```
+
 ### SSL / TLS compatibility issues
 
 Stripe's API now requires that [all connections use TLS 1.2](https://stripe.com/blog/upgrading-tls). Some systems (most notably some older CentOS and RHEL versions) are capable of using TLS 1.2 but will use TLS 1.0 or 1.1 by default. In this case, you'd get an `invalid_request_error` with the following error message: "Stripe no longer supports API requests made with TLS 1.0. Please initiate HTTPS connections with TLS 1.2 or later. You can learn more about this at [https://stripe.com/blog/upgrading-tls](https://stripe.com/blog/upgrading-tls).".
@@ -151,3 +161,5 @@ The method should be called once, before any request is sent to the API. The sec
 ### SSL / TLS configuration option
 
 See the "SSL / TLS compatibility issues" paragraph above for full context. If you want to ensure that your plugin can be used on all systems, you should add a configuration option to let your users choose between different values for `CURLOPT_SSLVERSION`: none (default), `CURL_SSLVERSION_TLSv1` and `CURL_SSLVERSION_TLSv1_2`.
+
+[psr3]: http://www.php-fig.org/psr/psr-3/

--- a/init.php
+++ b/init.php
@@ -5,6 +5,8 @@ require(dirname(__FILE__) . '/lib/Stripe.php');
 
 // Utilities
 require(dirname(__FILE__) . '/lib/Util/AutoPagingIterator.php');
+require(dirname(__FILE__) . '/lib/Util/LoggerInterface.php');
+require(dirname(__FILE__) . '/lib/Util/DefaultLogger.php');
 require(dirname(__FILE__) . '/lib/Util/RequestOptions.php');
 require(dirname(__FILE__) . '/lib/Util/Set.php');
 require(dirname(__FILE__) . '/lib/Util/Util.php');

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -30,6 +30,10 @@ class Stripe
     // @var array The application's information (name, version, URL)
     public static $appInfo = null;
 
+    // @var Util\LoggerInterface|null The logger to which the library will
+    //   produce messages.
+    public static $logger = null;
+
     const VERSION = '4.7.0';
 
     /**
@@ -38,6 +42,27 @@ class Stripe
     public static function getApiKey()
     {
         return self::$apiKey;
+    }
+
+    /**
+     * @return Util\LoggerInterface The logger to which the library will
+     *   produce messages.
+     */
+    public static function getLogger()
+    {
+        if (self::$logger == null) {
+            return new Util\DefaultLogger();
+        }
+        return self::$logger;
+    }
+
+    /**
+     * @param Util\LoggerInterface $logger The logger to which the library
+     *   will produce messages.
+     */
+    public static function setLogger($logger)
+    {
+        self::$logger = $logger;
     }
 
     /**

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -131,11 +131,11 @@ class StripeObject implements ArrayAccess, JsonSerializable
                     . "with the result returned by Stripe's API, "
                     . "probably as a result of a save(). The attributes currently "
                     . "available on this object are: $attrs";
-            error_log($message);
+            Stripe::getLogger()->error($message);
             return $nullval;
         } else {
             $class = get_class($this);
-            error_log("Stripe Notice: Undefined property of $class instance: $k");
+            Stripe::getLogger()->error("Stripe Notice: Undefined property of $class instance: $k");
             return $nullval;
         }
     }

--- a/lib/Util/DefaultLogger.php
+++ b/lib/Util/DefaultLogger.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stripe\Util;
+
+/**
+ * A very basic implementation of LoggerInterface that has just enough
+ * functionality that it can be the default for this library.
+ */
+class DefaultLogger implements LoggerInterface
+{
+    public function error($message, array $context = array())
+    {
+        if (count($context) > 0) {
+            throw new Exception('DefaultLogger does not currently implement context. Please implement if you need it.');
+        }
+        error_log($message);
+    }
+}

--- a/lib/Util/LoggerInterface.php
+++ b/lib/Util/LoggerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stripe\Util;
+
+/**
+ * Describes a logger instance.
+ *
+ * This is a subset of the interface of the same name in the PSR-3 logger
+ * interface. We guarantee to keep it compatible, but we'd redefined it here so
+ * that we don't have to pull in the extra dependencies for users who don't want
+ * it.
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
+ *
+ * The message MUST be a string or object implementing __toString().
+ *
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
+ *
+ * The context array can contain arbitrary data, the only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ */
+interface LoggerInterface
+{
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function error($message, array $context = array());
+}

--- a/tests/UtilDefaultLoggerTest.php
+++ b/tests/UtilDefaultLoggerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+// Test in a slightly different namespace than usual. See comment on
+// `error_log` below.
+namespace Stripe\Util;
+
+class UtilLoggerTest extends \Stripe\TestCase
+{
+    public function testDefaultLogger()
+    {
+        $logger = new DefaultLogger();
+        $logger->error("message");
+
+        global $lastMessage;
+        $this->assertSame($lastMessage, "message");
+    }
+}
+
+// This is a little terrible, but unfortunately there's no clean way to stub a
+// call to `error_log`. Here we overwrite it so that we can get the last arguments
+// that went to it. This is obviously bad, but luckily it's constrained to
+// being just in \Stripe\Util (i.e. won't interfere with PHPUnit for example)
+// and _just_ present when tests are running.
+function error_log($message)
+{
+    global $lastMessage;
+    $lastMessage = $message;
+}


### PR DESCRIPTION
Adds a configuration option so that a PSR-3 compatible logger can be
set on the library so that messages will end up there instead of
`error_log`.

Fixes #340.

@bkrausz-stripe Any thoughts on this approach? See context in #340.