### PR TITLE
Alphabetize list and add missing objects

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -65,11 +65,19 @@ abstract class Util
     public static function convertToStripeObject($resp, $opts)
     {
         $types = array(
+            // data structures
+            'list' => 'Stripe\\Collection',
+
+            // business objects
             'account' => 'Stripe\\Account',
             'alipay_account' => 'Stripe\\AlipayAccount',
             'apple_pay_domain' => 'Stripe\\ApplePayDomain',
-            'bank_account' => 'Stripe\\BankAccount',
+            'application_fee' => 'Stripe\\ApplicationFee',
+            'balance' => 'Stripe\\Balance',
             'balance_transaction' => 'Stripe\\BalanceTransaction',
+            'bank_account' => 'Stripe\\BankAccount',
+            'bitcoin_receiver' => 'Stripe\\BitcoinReceiver',
+            'bitcoin_transaction' => 'Stripe\\BitcoinTransaction',
             'card' => 'Stripe\\Card',
             'charge' => 'Stripe\\Charge',
             'country_spec' => 'Stripe\\CountrySpec',
@@ -77,16 +85,13 @@ abstract class Util
             'customer' => 'Stripe\\Customer',
             'dispute' => 'Stripe\\Dispute',
             'ephemeral_key' => 'Stripe\\EphemeralKey',
+            'event' => 'Stripe\\Event',
             'exchange_rate' => 'Stripe\\ExchangeRate',
-            'list' => 'Stripe\\Collection',
-            'login_link' => 'Stripe\\LoginLink',
+            'fee_refund' => 'Stripe\\ApplicationFeeRefund',
+            'file_upload' => 'Stripe\\FileUpload',
             'invoice' => 'Stripe\\Invoice',
             'invoiceitem' => 'Stripe\\InvoiceItem',
-            'event' => 'Stripe\\Event',
-            'file_upload' => 'Stripe\\FileUpload',
-            'token' => 'Stripe\\Token',
-            'transfer' => 'Stripe\\Transfer',
-            'transfer_reversal' => 'Stripe\\TransferReversal',
+            'login_link' => 'Stripe\\LoginLink',
             'order' => 'Stripe\\Order',
             'order_return' => 'Stripe\\OrderReturn',
             'payout' => 'Stripe\\Payout',
@@ -101,9 +106,9 @@ abstract class Util
             'subscription' => 'Stripe\\Subscription',
             'subscription_item' => 'Stripe\\SubscriptionItem',
             'three_d_secure' => 'Stripe\\ThreeDSecure',
-            'fee_refund' => 'Stripe\\ApplicationFeeRefund',
-            'bitcoin_receiver' => 'Stripe\\BitcoinReceiver',
-            'bitcoin_transaction' => 'Stripe\\BitcoinTransaction',
+            'token' => 'Stripe\\Token',
+            'transfer' => 'Stripe\\Transfer',
+            'transfer_reversal' => 'Stripe\\TransferReversal',
         );
         if (self::isList($resp)) {
             $mapped = array();


### PR DESCRIPTION
r? @dpetrovics-stripe (DP run, feel free to re-assign!)
cc @stripe/api-libraries @remi-stripe

Alphabetize the list of API resources in `Util::convertToStripeObject()` and add missing resources:
- `application_fee`
- `balance`

(This was not a big issue as the PHP library does not rely on this method to instantiate resource classes when retrieving a resource, but we might as well be comprehensive.)
