### PR TITLE
Add `shipping` to the list of nested attributes that can be updated

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -28,7 +28,7 @@ class StripeObject implements ArrayAccess, JsonSerializable
         self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
         self::$nestedUpdatableAttributes = new Util\Set(array(
             'metadata', 'legal_entity', 'address', 'dob', 'payout_schedule', 'transfer_schedule', 'verification',
-            'tos_acceptance', 'personal_address', 'address_kana', 'address_kanji',
+            'tos_acceptance', 'personal_address', 'address_kana', 'address_kanji', 'shipping',
             // will make the array into an AttachedObject: weird, but works for now
             'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly
             'inventory',


### PR DESCRIPTION
This ensures that updating the shipping details on an order and then saving the order properly updates the order.

The issue is that when doing this, updating a customer's shipping address and passing only one field such as `name` does not work anymore.

This PR is here to clarify what's going on with `nestedUpdatableAttributes` and what the right approach would be.

@brandur-stripe do you know why the order update would start to work and not the customer one?

Here's some example code where `customer[shipping][name]` and `customer[shipping][address][line1]` are set already on the customer:

```
$customer = \Stripe\Customer::retrieve("cus_XXXXXX");
$customer->shipping->name = "myname";
$customerUpdated = $customer->save();
```

It worked before this PR and now returns an error:
> Missing required param: shipping[address].

I think this is expected behaviour and we've seen similar issues with the Charge object before but the fact that it used to work leads to two questions:
* is this a breaking change?
* why was it working on the customer and not Order?