### PR TITLE
Stop testing Bitcoin APIs

### DIFF
--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -4,14 +4,16 @@ namespace Stripe;
 
 /**
  * Class BitcoinReceiver
- *
- * @package Stripe
+
+ * @deprecated Please use sources instead.
  */
 class BitcoinReceiver extends ExternalAccount
 {
     /**
      * @return string The class URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
+     *
+     * @deprecated Please use sources instead.
      */
     public static function classUrl()
     {
@@ -21,6 +23,8 @@ class BitcoinReceiver extends ExternalAccount
     /**
      * @return string The instance URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
+     *
+     * @deprecated Please use sources instead.
      */
     public function instanceUrl()
     {
@@ -42,6 +46,8 @@ class BitcoinReceiver extends ExternalAccount
      * @param array|string|null $opts
      *
      * @return BitcoinReceiver
+     *
+     * @deprecated Please use sources instead.
      */
     public static function retrieve($id, $opts = null)
     {
@@ -53,6 +59,8 @@ class BitcoinReceiver extends ExternalAccount
      * @param array|string|null $opts
      *
      * @return Collection of BitcoinReceivers
+     *
+     * @deprecated Please use sources instead.
      */
     public static function all($params = null, $opts = null)
     {
@@ -64,6 +72,8 @@ class BitcoinReceiver extends ExternalAccount
      * @param array|string|null $opts
      *
      * @return BitcoinReceiver The created Bitcoin Receiver item.
+     *
+     * @deprecated Please use sources instead.
      */
     public static function create($params = null, $opts = null)
     {
@@ -75,6 +85,8 @@ class BitcoinReceiver extends ExternalAccount
      * @param array|string|null $options
      *
      * @return BitcoinReceiver The refunded Bitcoin Receiver item.
+     *
+     * @deprecated Please use sources instead.
      */
     public function refund($params = null, $options = null)
     {

--- a/tests/BitcoinReceiverTest.php
+++ b/tests/BitcoinReceiverTest.php
@@ -13,108 +13,14 @@ class BitcoinReceiverTest extends TestCase
         $this->assertSame($instanceUrl, '/v1/bitcoin/receivers/abcd%2Fefgh');
     }
 
-    public function testCreate()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $this->assertSame(100, $receiver->amount);
-        $this->assertNotNull($receiver->id);
-    }
-
-    public function testRetrieve()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $r = BitcoinReceiver::retrieve($receiver->id);
-        $this->assertSame($receiver->id, $r->id);
-
-        $this->assertInstanceOf('Stripe\\BitcoinTransaction', $r->transactions->data[0]);
-    }
-
-    public function testList()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $receivers = BitcoinReceiver::all();
-        $this->assertGreaterThan(0, count($receivers->data));
-    }
-
-    public function testListTransactions()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-        $this->assertSame(0, count($receiver->transactions->data));
-
-        $transactions = $receiver->transactions->all(array("limit" => 1));
-        $this->assertSame(1, count($transactions->data));
-    }
-
-    public function testDeleteWithCustomer()
-    {
-        self::authorizeFromEnv();
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-        $customer = Customer::create(array("source" => $receiver->id));
-        $charge = Charge::create(array(
-            "customer" => $customer->id,
-            "amount" => $receiver->amount,
-            "currency" => $receiver->currency
-        ));
-        $receiver = BitcoinReceiver::retrieve($receiver->id);
-        $response = $receiver->delete();
-        $this->assertTrue($response->deleted);
-    }
-
-    public function testUpdateWithCustomer()
-    {
-        self::authorizeFromEnv();
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-        $customer = Customer::create(array("source" => $receiver->id));
-        $receiver = BitcoinReceiver::retrieve($receiver->id);
-
-        $receiver->description = "a new description";
-        $receiver->save();
-
-        $base = Customer::classUrl();
-        $parentExtn = $receiver['customer'];
-        $extn = $receiver['id'];
-        $this->assertEquals("$base/$parentExtn/sources/$extn", $receiver->instanceUrl());
-
-        $updatedReceiver = BitcoinReceiver::retrieve($receiver->id);
-        $this->assertEquals($receiver["description"], $updatedReceiver["description"]);
-    }
-
-    public function testUpdateWithoutCustomer()
-    {
-        self::authorizeFromEnv();
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $receiver->description = "a new description";
-        $receiver->save();
-
-        $this->assertEquals(BitcoinReceiver::classUrl() . "/" . $receiver['id'], $receiver->instanceUrl());
-
-        $updatedReceiver = BitcoinReceiver::retrieve($receiver->id);
-        $this->assertEquals($receiver["description"], $updatedReceiver["description"]);
-    }
-
-    public function testRefund()
-    {
-        self::authorizeFromEnv();
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $receiver = BitcoinReceiver::retrieve($receiver->id);
-        $this->assertNull($receiver->refund_address);
-
-        $refundAddress = "REFUNDHERE";
-        $receiver->refund(array("refund_address" => $refundAddress));
-
-        $this->assertSame($refundAddress, $receiver->refund_address);
-    }
+    //
+    // Note that there are no tests of consequences in here. The Bitcoin
+    // endpoints have been deprecated in favor of the generic sources API. The
+    // BitcoinReceiver class has been left in place for some backwards
+    // compatibility, but all users should be migrating off of it. The tests
+    // have been removed because we no longer have the API endpoints required
+    // to run them.
+    //
+    // [1] https://stripe.com/docs/sources
+    //
 }

--- a/tests/ChargeTest.php
+++ b/tests/ChargeTest.php
@@ -122,26 +122,6 @@ class ChargeTest extends TestCase
         );
     }
 
-    public function testCreateWithBitcoinReceiverSource()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $charge = Charge::create(
-            array(
-                'amount' => 100,
-                'currency' => 'usd',
-                'source' => $receiver->id
-            )
-        );
-
-        $this->assertSame($receiver->id, $charge->source->id);
-        $this->assertSame("bitcoin_receiver", $charge->source->object);
-        $this->assertSame("succeeded", $charge->status);
-        $this->assertInstanceOf('Stripe\\BitcoinReceiver', $charge->source);
-    }
-
     public function markAsSafe()
     {
         self::authorizeFromEnv();

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -45,32 +45,6 @@ class RefundTest extends TestCase
         $this->assertSame(10, count($all->data));
     }
 
-    public function testCreateForBitcoin()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $charge = Charge::create(
-            array(
-                'amount' => $receiver->amount,
-                'currency' => $receiver->currency,
-                'description' => $receiver->description,
-                'source' => $receiver->id
-            )
-        );
-
-        $ref = Refund::create(
-            array(
-                'amount' => $receiver->amount,
-                'refund_address' => 'ABCDEF',
-                'charge' => $charge->id
-            )
-        );
-        $this->assertSame($receiver->amount, $ref->amount);
-        $this->assertNotNull($ref->id);
-    }
-
     // Deprecated charge endpoints:
 
     public function testCreateViaCharge()
@@ -102,30 +76,5 @@ class RefundTest extends TestCase
         $this->assertSame(2, count($all->data));
         $this->assertSame($refB->id, $all->data[0]->id);
         $this->assertSame($refA->id, $all->data[1]->id);
-    }
-
-    public function testCreateForBitcoinViaCharge()
-    {
-        self::authorizeFromEnv();
-
-        $receiver = $this->createTestBitcoinReceiver("do+fill_now@stripe.com");
-
-        $charge = Charge::create(
-            array(
-                'amount' => $receiver->amount,
-                'currency' => $receiver->currency,
-                'description' => $receiver->description,
-                'source' => $receiver->id
-            )
-        );
-
-        $ref = $charge->refunds->create(
-            array(
-                'amount' => $receiver->amount,
-                'refund_address' => 'ABCDEF'
-            )
-        );
-        $this->assertSame($receiver->amount, $ref->amount);
-        $this->assertNotNull($ref->id);
     }
 }


### PR DESCRIPTION
The Bitcoin APIs have been deprecated in favor of Stripe's new generic
sources endpoint that handles all APMs.

Bitcoin-related tests are no longer working because they don't have the
endpoints they need to run anymore. For the time being to avoid a major
release, let's just remove tests instead of the whole API. We can
piggyback on another major release somewhere down the road to strip the
rest of Bitcoin from the library.

r? @remi-stripe