### PR TITLE
Use Trusty distribution (required for HHVM)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,38 @@
 language: php
+sudo: false
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
-env:
-  - AUTOLOAD=1
-  - AUTOLOAD=0
+matrix:
+  include:
+    - php: 5.3
+      env: AUTOLOAD=1
+    - php: 5.3
+      env: AUTOLOAD=0
+    - php: 5.4
+      env: AUTOLOAD=1
+    - php: 5.4
+      env: AUTOLOAD=0
+    - php: 5.5
+      env: AUTOLOAD=1
+    - php: 5.5
+      env: AUTOLOAD=0
+    - php: 5.6
+      env: AUTOLOAD=1
+    - php: 5.6
+      env: AUTOLOAD=0
+    - php: 7.0
+      env: AUTOLOAD=1
+    - php: 7.0
+      env: AUTOLOAD=0
+    - php: 7.1
+      env: AUTOLOAD=1
+    - php: 7.1
+      env: AUTOLOAD=0
+    - php: hhvm
+      dist: trusty
+      env: AUTOLOAD=1
+    - php: hhvm
+      dist: trusty
+      env: AUTOLOAD=0
 
 script: ./build.php ${AUTOLOAD}
 after_script: ./vendor/bin/coveralls -v
-sudo: false


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Travis no longer supports HHVM on Precise (the default dist). This PR updates `.travis.yml` to use Trusty for HHVM builds.
