### PR TITLE
Submit updated address_kana and address_kanji for Custom accounts

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -28,7 +28,7 @@ class StripeObject implements ArrayAccess, JsonSerializable
         self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
         self::$nestedUpdatableAttributes = new Util\Set(array(
             'metadata', 'legal_entity', 'address', 'dob', 'payout_schedule', 'transfer_schedule', 'verification',
-            'tos_acceptance', 'personal_address',
+            'tos_acceptance', 'personal_address', 'address_kana', 'address_kanji',
             // will make the array into an AttachedObject: weird, but works for now
             'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly
             'inventory',


### PR DESCRIPTION
Before that change, updating the fields under the `address_kana` or `address_kanji` in the `legal_entity` hash of a Custom JP account would not do anything as the data was ignored.

Fixes https://github.com/stripe/stripe-php/issues/366

r? @brandur-stripe 