### PR TITLE
Add missing invalid_client OAuth error

### DIFF
--- a/init.php
+++ b/init.php
@@ -28,6 +28,7 @@ require(dirname(__FILE__) . '/lib/Error/SignatureVerification.php');
 
 // OAuth errors
 require(dirname(__FILE__) . '/lib/Error/OAuth/OAuthBase.php');
+require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidClient.php');
 require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidGrant.php');
 require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidRequest.php');
 require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidScope.php');

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -140,6 +140,8 @@ class ApiRequestor
         $description = isset($resp['error_description']) ? $resp['error_description'] : $errorCode;
 
         switch ($errorCode) {
+            case 'invalid_client':
+                return new Error\OAuth\InvalidClient($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
             case 'invalid_grant':
                 return new Error\OAuth\InvalidGrant($errorCode, $description, $rcode, $rbody, $resp, $rheaders);
             case 'invalid_request':

--- a/lib/Error/OAuth/InvalidClient.php
+++ b/lib/Error/OAuth/InvalidClient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stripe\Error\OAuth;
+
+/**
+ * InvalidClient is raised when authentication fails.
+ */
+class InvalidClient extends OAuthBase
+{
+}

--- a/tests/ApiRequestorTest.php
+++ b/tests/ApiRequestorTest.php
@@ -176,6 +176,31 @@ class ApiRequestorTest extends TestCase
         }
     }
 
+    public function testErrorOAuthInvalidClient()
+    {
+        $this->mockRequest(
+            'POST',
+            '/oauth/token',
+            array(),
+            array(
+                'error' => 'invalid_client',
+                'error_description' => 'No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter.',
+            ),
+            401,
+            Stripe::$connectBase
+        );
+
+        try {
+            OAuth::token();
+            $this->fail("Did not raise error");
+        } catch (Error\OAuth\InvalidClient $e) {
+            $this->assertSame('invalid_client', $e->getErrorCode());
+            $this->assertSame('No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter.', $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
     public function testErrorOAuthInvalidGrant()
     {
         $this->mockRequest(


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries

Adds support for the invalid_client OAuth error.

Cf. https://github.com/stripe/stripe-ruby/pull/562
