### PR TITLE
Add support for listing source_transactions

### DIFF
--- a/init.php
+++ b/init.php
@@ -79,6 +79,7 @@ require(dirname(__FILE__) . '/lib/RecipientTransfer.php');
 require(dirname(__FILE__) . '/lib/Refund.php');
 require(dirname(__FILE__) . '/lib/SKU.php');
 require(dirname(__FILE__) . '/lib/Source.php');
+require(dirname(__FILE__) . '/lib/SourceTransaction.php');
 require(dirname(__FILE__) . '/lib/Subscription.php');
 require(dirname(__FILE__) . '/lib/SubscriptionItem.php');
 require(dirname(__FILE__) . '/lib/ThreeDSecure.php');

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -116,7 +116,22 @@ class Source extends ApiResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return BankAccount The verified bank account.
+     * @return Collection The list of source transactions.
+     */
+    public function sourceTransactions($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/source_transactions';
+        list($response, $opts) = $this->_request('get', $url, $params, $options);
+        $obj = Util\Util::convertToStripeObject($response, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return Source The verified source.
      */
     public function verify($params = null, $options = null)
     {

--- a/lib/SourceTransaction.php
+++ b/lib/SourceTransaction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class SourceTransaction
+ *
+ * @package Stripe
+ */
+class SourceTransaction extends ApiResource
+{
+
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -96,6 +96,7 @@ abstract class Util
             'refund' => 'Stripe\\Refund',
             'sku' => 'Stripe\\SKU',
             'source' => 'Stripe\\Source',
+            'source_transaction' => 'Stripe\\SourceTransaction',
             'subscription' => 'Stripe\\Subscription',
             'subscription_item' => 'Stripe\\SubscriptionItem',
             'three_d_secure' => 'Stripe\\ThreeDSecure',

--- a/tests/SourceTransactionTest.php
+++ b/tests/SourceTransactionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stripe;
+
+class SourceTransactionTest extends TestCase
+{
+    public function testList()
+    {
+        $this->mockRequest(
+            'GET',
+            '/v1/sources/src_foo/source_transactions',
+            array(),
+            array(
+                'object' => 'list',
+                'url' => '/v1/sources/src_foo/source_transactions',
+                'data' => array(
+                    array(
+                        'id' => 'srctxn_bar',
+                        'object' => 'source_transaction',
+                    ),
+                ),
+                'has_more' => false,
+            )
+        );
+
+        $source = \Stripe\Source::constructFrom(
+            array('id' => 'src_foo', 'object' => 'source'),
+            new \Stripe\Util\RequestOptions()
+        );
+
+        $transactions = $source->sourceTransactions();
+
+        $this->assertTrue(is_array($transactions->data));
+        $this->assertSame('source_transaction', $transactions->data[0]->object);
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @stan-stripe

Adds support for the `/v1/sources/src_.../source_transactions` endpoint.

