### PR TITLE
Let clients add info to the X-Stripe-Client-User-Agent header

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -36,6 +36,8 @@ class CurlClient implements ClientInterface
 
     protected $defaultOptions;
 
+    protected $userAgentInfo;
+
     /**
      * CurlClient constructor.
      *
@@ -52,11 +54,26 @@ class CurlClient implements ClientInterface
     public function __construct($defaultOptions = null)
     {
         $this->defaultOptions = $defaultOptions;
+        $this->initUserAgentInfo();
+    }
+
+    public function initUserAgentInfo()
+    {
+        $curlVersion = curl_version();
+        $this->userAgentInfo = array(
+            'httplib' =>  'curl ' . $curlVersion['version'],
+            'ssllib' => $curlVersion['ssl_version'],
+        );
     }
 
     public function getDefaultOptions()
     {
         return $this->defaultOptions;
+    }
+
+    public function getUserAgentInfo()
+    {
+        return $this->userAgentInfo;
     }
 
     // USER DEFINED TIMEOUTS

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -50,13 +50,16 @@ class ApiRequestorTest extends TestCase
         // no way to stub static methods with PHPUnit 4.x :(
         Stripe::setAppInfo('MyTestApp', '1.2.34', 'https://mytestapp.example');
         $apiKey = 'sk_test_notarealkey';
+        $clientInfo = array('httplib' => 'testlib 0.1.2');
 
-        $headers = $method->invoke(null, $apiKey);
+        $headers = $method->invoke(null, $apiKey, $clientInfo);
 
         $ua = json_decode($headers['X-Stripe-Client-User-Agent']);
         $this->assertSame($ua->application->name, 'MyTestApp');
         $this->assertSame($ua->application->version, '1.2.34');
         $this->assertSame($ua->application->url, 'https://mytestapp.example');
+
+        $this->assertSame($ua->httplib, 'testlib 0.1.2');
 
         $this->assertSame(
             $headers['User-Agent'],

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -23,6 +23,15 @@ class CurlClientTest extends TestCase
         $this->assertSame(0, $curl->getConnectTimeout());
     }
 
+    public function testUserAgentInfo()
+    {
+        $curl = new CurlClient();
+        $uaInfo = $curl->getUserAgentInfo();
+        $this->assertNotNull($uaInfo);
+        $this->assertNotNull($uaInfo['httplib']);
+        $this->assertNotNull($uaInfo['ssllib']);
+    }
+
     public function testDefaultOptions()
     {
         // make sure options array loads/saves properly


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

This is a followup to #332. Currently, we fill the `httplib` and `ssllib` keys in the `X-Stripe-Client-User-Agent` header with `curl_version()`, even if curl is not actually being used.

This PR lets HTTP clients provide an (optional) `getUserAgentInfo()` method. The method should return an array, and the contents of the array are appended to the `X-Stripe-Client-User-Agent` header, so HTTP clients are now responsible for providing information about whichever underlying library they use.
