### PR TITLE
Fix card source expiry date update

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -37,6 +37,7 @@ class StripeObject implements ArrayAccess, JsonSerializable
             'address',
             'address_kana',
             'address_kanji',
+            'card',
             'dob',
             'inventory',
             'legal_entity',

--- a/tests/SourceTest.php
+++ b/tests/SourceTest.php
@@ -137,6 +137,44 @@ class SourceTest extends TestCase
         $this->assertSame($source->owner['address']['country'], "Test Country");
     }
 
+
+    public function testSaveCardExpiryDate()
+    {
+        $response = array(
+            'id' => 'src_foo',
+            'object' => 'source',
+            'card' => array(
+                'exp_month' => 8,
+                'exp_year' => 2019,
+            ),
+        );
+        $source = Source::constructFrom(
+            $response,
+            new Util\RequestOptions()
+        );
+
+        $response['card']['exp_month'] = 12;
+        $response['card']['exp_year'] = 2022;
+        $this->mockRequest(
+            'POST',
+            '/v1/sources/src_foo',
+            array(
+                'card' => array(
+                    'exp_month' => 12,
+                    'exp_year' => 2022,
+                )
+            ),
+            $response
+        );
+
+        $source->card->exp_month = 12;
+        $source->card->exp_year = 2022;
+        $source->save();
+
+        $this->assertSame(12, $source->card->exp_month);
+        $this->assertSame(2022, $source->card->exp_year);
+    }
+
     public function testDetachAttached()
     {
         $response = array(


### PR DESCRIPTION
r? @dpetrovics-stripe (dev-platform run)
cc @stripe/api-libraries 

Fixes an issue where the library failed to update the expiry date when updating a card source.
