### PR TITLE
Flip to Trusty as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ matrix:
   include:
     - php: 5.3
       env: AUTOLOAD=1
+      dist: precise
     - php: 5.3
       env: AUTOLOAD=0
+      dist: precise
     - php: 5.4
       env: AUTOLOAD=1
     - php: 5.4
@@ -28,10 +30,8 @@ matrix:
     - php: 7.1
       env: AUTOLOAD=0
     - php: hhvm
-      dist: trusty
       env: AUTOLOAD=1
     - php: hhvm
-      dist: trusty
       env: AUTOLOAD=0
 
 cache:


### PR DESCRIPTION
Travis has recently changed so that Trusty is the default distribution. This is failing some of our build matrix.

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

PHP 5.3 doesn't run on Trusty, so specify Precise for those two builds.

Remove the Trusty tags where we've explicitly specified them. They're not longer needed.

cc @stripe/api-libraries