### PR TITLE
Start testing PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       env: AUTOLOAD=1
     - php: 7.1
       env: AUTOLOAD=0
+    - php: 7.2
+      env: AUTOLOAD=1
+    - php: 7.2
+      env: AUTOLOAD=0
     - php: hhvm
       env: AUTOLOAD=1
     - php: hhvm

--- a/tests/CountrySpecTest.php
+++ b/tests/CountrySpecTest.php
@@ -12,10 +12,8 @@ class CountrySpecTest extends TestCase
         $d = CountrySpec::retrieve($country);
         $this->assertSame($d->object, "country_spec");
         $this->assertSame($d->id, $country);
-        $this->assertGreaterThan(0, count($d->supported_bank_account_currencies));
         $this->assertGreaterThan(0, count($d->supported_payment_currencies));
         $this->assertGreaterThan(0, count($d->supported_payment_methods));
-        $this->assertGreaterThan(0, count($d->verification_fields));
     }
 
     public function testList()

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -51,7 +51,7 @@ class InvoiceTest extends TestCase
     {
         self::authorizeFromEnv();
         $invoices = Invoice::all();
-        $this->assertGreaterThan(0, count($invoices));
+        $this->assertGreaterThan(0, count($invoices->data));
     }
 
     public function testPay()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

PHP 7.2.0 has just been [released](http://php.net/releases/7_2_0.php), so we should start testing it in Travis.

The upgrade revealed a few bad tests where we were using `count()` on `StripeObject`s, which is [no longer supported](https://wiki.php.net/rfc/counting_non_countables) in PHP 7.2 (and returned `1` in previous versions, which likely wasn't the expected behavior when we wrote those tests). I've verified that the updated tests in the `ob-stripe-mock` branch all pass with PHP 7.2, and pushed a commit to fix the current tests here.
