### PR TITLE
Document getLastResponse() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ end up there instead of `error_log`:
 \Stripe\Stripe::setLogger($logger);
 ```
 
+### Accessing response data
+
+You can access the data from the last API response on any object via `getLastResponse()`.
+
+```php
+$charge = \Stripe\Charge::create(array('amount' => 2000, 'currency' => 'usd', 'source' => 'tok_visa'));
+echo $charge->getLastResponse()->headers['Request-Id'];
+```
+
 ### SSL / TLS compatibility issues
 
 Stripe's API now requires that [all connections use TLS 1.2](https://stripe.com/blog/upgrading-tls). Some systems (most notably some older CentOS and RHEL versions) are capable of using TLS 1.2 but will use TLS 1.0 or 1.1 by default. In this case, you'd get an `invalid_request_error` with the following error message: "Stripe no longer supports API requests made with TLS 1.0. Please initiate HTTPS connections with TLS 1.2 or later. You can learn more about this at [https://stripe.com/blog/upgrading-tls](https://stripe.com/blog/upgrading-tls).".


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Mentions the existence of `getLastResponse()` in the README file with a short sample.
