### PR TITLE
Fixes phpdoc declared type to qualify namespace correctly

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -56,7 +56,7 @@ class Collection extends ApiResource
     }
 
     /**
-     * @return AutoPagingIterator An iterator that can be used to iterate
+     * @return Util\AutoPagingIterator An iterator that can be used to iterate
      *    across all objects across all pages. As page boundaries are
      *    encountered, the next page will be fetched automatically for
      *    continued iteration.


### PR DESCRIPTION
When using `Collection#autoPagingIterator()` I get type warnings in PhpStorm as the `@return` type is hinted incorrectly.

This will fix this warning in PhpStorm inside Collection:

![15bcaa](https://user-images.githubusercontent.com/496145/28821151-47af0d18-76ac-11e7-841c-0e82abea9780.png)

And this warning when using the `autoPagingIterator` method to fetch the iterator, for example:

![113eba](https://user-images.githubusercontent.com/496145/28821187-6b718cda-76ac-11e7-94de-bb407ac234f7.png)
