### PR TITLE
Power test suite with external API stub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,28 @@ matrix:
       dist: trusty
       env: AUTOLOAD=0
 
+env:
+  global:
+    - STRIPE_STUB_PORT=6065
+    - STRIPE_STUB_VERSION=0.1.1
+
 cache:
   directories:
     - $HOME/.composer/cache/files
+    - stripestubs
+
+before_install:
+  # Unpack and start the Stripe API stub so that the test suite can talk to it
+  - |
+    if [ ! -d "stripestubs/stripestub_${STRIPE_STUB_VERSION}" ]; then
+      mkdir -p stripestubs/stripestub_${STRIPE_STUB_VERSION}/
+      curl -L "https://github.com/brandur/stripestub/releases/download/v${STRIPE_STUB_VERSION}/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -o "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz"
+      tar -zxf "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -C "stripestubs/stripestub_${STRIPE_STUB_VERSION}/"
+    fi
+  - |
+    stripestubs/stripestub_${STRIPE_STUB_VERSION}/stripestub -port ${STRIPE_STUB_PORT} &
+    STRIPE_STUB_PID=$!
 
 script: ./build.php ${AUTOLOAD}
+
 after_script: ./vendor/bin/coveralls -v

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,23 @@ class TestCase extends \PHPUnit_Framework_TestCase
 {
     const API_KEY = 'tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I';
 
+    private static $stubPort = null;
+
     private $mock;
+
+    /**
+     * Looks for STRIPE_STUB_PORT in the environment and fails tests quickly
+     * if it's not present.
+     *
+     * @beforeClass
+     */
+    public static function checkStripeStubPort()
+    {
+        self::$stubPort = getenv('STRIPE_STUB_PORT');
+        if (!self::$stubPort) {
+            die("Please specify STRIPE_STUB_PORT. See README for setup instructions.");
+        }
+    }
 
     protected static function authorizeFromEnv()
     {
@@ -32,6 +48,25 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
         $this->mock = null;
         $this->call = 0;
+    }
+
+    /**
+     * Set the API URL back to whatever it was before stripestub was enabled.
+     */
+    protected function disableStripeStub()
+    {
+        Stripe::$apiBase = $this->oldApiBase;
+    }
+
+    /**
+     * Set the API URL to the location of a locally running instance of
+     * stripestub.
+     */
+    protected function enableStripeStub()
+    {
+        Stripe::setApiKey("sk_test_myValidKey");
+        $this->oldApiBase = Stripe::$apiBase;
+        Stripe::$apiBase = "http://localhost:" . self::$stubPort;
     }
 
     protected function mockRequest($method, $path, $params = array(), $return = array('id' => 'myId'), $rcode = 200)


### PR DESCRIPTION
Move to using an external API stub in the test suite instead of issuing live API calls so that we can have tests that run more quickly and more reliably.

For the time being, I've just converted the plan test suite over to use the new scheme.

This is an experimental prototype for demonstrative purposes and should not be merged.

See also:

* https://github.com/stripe/stripe-java/pull/384
* https://github.com/stripe/stripe-go/issues/424
* https://github.com/stripe/stripe-ruby/pull/553