### PR TITLE
[WIP] Ensure that `card` is only treated as a nested updatable attribute on Source objects

### DIFF
--- a/lib/Source.php
+++ b/lib/Source.php
@@ -10,6 +10,20 @@ namespace Stripe;
 class Source extends ApiResource
 {
     /**
+     * @return Util\Set Attributes that are nested but still updatable from
+     *    the parent class's URL (e.g. metadata).
+     */
+    public static function getNestedUpdatableAttributes()
+    {
+        static $nestedUpdatableAttributes = null;
+        if ($nestedUpdatableAttributes === null) {
+            $nestedUpdatableAttributes = StripeObject::getNestedUpdatableAttributes();
+            $nestedUpdatableAttributes->add('card');
+        }
+        return $nestedUpdatableAttributes;
+    }
+
+    /**
      * @param array|string $id The ID of the source to retrieve, or an options
      *     array containing an `id` key.
      * @param array|string|null $opts

--- a/tests/StripeObjectTest.php
+++ b/tests/StripeObjectTest.php
@@ -97,7 +97,6 @@ class StripeObjectTest extends TestCase
 
     public function testReplaceNewNestedUpdatable()
     {
-        StripeObject::init(); // Populate the $nestedUpdatableAttributes Set
         $s = new StripeObject();
 
         $s->metadata = array('bar');

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -10,4 +10,21 @@ class TokenTest extends TestCase
         $token = new Token('abcd/efgh');
         $this->assertSame($token->instanceUrl(), '/v1/tokens/abcd%2Fefgh');
     }
+
+    public function testNestedCardObject()
+    {
+        $token = Token::constructFrom(
+            array(
+                'id' => 'tok_foo',
+                'object' => 'token',
+                'card' => array(
+                    'id' => 'card_foo',
+                    'object' => 'card',
+                ),
+            ),
+            new Util\RequestOptions()
+        );
+        $this->assertSame("Stripe\\Token", get_class($token));
+        $this->assertSame("Stripe\\Card", get_class($token->card));
+    }
 }


### PR DESCRIPTION
r? @deontologician-stripe (dev-platform run, feel free to reassign)
cc @stripe/api-libraries @arcanedev-maroc 

This fixes the issue described by @arcanedev-maroc [here](https://github.com/stripe/stripe-php/pull/393#discussion_r153878518).

Basically, in #393 I added `card` to the list of nested updatable attributes so that users can update the expiry date on card sources:

```php
$source = \Stripe\Source::create(array(
  "type" => "card",
  "token" => "tok_visa",
));
$source->card->exp_month = 12;
$source->card->exp_month = 2022;
$source->save();
```

This worked, but had the side-effect of turning all nested `card` hashes into `\Stripe\AttachedObject`. That's fine for sources since the `card` hash is just a hash, but not for token objects since the `card` hash nested in token objects is an actual card object, and so the instance should be a `\Stripe\Card` (even though I have trouble imagining a practical case where that would be an issue -- there's no reason I can think of to manipulate a card object via token rather than via a customer/recipient/account).

This PR changes the way the `$nestedUpdatableAttributes` works so that each class can define its own nested updatable attributes. `StripeObject` now uses [late static bindings](http://uk1.php.net/manual/en/language.oop5.late-static-bindings.php) so that derived classes can override the `getNestedUpdatableAttributes()` static function (which replaces the `$nestedUpdatableAttributes` static variable) to define its own list of nested updatable attributes.