### PR TITLE
Adds count() implementation to AttachedObject

### DIFF
--- a/lib/AttachedObject.php
+++ b/lib/AttachedObject.php
@@ -2,6 +2,8 @@
 
 namespace Stripe;
 
+use Countable;
+
 /**
  * Class AttachedObject
  *
@@ -9,7 +11,7 @@ namespace Stripe;
  *
  * @package Stripe
  */
-class AttachedObject extends StripeObject
+class AttachedObject extends StripeObject implements Countable
 {
     /**
      * Updates this object.
@@ -27,5 +29,15 @@ class AttachedObject extends StripeObject
         foreach ($properties as $k => $v) {
             $this->$k = $v;
         }
+    }
+
+    /**
+     * Counts the number of elements in the AttachedObject instance.
+     *
+     * @return int the number of elements
+     */
+    public function count()
+    {
+        return count($this->_values);
     }
 }

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -295,6 +295,7 @@ class AccountTest extends TestCase
 
         $account->legal_entity->additional_owners[1] = array('first_name' => 'Jane');
         $account->save();
+        $this->assertSame(2, count($account->legal_entity->additional_owners));
         $this->assertSame('Jane', $account->legal_entity->additional_owners[1]->first_name);
     }
 

--- a/tests/AttachedObjectTest.php
+++ b/tests/AttachedObjectTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stripe;
+
+class AttachedObjectTest extends TestCase
+{
+    public function testCount()
+    {
+        $ao = new AttachedObject();
+        $this->assertSame(0, count($ao));
+
+        $ao['key1'] = 'value1';
+        $this->assertSame(1, count($ao));
+
+        $ao['key2'] = 'value2';
+        $this->assertSame(2, count($ao));
+    }
+}

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -68,11 +68,14 @@ class CustomerTest extends TestCase
     {
         $customer = self::createTestCustomer();
 
-        $customer->metadata['test'] = 'foo bar';
+        $customer->metadata['test1'] = 'foo';
+        $customer->metadata['test2'] = 'bar';
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);
-        $this->assertSame('foo bar', $updatedCustomer->metadata['test']);
+        $this->assertSame(2, count($updatedCustomer->metadata));
+        $this->assertSame('foo', $updatedCustomer->metadata['test1']);
+        $this->assertSame('bar', $updatedCustomer->metadata['test2']);
     }
 
     public function testDeleteMetadata()
@@ -83,7 +86,7 @@ class CustomerTest extends TestCase
         $customer->save();
 
         $updatedCustomer = Customer::retrieve($customer->id);
-        $this->assertSame(0, count($updatedCustomer->metadata->keys()));
+        $this->assertSame(0, count($updatedCustomer->metadata));
     }
 
     public function testUpdateSomeMetadata()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @gh-stripe @jlomas-stripe 

Replaces #329.

This PR adds a `count()` method to the `AttachedObject` class, which is used to store metadata as well as the infamous `additional_owners` attribute for account objects. Both `metadata` and `addtional_owners` can have a varying number of elements, so having a `count()` method available is useful.

This lets users write:

```php
count($account->additional_owners)
```

instead of:

```php
count($account->additional_owners->keys())
```
