### PR TITLE
Add personal_address_kana and personal_address_kanji for jp

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -28,7 +28,8 @@ class StripeObject implements ArrayAccess, JsonSerializable
         self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
         self::$nestedUpdatableAttributes = new Util\Set(array(
             'metadata', 'legal_entity', 'address', 'dob', 'payout_schedule', 'transfer_schedule', 'verification',
-            'tos_acceptance', 'personal_address', 'address_kana', 'address_kanji', 'shipping',
+            'tos_acceptance', 'personal_address', 'personal_address_kana', 'personal_address_kanji',
+            'address_kana', 'address_kanji', 'shipping',
             // will make the array into an AttachedObject: weird, but works for now
             'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly
             'inventory',


### PR DESCRIPTION
Hi.

When country is jp, update account does not work.
Because personal_address_kana and personal_address_kanji are necessary.

Thanks.