### PR TITLE
Add support for exchange_rates API requests

### DIFF
--- a/init.php
+++ b/init.php
@@ -65,6 +65,7 @@ require(dirname(__FILE__) . '/lib/Customer.php');
 require(dirname(__FILE__) . '/lib/Dispute.php');
 require(dirname(__FILE__) . '/lib/EphemeralKey.php');
 require(dirname(__FILE__) . '/lib/Event.php');
+require(dirname(__FILE__) . '/lib/ExchangeRate.php');
 require(dirname(__FILE__) . '/lib/FileUpload.php');
 require(dirname(__FILE__) . '/lib/Invoice.php');
 require(dirname(__FILE__) . '/lib/InvoiceItem.php');

--- a/lib/ExchangeRate.php
+++ b/lib/ExchangeRate.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class ExchangeRate
+ *
+ * @package Stripe
+ */
+class ExchangeRate extends ApiResource
+{
+    /**
+     * This is a special case because the exchange rates endpoint has an
+     *    underscore in it. The parent `className` function strips underscores.
+     *
+     * @return string The name of the class.
+     */
+    public static function className()
+    {
+        return 'exchange_rate';
+    }
+
+    /**
+     * @param array|string $currency
+     * @param array|string|null $opts
+     *
+     * @return ExchangeRate
+     */
+    public static function retrieve($currency, $opts = null)
+    {
+        return self::_retrieve($currency, $opts);
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return ExchangeRate
+     */
+    public static function all($params = null, $opts = null)
+    {
+        return self::_all($params, $opts);
+    }
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -77,6 +77,7 @@ abstract class Util
             'customer' => 'Stripe\\Customer',
             'dispute' => 'Stripe\\Dispute',
             'ephemeral_key' => 'Stripe\\EphemeralKey',
+            'exchange_rate' => 'Stripe\\ExchangeRate',
             'list' => 'Stripe\\Collection',
             'login_link' => 'Stripe\\LoginLink',
             'invoice' => 'Stripe\\Invoice',

--- a/tests/ExchangeRateTest.php
+++ b/tests/ExchangeRateTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Stripe;
+
+class ExchangeRateTest extends TestCase
+{
+    public function testRetrieve()
+    {
+        $this->mockRequest(
+            'GET',
+            '/v1/exchange_rates/usd',
+            array(),
+            array(
+                'id' => 'usd',
+                'object' => 'exchange_rate',
+                'rates' => array('eur' => 0.845876),
+            )
+        );
+
+        $currency = "usd";
+        $rates = ExchangeRate::retrieve($currency);
+        $this->assertEquals('exchange_rate', $rates->object);
+    }
+
+    public function testList()
+    {
+        $this->mockRequest(
+            'GET',
+            '/v1/exchange_rates',
+            array(),
+            array(
+                'object' => 'list',
+                'data' => array(
+                    array(
+                        'id' => 'eur',
+                        'object' => 'exchange_rate',
+                        'rates' => array('usd' => 1.18221),
+                    ),
+                    array(
+                        'id' => 'usd',
+                        'object' => 'exchange_rate',
+                        'rates' => array('eur' => 0.845876),
+                    ),
+                ),
+            )
+        );
+
+        $listRates = ExchangeRate::all();
+        $this->assertTrue(is_array($listRates->data));
+        $this->assertEquals('exchange_rate', $listRates->data[0]->object);
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints.