### PR TITLE
allow payout_schedule to be updated

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -27,7 +27,7 @@ class StripeObject implements ArrayAccess, JsonSerializable
     {
         self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
         self::$nestedUpdatableAttributes = new Util\Set(array(
-            'metadata', 'legal_entity', 'address', 'dob', 'transfer_schedule', 'verification',
+            'metadata', 'legal_entity', 'address', 'dob', 'payout_schedule', 'transfer_schedule', 'verification',
             'tos_acceptance', 'personal_address',
             // will make the array into an AttachedObject: weird, but works for now
             'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly


### PR DESCRIPTION
`transfer_schedule` was renamed to `payout_schedule` in `2017-04-06`. This allows that nested field to be updated.