### PR TITLE
Add __debugInfo() magic method

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -158,6 +158,12 @@ class StripeObject implements ArrayAccess, JsonSerializable
         }
     }
 
+    // Magic method for var_dump output. Only works with PHP >= 5.6
+    public function __debugInfo()
+    {
+        return $this->_values;
+    }
+
     // ArrayAccess methods
     public function offsetSet($k, $v)
     {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds a [`__debugInfo()`](http://php.net/manual/en/language.oop5.magic.php#object.debuginfo) method to `StripeObject`. This is a magic method that is called by `var_dump` and returns the array of values that should be displayed. Returning `$this->_values` makes the output much more legible and avoids inadvertently leaking credentials (the secret API keys is stored in `$this->_opts` and displayed by default).

This is similar to what we do in other libraries, e.g. [stripe-ruby](https://github.com/stripe/stripe-ruby/blob/cfa6c2b8aeb91789fba63e9b082a7967a1c60b98/lib/stripe/stripe_object.rb#L47-L50) or [stripe-python](https://github.com/stripe/stripe-python/blob/master/stripe/stripe_object.py#L221-L223).
