### PR TITLE
Clean up + sort `$nestedUpdateableAttributes` array

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -27,13 +27,29 @@ class StripeObject implements ArrayAccess, JsonSerializable
     {
         self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
         self::$nestedUpdatableAttributes = new Util\Set(array(
-            'metadata', 'legal_entity', 'address', 'dob', 'payout_schedule', 'transfer_schedule', 'verification',
-            'tos_acceptance', 'personal_address', 'personal_address_kana', 'personal_address_kanji',
-            'address_kana', 'address_kanji', 'shipping',
-            // will make the array into an AttachedObject: weird, but works for now
-            'additional_owners', 0, 1, 2, 3, 4, // Max 3, but leave the 4th so errors work properly
+            // Numbers are in place for indexes in an `additional_owners` array.
+            //
+            // There's a maximum allowed additional owners of 3, but leave the
+            // 4th so errors work properly.
+            0, 1, 2, 3, 4,
+
+            'additional_owners',
+            'address',
+            'address_kana',
+            'address_kanji',
+            'dob',
             'inventory',
+            'legal_entity',
+            'metadata',
             'owner',
+            'payout_schedule',
+            'personal_address',
+            'personal_address_kana',
+            'personal_address_kanji',
+            'shipping',
+            'tos_acceptance',
+            'transfer_schedule',
+            'verification',
         ));
     }
 


### PR DESCRIPTION
Here we cleanup `$nestedUpdatableAttributes` in `StripeObject` by moving
every field name to its own line and then alphabetizing them. This makes
it a little easier to see what's going on when people add new ones, and
gives them a deterministic place in the array with which to make the
addition.

r? @ob-stripe