### PR TITLE
Fix namespaces

### DIFF
--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -11,7 +11,7 @@ interface ClientInterface
      * @param array $params KV pairs for parameters. Can be nested for arrays and hashes
      * @param boolean $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CurlFile)
-     * @throws Error\Api & Error\ApiConnection
+     * @throws \Stripe\Error\Api & \Stripe\Error\ApiConnection
      * @return array($rawBody, $httpStatusCode, $httpHeader)
      */
     public function request($method, $absUrl, $headers, $params, $hasFile);


### PR DESCRIPTION
Currently, these refer to `\Stripe\HttpClient\Error\{Api,ApiConnection}`, which is not right and throws warnings in my IDE.