### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -83,10 +83,10 @@ class Invoice extends ApiResource
     /**
      * @return Invoice The paid invoice.
      */
-    public function pay($opts = null)
+    public function pay($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/pay';
-        list($response, $opts) = $this->_request('post', $url, null, $opts);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -53,4 +53,31 @@ class InvoiceTest extends TestCase
         $invoices = Invoice::all();
         $this->assertGreaterThan(0, count($invoices));
     }
+
+    public function testPay()
+    {
+        $response = array(
+            'id' => 'in_foo',
+            'object' => 'invoice',
+            'paid' => false,
+        );
+        $this->mockRequest(
+            'GET',
+            '/v1/invoices/in_foo',
+            array(),
+            $response
+        );
+
+        $response['paid'] = true;
+        $this->mockRequest(
+            'POST',
+            '/v1/invoices/in_foo/pay',
+            array('source' => 'src_bar'),
+            $response
+        );
+
+        $invoice = Invoice::retrieve('in_foo');
+        $invoice->pay(array('source' => 'src_bar'));
+        $this->assertTrue($invoice->paid);
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @ark-stripe 

Users can now provide a `source` parameter when paying invoices, but the `pay` method currently does not let users provide any parameters. This PR fixes that.

Unfortunately, this is a breaking change because if someone is currently passing a `$opts` argument, they'll need to modify their code since it's now the second argument. I didn't want to add `$params` as the second argument since it would be inconsistent with ~every other method in the library.
