### PR TITLE
Set correct mapping for FileUpload

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -82,7 +82,7 @@ abstract class Util
             'invoice' => 'Stripe\\Invoice',
             'invoiceitem' => 'Stripe\\InvoiceItem',
             'event' => 'Stripe\\Event',
-            'file' => 'Stripe\\FileUpload',
+            'file_upload' => 'Stripe\\FileUpload',
             'token' => 'Stripe\\Token',
             'transfer' => 'Stripe\\Transfer',
             'transfer_reversal' => 'Stripe\\TransferReversal',

--- a/tests/FileUploadTest.php
+++ b/tests/FileUploadTest.php
@@ -17,6 +17,7 @@ class FileUploadTest extends TestCase
         fclose($fp);
         $this->assertSame(95, $file->size);
         $this->assertSame('png', $file->type);
+        $this->assertInstanceOf('Stripe\\FileUpload', $file);
     }
 
     public function testCreateAndRetrieveCurlFile()


### PR DESCRIPTION
Just found a bug while working with strict return types. Also, according to [the docs](https://stripe.com/docs/api/curl#file_uploads), `"object": "file_upload"` gets returned:

```
{
  "id": "file_1B44w82IJJWDZPe7TAatUjAc",
  "object": "file_upload",
  "created": 1505901368,
  "purpose": "identity_document",
  "size": 158860,
  "type": "png",
  "url": "https://stripe-upload-api.s3.amazonaws.com/uploads/file_1B44w82IJJWDZPe7TAatUjAc?AWSAccessKeyId=KEY_ID\u0026Expires=TIMESTAMP\u0026Signature=SIGNATURE"
}
```

Therefore changed the mapping from `file` to `file_upload`.