### PR TITLE
detach method for detaching sources from customers

### DIFF
--- a/lib/Source.php
+++ b/lib/Source.php
@@ -67,11 +67,11 @@ class Source extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $opts
+     * @param array|string|null $options
      *
-     * @return Source The deleted source.
+     * @return Source The detached source.
      */
-    public function delete($params = null, $options = null)
+    public function detach($params = null, $options = null)
     {
         self::_validateParams($params);
 
@@ -93,11 +93,23 @@ class Source extends ApiResource
             $this->refreshFrom($response, $opts);
             return $this;
         } else {
-            $message = "Source objects cannot be deleted, they can only be "
-               . "detached from customer objects. This source object does not "
-               . "appear to be currently attached to a customer object.";
+            $message = "This source object does not appear to be currently attached "
+               . "to a customer object.";
             throw new Error\Api($message);
         }
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return Source The detached source.
+     *
+     * @deprecated Use the `detach` method instead.
+     */
+    public function delete($params = null, $options = null)
+    {
+        $this->detach($params, $options);
     }
 
     /**

--- a/tests/SourceTest.php
+++ b/tests/SourceTest.php
@@ -137,18 +137,16 @@ class SourceTest extends TestCase
         $this->assertSame($source->owner['address']['country'], "Test Country");
     }
 
-    public function testDeleteAttached()
+    public function testDetachAttached()
     {
         $response = array(
             'id' => 'src_foo',
             'object' => 'source',
             'customer' => 'cus_bar',
         );
-        $this->mockRequest(
-            'GET',
-            '/v1/sources/src_foo',
-            array(),
-            $response
+        $source = Source::constructFrom(
+            $response,
+            new Util\RequestOptions()
         );
 
         unset($response['customer']);
@@ -159,29 +157,25 @@ class SourceTest extends TestCase
             $response
         );
 
-        $source = Source::retrieve('src_foo');
-        $source->delete();
+        $source->detach();
         $this->assertFalse(array_key_exists('customer', $source));
     }
 
     /**
      * @expectedException Stripe\Error\Api
      */
-    public function testDeleteUnattached()
+    public function testDetachUnattached()
     {
         $response = array(
             'id' => 'src_foo',
             'object' => 'source',
         );
-        $this->mockRequest(
-            'GET',
-            '/v1/sources/src_foo',
-            array(),
-            $response
+        $source = Source::constructFrom(
+            $response,
+            new Util\RequestOptions()
         );
 
-        $source = Source::retrieve('src_foo');
-        $source->delete();
+        $source->detach();
     }
 
     public function testVerify()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe @will-stripe

- Renames the `Source::delete` method to `Source::detach`. `detach` is more descriptive of what the method actually does (i.e. detaching the source object from its customer object, not actually deleting the source object).

- Alias `detach` to `delete` to avoid a breaking change. We should remove the `delete` method in next major version. (No tests here as deprecated methods are only marked via the `@deprecated` PHPDoc tag in the library.)
