### PR TITLE
Remove unsupported API methods

### DIFF
--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -35,18 +35,6 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the application fee to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return ApplicationFee The updated application fee.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
      * @param array|null $params
      * @param array|string|null $opts
      *

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -25,17 +25,6 @@ class Source extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return Collection of Sources
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
      * @return Source The created Source.
      */
     public static function create($params = null, $opts = null)


### PR DESCRIPTION
r? @dpetrovics-stripe (DP run, feel free to re-assign!)
cc @stripe/api-libraries @remi-stripe 

Removes two methods that exist in the PHP library but are not (and never were) supported by the API:
- `ApplicationFee::update()`
- `Source::all()`
