### PR TITLE
Cache composer files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,9 @@ matrix:
       dist: trusty
       env: AUTOLOAD=0
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 script: ./build.php ${AUTOLOAD}
 after_script: ./vendor/bin/coveralls -v


### PR DESCRIPTION
It seems that the build's speed is pretty sizably impacted by installing
Composer dependencies from `build.php`. Lets try caching them in Travis
to see if we get any speed up.