### PR TITLE
Add OAuth methods

### DIFF
--- a/examples/oauth.php
+++ b/examples/oauth.php
@@ -1,0 +1,55 @@
+<?php
+
+require('../init.php');
+
+\Stripe\Stripe::setApiKey(getenv('STRIPE_SECRET_KEY'));
+\Stripe\Stripe::setClientId(getenv('STRIPE_CLIENT_ID'));
+
+
+if (isset($_GET['code'])) {
+    // The user was redirected back from the OAuth form with an authorization code.
+    $code = $_GET['code'];
+
+    try {
+        $resp = \Stripe\OAuth::token(array(
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+        ));
+    } catch (\Stripe\Error\OAuth\OAuthBase $e) {
+        exit("Error: " . $e->getMessage());
+    }
+
+    $accountId = $resp->stripe_user_id;
+
+    echo "<p>Success! Account <code>$accountId</code> is connected.</p>\n";
+    echo "<p>Click <a href=\"?deauth=$accountId\">here</a> to disconnect the account.</p>\n";
+
+} elseif (isset($_GET['error'])) {
+    // The user was redirect back from the OAuth form with an error.
+    $error = $_GET['error'];
+    $error_description = $_GET['error_description'];
+
+    echo "<p>Error: code=$error, description=$error_description</p>\n";
+    echo "<p>Click <a href=\"?\">here</a> to restart the OAuth flow.</p>\n";
+
+} elseif (isset($_GET['deauth'])) {
+    // Deauthorization request
+    $accountId = $_GET['deauth'];
+
+    try {
+        \Stripe\OAuth::deauthorize(array(
+            'stripe_user_id' => $accountId,
+        ));
+    } catch (\Stripe\Error\OAuth\OAuthBase $e) {
+        exit("Error: " . $e->getMessage());
+    }
+
+    echo "<p>Success! Account <code>$accountId</code> is disonnected.</p>\n";
+    echo "<p>Click <a href=\"?\">here</a> to restart the OAuth flow.</p>\n";
+
+} else {
+    $url = \Stripe\OAuth::authorizeUrl(array(
+        'scope' => 'read_only',
+    ));
+    echo "<a href=\"$url\">Connect with Stripe</a>\n";
+}

--- a/init.php
+++ b/init.php
@@ -26,6 +26,14 @@ require(dirname(__FILE__) . '/lib/Error/Permission.php');
 require(dirname(__FILE__) . '/lib/Error/RateLimit.php');
 require(dirname(__FILE__) . '/lib/Error/SignatureVerification.php');
 
+// OAuth errors
+require(dirname(__FILE__) . '/lib/Error/OAuth/OAuthBase.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidGrant.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidRequest.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidScope.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedGrantType.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedResponseType.php');
+
 // Plumbing
 require(dirname(__FILE__) . '/lib/ApiResponse.php');
 require(dirname(__FILE__) . '/lib/JsonSerializable.php');
@@ -76,5 +84,10 @@ require(dirname(__FILE__) . '/lib/ThreeDSecure.php');
 require(dirname(__FILE__) . '/lib/Token.php');
 require(dirname(__FILE__) . '/lib/Transfer.php');
 require(dirname(__FILE__) . '/lib/TransferReversal.php');
+
+// OAuth
+require(dirname(__FILE__) . '/lib/OAuth.php');
+
+// Webhooks
 require(dirname(__FILE__) . '/lib/Webhook.php');
 require(dirname(__FILE__) . '/lib/WebhookSignature.php');

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -130,4 +130,13 @@ class Account extends ApiResource
     {
         return self::_all($params, $opts);
     }
+
+    public function deauthorize($clientId = null, $opts = null)
+    {
+        $params = array(
+            'client_id' => $clientId,
+            'stripe_user_id' => $this->id,
+        );
+        OAuth::deauthorize($params, $opts);
+    }
 }

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -84,7 +84,7 @@ class ApiRequestor
      *    hitting the API.
      * @throws Error\Api otherwise.
      */
-    public function handleApiError($rbody, $rcode, $rheaders, $resp)
+    public function handleErrorResponse($rbody, $rcode, $rheaders, $resp)
     {
         if (!is_array($resp) || !isset($resp['error'])) {
             $msg = "Invalid response object from API: $rbody "
@@ -92,33 +92,67 @@ class ApiRequestor
             throw new Error\Api($msg, $rcode, $rbody, $resp, $rheaders);
         }
 
-        $error = $resp['error'];
-        $msg = isset($error['message']) ? $error['message'] : null;
-        $param = isset($error['param']) ? $error['param'] : null;
-        $code = isset($error['code']) ? $error['code'] : null;
+        $errorData = $resp['error'];
+
+        $error = null;
+        if (is_string($errorData)) {
+            $error = self::_specificOAuthError($rbody, $rcode, $rheaders, $resp, $errorData);
+        }
+        if (!$error) {
+            $error = self::_specificAPIError($rbody, $rcode, $rheaders, $resp, $errorData);
+        }
+
+        throw $error;
+    }
+
+    private static function _specificAPIError($rbody, $rcode, $rheaders, $resp, $errorData)
+    {
+        $msg = isset($errorData['message']) ? $errorData['message'] : null;
+        $param = isset($errorData['param']) ? $errorData['param'] : null;
+        $code = isset($errorData['code']) ? $errorData['code'] : null;
 
         switch ($rcode) {
             case 400:
                 // 'rate_limit' code is deprecated, but left here for backwards compatibility
                 // for API versions earlier than 2015-09-08
                 if ($code == 'rate_limit') {
-                    throw new Error\RateLimit($msg, $param, $rcode, $rbody, $resp, $rheaders);
+                    return new Error\RateLimit($msg, $param, $rcode, $rbody, $resp, $rheaders);
                 }
 
                 // intentional fall-through
             case 404:
-                throw new Error\InvalidRequest($msg, $param, $rcode, $rbody, $resp, $rheaders);
+                return new Error\InvalidRequest($msg, $param, $rcode, $rbody, $resp, $rheaders);
             case 401:
-                throw new Error\Authentication($msg, $rcode, $rbody, $resp, $rheaders);
+                return new Error\Authentication($msg, $rcode, $rbody, $resp, $rheaders);
             case 402:
-                throw new Error\Card($msg, $param, $code, $rcode, $rbody, $resp, $rheaders);
+                return new Error\Card($msg, $param, $code, $rcode, $rbody, $resp, $rheaders);
             case 403:
-                throw new Error\Permission($msg, $rcode, $rbody, $resp, $rheaders);
+                return new Error\Permission($msg, $rcode, $rbody, $resp, $rheaders);
             case 429:
-                throw new Error\RateLimit($msg, $param, $rcode, $rbody, $resp, $rheaders);
+                return new Error\RateLimit($msg, $param, $rcode, $rbody, $resp, $rheaders);
             default:
-                throw new Error\Api($msg, $rcode, $rbody, $resp, $rheaders);
+                return new Error\Api($msg, $rcode, $rbody, $resp, $rheaders);
         }
+    }
+
+    private static function _specificOAuthError($rbody, $rcode, $rheaders, $resp, $errorCode)
+    {
+        $description = isset($resp['error_description']) ? $resp['error_description'] : $errorCode;
+
+        switch ($errorCode) {
+            case 'invalid_grant':
+                return new Error\OAuth\InvalidGrant($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
+            case 'invalid_request':
+                return new Error\OAuth\InvalidRequest($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
+            case 'invalid_scope':
+                return new Error\OAuth\InvalidScope($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
+            case 'unsupported_grant_type':
+                return new Error\OAuth\UnsupportedGrantType($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
+            case 'unsupported_response_type':
+                return new Error\OAuth\UnsupportedResponseType($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
+        }
+
+        return null;
     }
 
     private static function _formatAppInfo($appInfo)
@@ -270,7 +304,7 @@ class ApiRequestor
         }
 
         if ($rcode < 200 || $rcode >= 300) {
-            $this->handleApiError($rbody, $rcode, $rheaders, $resp);
+            $this->handleErrorResponse($rbody, $rcode, $rheaders, $resp);
         }
         return $resp;
     }

--- a/lib/Error/OAuth/InvalidGrant.php
+++ b/lib/Error/OAuth/InvalidGrant.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * InvalidGrant is raised when a specified code doesn't exist, is
+ * expired, has been used, or doesn't belong to you; a refresh token doesn't
+ * exist, or doesn't belong to you; or if an API key's mode (live or test)
+ * doesn't match the mode of a code or refresh token.
+ */
+class InvalidGrant extends OAuthBase
+{
+}

--- a/lib/Error/OAuth/InvalidRequest.php
+++ b/lib/Error/OAuth/InvalidRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * InvalidRequest is raised when a code, refresh token, or grant type
+ * parameter is not provided, but was required.
+ */
+class InvalidRequest extends OAuthBase
+{
+}

--- a/lib/Error/OAuth/InvalidScope.php
+++ b/lib/Error/OAuth/InvalidScope.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * InvalidScope is raised when an invalid scope parameter is provided.
+ */
+class InvalidScope extends OAuthBase
+{
+}

--- a/lib/Error/OAuth/OAuthBase.php
+++ b/lib/Error/OAuth/OAuthBase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+class OAuthBase extends \Stripe\Error\Base
+{
+    public function __construct(
+        $code,
+        $description,
+        $httpStatus = null,
+        $httpBody = null,
+        $jsonBody = null,
+        $httpHeaders = null
+    ) {
+        parent::__construct($description, $httpStatus, $httpBody, $jsonBody, $httpHeaders);
+        $this->code = $code;
+    }
+
+    public function getErrorCode()
+    {
+        return $this->code;
+    }
+}

--- a/lib/Error/OAuth/UnsupportedGrantType.php
+++ b/lib/Error/OAuth/UnsupportedGrantType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * UnsupportedGrantType is raised when an unuspported grant type
+ * parameter is specified.
+ */
+class UnsupportedGrantType extends OAuthBase
+{
+}

--- a/lib/Error/OAuth/UnsupportedResponseType.php
+++ b/lib/Error/OAuth/UnsupportedResponseType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * UnsupportedResponseType is raised when an unsupported response type
+ * parameter is specified.
+ */
+class UnsupportedResponseType extends OAuthBase
+{
+}

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -131,16 +131,16 @@ class CurlClient implements ClientInterface
             }
             $opts[CURLOPT_HTTPGET] = 1;
             if (count($params) > 0) {
-                $encoded = self::encode($params);
+                $encoded = Util\Util::urlEncode($params);
                 $absUrl = "$absUrl?$encoded";
             }
         } elseif ($method == 'post') {
             $opts[CURLOPT_POST] = 1;
-            $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : self::encode($params);
+            $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : Util\Util::urlEncode($params);
         } elseif ($method == 'delete') {
             $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
             if (count($params) > 0) {
-                $encoded = self::encode($params);
+                $encoded = Util\Util::urlEncode($params);
                 $absUrl = "$absUrl?$encoded";
             }
         } else {
@@ -254,46 +254,5 @@ class CurlClient implements ClientInterface
     private static function caBundle()
     {
         return dirname(__FILE__) . '/../../data/ca-certificates.crt';
-    }
-
-    /**
-     * @param array $arr An map of param keys to values.
-     * @param string|null $prefix
-     *
-     * Only public for testability, should not be called outside of CurlClient
-     *
-     * @return string A querystring, essentially.
-     */
-    public static function encode($arr, $prefix = null)
-    {
-        if (!is_array($arr)) {
-            return $arr;
-        }
-
-        $r = array();
-        foreach ($arr as $k => $v) {
-            if (is_null($v)) {
-                continue;
-            }
-
-            if ($prefix) {
-                if ($k !== null && (!is_int($k) || is_array($v))) {
-                    $k = $prefix."[".$k."]";
-                } else {
-                    $k = $prefix."[]";
-                }
-            }
-
-            if (is_array($v)) {
-                $enc = self::encode($v, $k);
-                if ($enc) {
-                    $r[] = $enc;
-                }
-            } else {
-                $r[] = urlencode($k)."=".urlencode($v);
-            }
-        }
-
-        return implode("&", $r);
     }
 }

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -15,8 +15,7 @@ abstract class OAuth {
         if (!array_key_exists('response_type', $params)) {
             $params['response_type'] = 'code';
         }
-        // TODO: move encode out of CurlClient (and into Util probably)
-        $query = HttpClient\CurlClient::encode($params);
+        $query = Util\Util::urlEncode($params);
 
         return $base . '/oauth/authorize?' . $query;
     }

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -2,7 +2,8 @@
 
 namespace Stripe;
 
-abstract class OAuth {
+abstract class OAuth
+{
     /**
      * Generates a URL to Stripe's OAuth form.
      *
@@ -80,7 +81,7 @@ abstract class OAuth {
     {
         $clientId = ($params && array_key_exists('client_id', $params)) ? $params['client_id'] : null;
         if ($clientId === null) {
-          $clientId = Stripe::getClientId();
+            $clientId = Stripe::getClientId();
         }
         if ($clientId === null) {
             $msg = 'No client_id provided.  (HINT: set your client_id using '

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -3,6 +3,14 @@
 namespace Stripe;
 
 abstract class OAuth {
+    /**
+     * Generates a URL to Stripe's OAuth form.
+     *
+     * @param array|null $params
+     * @param array|null $opts
+     *
+     * @return string The URL to Stripe's OAuth form.
+     */
     public static function authorizeUrl($params = null, $opts = null)
     {
         if (!$params) {
@@ -20,6 +28,15 @@ abstract class OAuth {
         return $base . '/oauth/authorize?' . $query;
     }
 
+    /**
+     * Use an authoriztion code to connect an account to your platform and
+     * fetch the user's credentials.
+     *
+     * @param array|null $params
+     * @param array|null $opts
+     *
+     * @return StripeObject Object containing the response from the API.
+     */
     public static function token($params = null, $opts = null)
     {
         $base = ($opts && array_key_exists('connect_base', $opts)) ? $opts['connect_base'] : Stripe::$connectBase;
@@ -33,6 +50,14 @@ abstract class OAuth {
         return Util\Util::convertToStripeObject($response->json, $opts);
     }
 
+    /**
+     * Disconnects an account from your platform.
+     *
+     * @param array|null $params
+     * @param array|null $opts
+     *
+     * @return StripeObject Object containing the response from the API.
+     */
     public static function deauthorize($params = null, $opts = null)
     {
         if (!$params) {

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -12,8 +12,14 @@ class Stripe
     // @var string The Stripe API key to be used for requests.
     public static $apiKey;
 
+    // @var string The Stripe client_id to be used for Connect requests.
+    public static $clientId;
+
     // @var string The base URL for the Stripe API.
     public static $apiBase = 'https://api.stripe.com';
+
+    // @var string The base URL for the OAuth API.
+    public static $connectBase = 'https://connect.stripe.com';
 
     // @var string The base URL for the Stripe API uploads endpoint.
     public static $apiUploadBase = 'https://uploads.stripe.com';
@@ -45,6 +51,14 @@ class Stripe
     }
 
     /**
+     * @return string The client_id used for Connect requests.
+     */
+    public static function getClientId()
+    {
+        return self::$clientId;
+    }
+
+    /**
      * @return Util\LoggerInterface The logger to which the library will
      *   produce messages.
      */
@@ -73,6 +87,16 @@ class Stripe
     public static function setApiKey($apiKey)
     {
         self::$apiKey = $apiKey;
+    }
+
+    /**
+     * Sets the client_id to be used for Connect requests.
+     *
+     * @param string $clientId
+     */
+    public static function setClientId($clientId)
+    {
+        self::$clientId = $clientId;
     }
 
     /**

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -175,4 +175,43 @@ abstract class Util
             return ($result == 0);
         }
     }
+
+    /**
+     * @param array $arr A map of param keys to values.
+     * @param string|null $prefix
+     *
+     * @return string A querystring, essentially.
+     */
+    public static function urlEncode($arr, $prefix = null)
+    {
+        if (!is_array($arr)) {
+            return $arr;
+        }
+
+        $r = array();
+        foreach ($arr as $k => $v) {
+            if (is_null($v)) {
+                continue;
+            }
+
+            if ($prefix) {
+                if ($k !== null && (!is_int($k) || is_array($v))) {
+                    $k = $prefix."[".$k."]";
+                } else {
+                    $k = $prefix."[]";
+                }
+            }
+
+            if (is_array($v)) {
+                $enc = self::urlEncode($v, $k);
+                if ($enc) {
+                    $r[] = $enc;
+                }
+            } else {
+                $r[] = urlencode($k)."=".urlencode($v);
+            }
+        }
+
+        return implode("&", $r);
+    }
 }

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -328,4 +328,36 @@ class AccountTest extends TestCase
         $this->assertSame('login_link', $loginLink->object);
         $this->assertSame('Stripe\LoginLink', get_class($loginLink));
     }
+
+    public function testDeauthorize()
+    {
+        Stripe::setClientId('ca_test');
+
+        $accountId = 'acct_test_deauth';
+        $mockAccount = array(
+            'id' => $accountId,
+            'object' => 'account',
+        );
+
+        $this->mockRequest('GET', "/v1/accounts/$accountId", array(), $mockAccount);
+
+        $this->mockRequest(
+            'POST',
+            '/oauth/deauthorize',
+            array(
+                'client_id' => 'ca_test',
+                'stripe_user_id' => $accountId,
+            ),
+            array(
+                'stripe_user_id' => $accountId,
+            ),
+            200,
+            Stripe::$connectBase
+        );
+
+        $account = Account::retrieve($accountId);
+        $account->deauthorize();
+
+        Stripe::setClientId(null);
+    }
 }

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -199,6 +199,5 @@ class ApiRequestorTest extends TestCase
         } catch (\Exception $e) {
             $this->fail("Unexpected exception: " . get_class($e));
         }
-
     }
 }

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -68,4 +68,137 @@ class ApiRequestorTest extends TestCase
 
         $this->assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
+
+    public function testErrorInvalidRequest()
+    {
+        $this->mockRequest(
+            'POST',
+            '/v1/charges',
+            array(),
+            array(
+                'error' => array(
+                    'type' => 'invalid_request_error',
+                    'message' => 'Missing id',
+                    'param' => 'id',
+                ),
+            ),
+            400
+        );
+
+        try {
+            Charge::create();
+            $this->fail("Did not raise error");
+        } catch (Error\InvalidRequest $e) {
+            $this->assertSame('Missing id', $e->getMessage());
+            $this->assertSame('id', $e->getStripeParam());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
+    public function testErrorAuthentication()
+    {
+        $this->mockRequest(
+            'POST',
+            '/v1/charges',
+            array(),
+            array(
+                'error' => array(
+                    'type' => 'invalid_request_error',
+                    'message' => 'You did not provide an API key.',
+                ),
+            ),
+            401
+        );
+
+        try {
+            Charge::create();
+            $this->fail("Did not raise error");
+        } catch (Error\Authentication $e) {
+            $this->assertSame('You did not provide an API key.', $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
+    public function testErrorCard()
+    {
+        $this->mockRequest(
+            'POST',
+            '/v1/charges',
+            array(),
+            array(
+                'error' => array(
+                    'type' => 'card_error',
+                    'message' => 'Your card was declined.',
+                    'code' => 'card_declined',
+                    'decline_code' => 'generic_decline',
+                    'charge' => 'ch_declined_charge',
+                ),
+            ),
+            402
+        );
+
+        try {
+            Charge::create();
+            $this->fail("Did not raise error");
+        } catch (Error\Card $e) {
+            $this->assertSame('Your card was declined.', $e->getMessage());
+            $this->assertSame('card_declined', $e->getStripeCode());
+            $this->assertSame('generic_decline', $e->getDeclineCode());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
+    public function testErrorOAuthInvalidRequest()
+    {
+        $this->mockRequest(
+            'POST',
+            '/oauth/token',
+            array(),
+            array(
+                'error' => 'invalid_request',
+                'error_description' => 'No grant type specified',
+            ),
+            400,
+            Stripe::$connectBase
+        );
+
+        try {
+            OAuth::token();
+            $this->fail("Did not raise error");
+        } catch (Error\OAuth\InvalidRequest $e) {
+            $this->assertSame('invalid_request', $e->getErrorCode());
+            $this->assertSame('No grant type specified', $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
+    public function testErrorOAuthInvalidGrant()
+    {
+        $this->mockRequest(
+            'POST',
+            '/oauth/token',
+            array(),
+            array(
+                'error' => 'invalid_grant',
+                'error_description' => 'This authorization code has already been used. All tokens issued with this code have been revoked.',
+            ),
+            400,
+            Stripe::$connectBase
+        );
+
+        try {
+            OAuth::token();
+            $this->fail("Did not raise error");
+        } catch (Error\OAuth\InvalidGrant $e) {
+            $this->assertSame('invalid_grant', $e->getErrorCode());
+            $this->assertSame('This authorization code has already been used. All tokens issued with this code have been revoked.', $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+
+    }
 }

--- a/tests/CurlClientTest.php
+++ b/tests/CurlClientTest.php
@@ -57,48 +57,6 @@ class CurlClientTest extends TestCase
         $withBadClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
     }
 
-    public function testEncode()
-    {
-        $a = array(
-            'my' => 'value',
-            'that' => array('your' => 'example'),
-            'bar' => 1,
-            'baz' => null
-        );
-
-        $enc = CurlClient::encode($a);
-        $this->assertSame('my=value&that%5Byour%5D=example&bar=1', $enc);
-
-        $a = array('that' => array('your' => 'example', 'foo' => null));
-        $enc = CurlClient::encode($a);
-        $this->assertSame('that%5Byour%5D=example', $enc);
-
-        $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
-        $enc = CurlClient::encode($a);
-        $this->assertSame('that=example&foo%5B%5D=bar&foo%5B%5D=baz', $enc);
-
-        $a = array(
-            'my' => 'value',
-            'that' => array('your' => array('cheese', 'whiz', null)),
-            'bar' => 1,
-            'baz' => null
-        );
-
-        $enc = CurlClient::encode($a);
-        $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
-              . '&that%5Byour%5D%5B%5D=whiz&bar=1';
-        $this->assertSame($expected, $enc);
-
-        // Ignores an empty array
-        $enc = CurlClient::encode(array('foo' => array(), 'bar' => 'baz'));
-        $expected = 'bar=baz';
-        $this->assertSame($expected, $enc);
-
-        $a = array('foo' => array(array('bar' => 'baz'), array('bar' => 'bin')));
-        $enc = CurlClient::encode($a);
-        $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
-    }
-
     public function testSslOption()
     {
         // make sure options array loads/saves properly

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Stripe;
+
+class OAuthTest extends TestCase
+{
+    /**
+     * @before
+     */
+    public function setUpClientId()
+    {
+        Stripe::setClientId('ca_test');
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownClientId()
+    {
+        Stripe::setClientId(null);
+    }
+
+    public function testAuthorizeUrl()
+    {
+        $uriStr = OAuth::authorizeUrl(array(
+            'scope' => 'read_write',
+            'state' => 'csrf_token',
+            'stripe_user' => array(
+                'email' => 'test@example.com',
+                'url' => 'https://example.com/profile/test',
+                'country' => 'US',
+            ),
+        ));
+
+        $uri = parse_url($uriStr);
+        parse_str($uri['query'], $params);
+
+        $this->assertSame('https', $uri['scheme']);
+        $this->assertSame('connect.stripe.com', $uri['host']);
+        $this->assertSame('/oauth/authorize', $uri['path']);
+
+        $this->assertSame('ca_test', $params['client_id']);
+        $this->assertSame('read_write', $params['scope']);
+        $this->assertSame('test@example.com', $params['stripe_user']['email']);
+        $this->assertSame('https://example.com/profile/test', $params['stripe_user']['url']);
+        $this->assertSame('US', $params['stripe_user']['country']);
+    }
+
+    public function testToken()
+    {
+        $this->mockRequest(
+            'POST',
+            '/oauth/token',
+            array(
+                'grant_type' => 'authorization_code',
+                'code' => 'this_is_an_authorization_code',
+            ),
+            array(
+                'access_token' => 'sk_access_token',
+                'scope' => 'read_only',
+                'livemode' => false,
+                'token_type' => 'bearer',
+                'refresh_token' => 'sk_refresh_token',
+                'stripe_user_id' => 'acct_test',
+                'stripe_publishable_key' => 'pk_test',
+            ),
+            200,
+            Stripe::$connectBase
+        );
+
+        $resp = OAuth::token(array(
+            'grant_type' => 'authorization_code',
+            'code' => 'this_is_an_authorization_code',
+        ));
+        $this->assertSame('sk_access_token', $resp->access_token);
+    }
+
+    public function testDeauthorize()
+    {
+        $this->mockRequest(
+            'POST',
+            '/oauth/deauthorize',
+            array(
+                'client_id' => 'ca_test',
+                'stripe_user_id' => 'acct_test_deauth',
+            ),
+            array(
+                'stripe_user_id' => 'acct_test_deauth',
+            ),
+            200,
+            Stripe::$connectBase
+        );
+
+        $resp = OAuth::deauthorize(array(
+                'stripe_user_id' => 'acct_test_deauth',
+        ));
+        $this->assertSame('acct_test_deauth', $resp->stripe_user_id);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,12 +34,12 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->call = 0;
     }
 
-    protected function mockRequest($method, $path, $params = array(), $return = array('id' => 'myId'), $rcode = 200)
+    protected function mockRequest($method, $path, $params = array(), $return = array('id' => 'myId'), $rcode = 200, $base = 'https://api.stripe.com')
     {
         $mock = $this->setUpMockRequest();
         $mock->expects($this->at($this->call++))
              ->method('request')
-             ->with(strtolower($method), 'https://api.stripe.com' . $path, $this->anything(), $params, false)
+             ->with(strtolower($method), $base . $path, $this->anything(), $params, false)
              ->willReturn(array(json_encode($return), $rcode, array()));
     }
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -42,4 +42,46 @@ class UtilTest extends TestCase
         $x = true;
         $this->assertSame(Util\Util::utf8($x), $x);
     }
+
+    public function testUrlEncode()
+    {
+        $a = array(
+            'my' => 'value',
+            'that' => array('your' => 'example'),
+            'bar' => 1,
+            'baz' => null
+        );
+
+        $enc = Util\Util::urlEncode($a);
+        $this->assertSame('my=value&that%5Byour%5D=example&bar=1', $enc);
+
+        $a = array('that' => array('your' => 'example', 'foo' => null));
+        $enc = Util\Util::urlEncode($a);
+        $this->assertSame('that%5Byour%5D=example', $enc);
+
+        $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
+        $enc = Util\Util::urlEncode($a);
+        $this->assertSame('that=example&foo%5B%5D=bar&foo%5B%5D=baz', $enc);
+
+        $a = array(
+            'my' => 'value',
+            'that' => array('your' => array('cheese', 'whiz', null)),
+            'bar' => 1,
+            'baz' => null
+        );
+
+        $enc = Util\Util::urlEncode($a);
+        $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
+              . '&that%5Byour%5D%5B%5D=whiz&bar=1';
+        $this->assertSame($expected, $enc);
+
+        // Ignores an empty array
+        $enc = Util\Util::urlEncode(array('foo' => array(), 'bar' => 'baz'));
+        $expected = 'bar=baz';
+        $this->assertSame($expected, $enc);
+
+        $a = array('foo' => array(array('bar' => 'baz'), array('bar' => 'bin')));
+        $enc = Util\Util::urlEncode($a);
+        $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR adds support for sending requests to the OAuth API directly from the PHP library.

I've tried to stay as close as possible to the existing Ruby and Python implementations:
- https://github.com/stripe/stripe-ruby/pull/523
- https://github.com/stripe/stripe-python/pull/323

Nothing major to note, except that I moved the `CurlClient::encode` function to `Util\Util::urlEncode` because I needed to use it (for `authorizeUrl`) and it made little sense to have `OAuth` depend on `CurlClient`. Now both `OAuth` and `CurlClient` depend on `Util`, which seems more reasonable IMHO.
