### PR TITLE
Update retrieve method documentation to accept arrays

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -47,7 +47,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param string|null $id
+     * @param array|string|null $id
      * @param array|string|null $opts
      *
      * @return Account

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -47,7 +47,8 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|string|null $id
+     * @param array|string|null $id The ID of the account to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Account

--- a/lib/ApplePayDomain.php
+++ b/lib/ApplePayDomain.php
@@ -20,7 +20,8 @@ class ApplePayDomain extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the domain to retrieve.
+     * @param array|string $id The ID of the domain to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return ApplePayDomain

--- a/lib/ApplePayDomain.php
+++ b/lib/ApplePayDomain.php
@@ -20,7 +20,7 @@ class ApplePayDomain extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the domain to retrieve.
+     * @param array|string $id The ID of the domain to retrieve.
      * @param array|string|null $opts
      *
      * @return ApplePayDomain

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -21,7 +21,8 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the application fee to retrieve.
+     * @param array|string $id The ID of the application fee to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return ApplicationFee

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -21,7 +21,7 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the application fee to retrieve.
+     * @param array|string $id The ID of the application fee to retrieve.
      * @param array|string|null $opts
      *
      * @return ApplicationFee

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -34,7 +34,8 @@ class BalanceTransaction extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the balance transaction to retrieve.
+     * @param array|string $id The ID of the balance transaction to retrieve,
+     *     or an options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return BalanceTransaction

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -34,7 +34,7 @@ class BalanceTransaction extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the balance transaction to retrieve.
+     * @param array|string $id The ID of the balance transaction to retrieve.
      * @param array|string|null $opts
      *
      * @return BalanceTransaction

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -37,7 +37,7 @@ class BitcoinReceiver extends ExternalAccount
     }
 
     /**
-     * @param string $id The ID of the Bitcoin Receiver to retrieve.
+     * @param array|string $id The ID of the Bitcoin Receiver to retrieve.
      * @param array|string|null $opts
      *
      * @return BitcoinReceiver

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -37,7 +37,8 @@ class BitcoinReceiver extends ExternalAccount
     }
 
     /**
-     * @param array|string $id The ID of the Bitcoin Receiver to retrieve.
+     * @param array|string $id The ID of the bitcoin receiver to retrieve, or
+     *     an options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return BitcoinReceiver

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -41,7 +41,7 @@ namespace Stripe;
 class Charge extends ApiResource
 {
     /**
-     * @param string $id The ID of the charge to retrieve.
+     * @param array|string $id The ID of the charge to retrieve.
      * @param array|string|null $options
      *
      * @return Charge

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -41,7 +41,8 @@ namespace Stripe;
 class Charge extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the charge to retrieve.
+     * @param array|string $id The ID of the charge to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $options
      *
      * @return Charge

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -21,7 +21,9 @@ class CountrySpec extends ApiResource
     }
 
     /**
-     * @param array|string $country The ISO country code of the country we retrieve the CountrySpec for.
+     * @param array|string $country The ISO country code of the country we
+     *     retrieve the country specfication for, or an options array
+     *     containing an `id` containing that code.
      * @param array|string|null $opts
      *
      * @return CountrySpec

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -21,7 +21,7 @@ class CountrySpec extends ApiResource
     }
 
     /**
-     * @param string $country The ISO country code of the country we retrieve the CountrySpec for.
+     * @param array|string $country The ISO country code of the country we retrieve the CountrySpec for.
      * @param array|string|null $opts
      *
      * @return CountrySpec

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class Coupon extends ApiResource
 {
     /**
-     * @param string $id The ID of the coupon to retrieve.
+     * @param array|string $id The ID of the coupon to retrieve.
      * @param array|string|null $opts
      *
      * @return Coupon

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class Coupon extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the coupon to retrieve.
+     * @param array|string $id The ID of the coupon to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Coupon

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -27,7 +27,7 @@ namespace Stripe;
 class Customer extends ApiResource
 {
     /**
-     * @param string $id The ID of the customer to retrieve.
+     * @param array|string $id The ID of the customer to retrieve.
      * @param array|string|null $opts
      *
      * @return Customer

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -27,7 +27,8 @@ namespace Stripe;
 class Customer extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the customer to retrieve.
+     * @param array|string $id The ID of the customer to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Customer

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -25,7 +25,8 @@ namespace Stripe;
 class Dispute extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the dispute to retrieve.
+     * @param array|string $id The ID of the dispute to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $options
      *
      * @return Dispute

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -25,7 +25,7 @@ namespace Stripe;
 class Dispute extends ApiResource
 {
     /**
-     * @param string $id The ID of the dispute to retrieve.
+     * @param array|string $id The ID of the dispute to retrieve.
      * @param array|string|null $options
      *
      * @return Dispute

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -20,7 +20,7 @@ namespace Stripe;
 class Event extends ApiResource
 {
     /**
-     * @param string $id The ID of the event to retrieve.
+     * @param array|string $id The ID of the event to retrieve.
      * @param array|string|null $opts
      *
      * @return Event

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -20,7 +20,8 @@ namespace Stripe;
 class Event extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the event to retrieve.
+     * @param array|string $id The ID of the event to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Event

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -27,7 +27,8 @@ class FileUpload extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the file upload to retrieve.
+     * @param array|string $id The ID of the file upload to retrieve, or an
+     *     options array containing an `id key.
      * @param array|string|null $opts
      *
      * @return FileUpload

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -27,7 +27,7 @@ class FileUpload extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the file upload to retrieve.
+     * @param array|string $id The ID of the file upload to retrieve.
      * @param array|string|null $opts
      *
      * @return FileUpload

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -21,7 +21,8 @@ class Invoice extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the invoice to retrieve.
+     * @param array|string $id The ID of the invoice to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Invoice

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -21,7 +21,7 @@ class Invoice extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the invoice to retrieve.
+     * @param array|string $id The ID of the invoice to retrieve.
      * @param array|string|null $opts
      *
      * @return Invoice

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class InvoiceItem extends ApiResource
 {
     /**
-     * @param string $id The ID of the invoice item to retrieve.
+     * @param array|string $id The ID of the invoice item to retrieve.
      * @param array|string|null $opts
      *
      * @return InvoiceItem

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class InvoiceItem extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the invoice item to retrieve.
+     * @param array|string $id The ID of the invoice item to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return InvoiceItem

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class Order extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the Order to retrieve.
+     * @param array|string $id The ID of the order to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Order

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class Order extends ApiResource
 {
     /**
-     * @param string $id The ID of the Order to retrieve.
+     * @param array|string $id The ID of the Order to retrieve.
      * @param array|string|null $opts
      *
      * @return Order

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class OrderReturn extends ApiResource
 {
     /**
-     * @param string $id The ID of the OrderReturn to retrieve.
+     * @param array|string $id The ID of the OrderReturn to retrieve.
      * @param array|string|null $opts
      *
      * @return Order

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class OrderReturn extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the OrderReturn to retrieve.
+     * @param array|string $id The ID of the order return to retrieve, or an
+     *     options array containing an `id` field.
      * @param array|string|null $opts
      *
      * @return Order

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -30,7 +30,7 @@ namespace Stripe;
 class Payout extends ApiResource
 {
     /**
-     * @param string $id The ID of the payout to retrieve.
+     * @param array|string $id The ID of the payout to retrieve.
      * @param array|string|null $opts
      *
      * @return Payout

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -30,7 +30,8 @@ namespace Stripe;
 class Payout extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the payout to retrieve.
+     * @param array|string $id The ID of the payout to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Payout

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -23,7 +23,7 @@ namespace Stripe;
 class Plan extends ApiResource
 {
     /**
-     * @param string $id The ID of the plan to retrieve.
+     * @param array|string $id The ID of the plan to retrieve.
      * @param array|string|null $opts
      *
      * @return Plan

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -23,7 +23,8 @@ namespace Stripe;
 class Plan extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the plan to retrieve.
+     * @param array|string $id The ID of the plan to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Plan

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class Product extends ApiResource
 {
     /**
-     * @param string $id The ID of the Product to retrieve.
+     * @param array|string $id The ID of the Product to retrieve.
      * @param array|string|null $opts
      *
      * @return Product

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class Product extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the Product to retrieve.
+     * @param array|string $id The ID of the product to retrieve, or an options
+     *     array contianing an `id` key.
      * @param array|string|null $opts
      *
      * @return Product

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class Recipient extends ApiResource
 {
     /**
-     * @param string $id The ID of the recipient to retrieve.
+     * @param array|string $id The ID of the recipient to retrieve.
      * @param array|string|null $opts
      *
      * @return Recipient

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class Recipient extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the recipient to retrieve.
+     * @param array|string $id The ID of the recipient to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Recipient

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -23,7 +23,7 @@ class Refund extends ApiResource
 {
 
     /**
-     * @param string $id The ID of the refund to retrieve.
+     * @param array|string $id The ID of the refund to retrieve.
      * @param array|string|null $options
      *
      * @return Refund

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -23,7 +23,8 @@ class Refund extends ApiResource
 {
 
     /**
-     * @param array|string $id The ID of the refund to retrieve.
+     * @param array|string $id The ID of the refund to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $options
      *
      * @return Refund

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class SKU extends ApiResource
 {
     /**
-     * @param string $id The ID of the SKU to retrieve.
+     * @param array|string $id The ID of the SKU to retrieve.
      * @param array|string|null $opts
      *
      * @return SKU

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class SKU extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the SKU to retrieve.
+     * @param array|string $id The ID of the SKU to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return SKU

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -10,7 +10,8 @@ namespace Stripe;
 class Source extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the Source to retrieve.
+     * @param array|string $id The ID of the source to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Source

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -10,7 +10,7 @@ namespace Stripe;
 class Source extends ApiResource
 {
     /**
-     * @param string $id The ID of the Source to retrieve.
+     * @param array|string $id The ID of the Source to retrieve.
      * @param array|string|null $opts
      *
      * @return Source

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -21,7 +21,7 @@ class Subscription extends ApiResource
     const STATUS_UNPAID = 'unpaid';
 
     /**
-     * @param string $id The ID of the subscription to retrieve.
+     * @param array|string $id The ID of the subscription to retrieve.
      * @param array|string|null $opts
      *
      * @return Subscription

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -21,7 +21,8 @@ class Subscription extends ApiResource
     const STATUS_UNPAID = 'unpaid';
 
     /**
-     * @param array|string $id The ID of the subscription to retrieve.
+     * @param array|string $id The ID of the subscription to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Subscription

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -21,7 +21,7 @@ class SubscriptionItem extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the subscription item to retrieve.
+     * @param array|string $id The ID of the subscription item to retrieve.
      * @param array|string|null $opts
      *
      * @return SubscriptionItem

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -21,7 +21,8 @@ class SubscriptionItem extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the subscription item to retrieve.
+     * @param array|string $id The ID of the subscription item to retrieve, or
+     *     an options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return SubscriptionItem

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -13,7 +13,8 @@ class ThreeDSecure extends ApiResource
     }
 
     /**
-     * @param array|string $id The ID of the 3DS auth to retrieve.
+     * @param array|string $id The ID of the 3DS auth to retrieve, or an
+     *     options array contianing an `id` key.
      * @param array|string|null $options
      *
      * @return ThreeDSecure

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -13,7 +13,7 @@ class ThreeDSecure extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the 3DS auth to retrieve.
+     * @param array|string $id The ID of the 3DS auth to retrieve.
      * @param array|string|null $options
      *
      * @return ThreeDSecure

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -20,7 +20,8 @@ namespace Stripe;
 class Token extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the token to retrieve.
+     * @param array|string $id The ID of the token to retrieve, or an options
+     *     array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Token

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -20,7 +20,7 @@ namespace Stripe;
 class Token extends ApiResource
 {
     /**
-     * @param string $id The ID of the token to retrieve.
+     * @param array|string $id The ID of the token to retrieve.
      * @param array|string|null $opts
      *
      * @return Token

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -26,7 +26,8 @@ namespace Stripe;
 class Transfer extends ApiResource
 {
     /**
-     * @param array|string $id The ID of the transfer to retrieve.
+     * @param array|string $id The ID of the transfer to retrieve, or an
+     *     options array containing an `id` key.
      * @param array|string|null $opts
      *
      * @return Transfer

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -26,7 +26,7 @@ namespace Stripe;
 class Transfer extends ApiResource
 {
     /**
-     * @param string $id The ID of the transfer to retrieve.
+     * @param array|string $id The ID of the transfer to retrieve.
      * @param array|string|null $opts
      *
      * @return Transfer


### PR DESCRIPTION
Retrieve methods can take an array in some cases like when an expansion is requested. This patch updates documentation to better show that.

Fixes #346.

r? @bkrausz-stripe 