### PR TITLE
Use traits for API operations methods

### DIFF
--- a/init.php
+++ b/init.php
@@ -35,6 +35,14 @@ require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidScope.php');
 require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedGrantType.php');
 require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedResponseType.php');
 
+// API operations
+echo "bouh";
+require(dirname(__FILE__) . '/lib/ApiOperations/All.php');
+require(dirname(__FILE__) . '/lib/ApiOperations/Create.php');
+require(dirname(__FILE__) . '/lib/ApiOperations/Delete.php');
+require(dirname(__FILE__) . '/lib/ApiOperations/Retrieve.php');
+require(dirname(__FILE__) . '/lib/ApiOperations/Update.php');
+
 // Plumbing
 require(dirname(__FILE__) . '/lib/ApiResponse.php');
 require(dirname(__FILE__) . '/lib/StripeObject.php');

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -37,6 +37,11 @@ namespace Stripe;
  */
 class Account extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Update;
+
     const PATH_EXTERNAL_ACCOUNTS = '/external_accounts';
     const PATH_LOGIN_LINKS = '/login_links';
 
@@ -69,50 +74,6 @@ class Account extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return Account
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Account The updated account.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Account
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Account The deleted account.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
      * @return Account The rejected account.
      */
     public function reject($params = null, $opts = null)
@@ -121,17 +82,6 @@ class Account extends ApiResource
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Accounts
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 
     /**

--- a/lib/ApiOperations/All.php
+++ b/lib/ApiOperations/All.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for listable resources. Adds a `all()` static method to the class.
+ *
+ * This trait should only be applied to classes that derive from ApiResource.
+ */
+trait All
+{
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return Collection of ApiResources
+     */
+    public static function all($params = null, $opts = null)
+    {
+        return self::_all($params, $opts);
+    }
+}

--- a/lib/ApiOperations/Create.php
+++ b/lib/ApiOperations/Create.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for creatable resources. Adds a `create()` static method to the class.
+ *
+ * This trait should only be applied to classes that derive from ApiResource.
+ */
+trait Create
+{
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return ApiResource The created resource.
+     */
+    public static function create($params = null, $options = null)
+    {
+        return self::_create($params, $options);
+    }
+}

--- a/lib/ApiOperations/Delete.php
+++ b/lib/ApiOperations/Delete.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for deletable resources. Adds a `delete()` method to the class.
+ *
+ * This trait should only be applied to classes that derive from ApiResource.
+ */
+trait Delete
+{
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return ApiResource The deleted resource.
+     */
+    public function delete($params = null, $opts = null)
+    {
+        return $this->_delete($params, $opts);
+    }
+}

--- a/lib/ApiOperations/Retrieve.php
+++ b/lib/ApiOperations/Retrieve.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for retrievable resources. Adds a `retrieve()` static method to the
+ * class.
+ *
+ * This trait should only be applied to classes that derive from ApiResource.
+ */
+trait Retrieve
+{
+    /**
+     * @param array|string $id The ID of the API resource to retrieve,
+     *     or an options array containing an `id` key.
+     * @param array|string|null $opts
+     *
+     * @return ApiResource
+     */
+    public static function retrieve($id, $opts = null)
+    {
+        return self::_retrieve($id, $opts);
+    }
+}

--- a/lib/ApiOperations/Update.php
+++ b/lib/ApiOperations/Update.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for updatable resources. Adds an `update()` static method and a
+ * `save()` method to the class.
+ *
+ * This trait should only be applied to classes that derive from ApiResource.
+ */
+trait Update
+{
+    /**
+     * @param string $id The ID of the resource to update.
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return ApiResource The updated resource.
+     */
+    public static function update($id, $params = null, $options = null)
+    {
+        return self::_update($id, $params, $options);
+    }
+
+    /**
+     * @param array|string|null $options
+     *
+     * @return ApiResource The saved resource.
+     */
+    public function save($options = null)
+    {
+        return $this->_save($options);
+    }
+}

--- a/lib/ApplePayDomain.php
+++ b/lib/ApplePayDomain.php
@@ -9,7 +9,11 @@ namespace Stripe;
  */
 class ApplePayDomain extends ApiResource
 {
-    
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+
     /**
      * @return string The class URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
@@ -17,50 +21,5 @@ class ApplePayDomain extends ApiResource
     public static function classUrl()
     {
         return '/v1/apple_pay/domains';
-    }
-
-    /**
-     * @param array|string $id The ID of the domain to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return ApplePayDomain
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return ApplePayDomain The created domain.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return ApplePayDomain The deleted domain.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of ApplePayDomains
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -9,6 +9,9 @@ namespace Stripe;
  */
 class ApplicationFee extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     const PATH_REFUNDS = '/refunds';
 
     /**
@@ -20,29 +23,6 @@ class ApplicationFee extends ApiResource
     public static function className()
     {
         return 'application_fee';
-    }
-
-    /**
-     * @param array|string $id The ID of the application fee to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return ApplicationFee
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of ApplicationFees
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 
     /**

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -24,6 +24,9 @@ namespace Stripe;
  */
 class BalanceTransaction extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     /**
      * @return string The class URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
@@ -31,28 +34,5 @@ class BalanceTransaction extends ApiResource
     public static function classUrl()
     {
         return "/v1/balance/history";
-    }
-
-    /**
-     * @param array|string $id The ID of the balance transaction to retrieve,
-     *     or an options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return BalanceTransaction
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of BalanceTransactions
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -9,6 +9,10 @@ namespace Stripe;
  */
 class BitcoinReceiver extends ExternalAccount
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+
     /**
      * @return string The class URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
@@ -38,46 +42,6 @@ class BitcoinReceiver extends ExternalAccount
             $base = BitcoinReceiver::classUrl();
             return "$base/$extn";
         }
-    }
-
-    /**
-     * @param array|string $id The ID of the bitcoin receiver to retrieve, or
-     *     an options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return BitcoinReceiver
-     *
-     * @deprecated Please use sources instead.
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of BitcoinReceivers
-     *
-     * @deprecated Please use sources instead.
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return BitcoinReceiver The created Bitcoin Receiver item.
-     *
-     * @deprecated Please use sources instead.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
     }
 
     /**

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -40,61 +40,10 @@ namespace Stripe;
  */
 class Charge extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the charge to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $options
-     *
-     * @return Charge
-     */
-    public static function retrieve($id, $options = null)
-    {
-        return self::_retrieve($id, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Collection of Charges
-     */
-    public static function all($params = null, $options = null)
-    {
-        return self::_all($params, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Charge The created charge.
-     */
-    public static function create($params = null, $options = null)
-    {
-        return self::_create($params, $options);
-    }
-
-    /**
-     * @param string $id The ID of the charge to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Charge The updated charge.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $options
-     *
-     * @return Charge The saved charge.
-     */
-    public function save($options = null)
-    {
-        return $this->_save($options);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @param array|null $params

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -9,6 +9,9 @@ namespace Stripe;
  */
 class CountrySpec extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     /**
      * This is a special case because the country specs endpoint has an
      *    underscore in it. The parent `className` function strips underscores.
@@ -18,29 +21,5 @@ class CountrySpec extends ApiResource
     public static function className()
     {
         return 'country_spec';
-    }
-
-    /**
-     * @param array|string $country The ISO country code of the country we
-     *     retrieve the country specfication for, or an options array
-     *     containing an `id` containing that code.
-     * @param array|string|null $opts
-     *
-     * @return CountrySpec
-     */
-    public static function retrieve($country, $opts = null)
-    {
-        return self::_retrieve($country, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of CountrySpecs
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -9,70 +9,9 @@ namespace Stripe;
  */
 class Coupon extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the coupon to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Coupon
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Coupon The created coupon.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the coupon to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Coupon The updated coupon.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Coupon The deleted coupon.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Coupon The saved coupon.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Coupons
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -26,74 +26,13 @@ namespace Stripe;
  */
 class Customer extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+
     const PATH_SOURCES = '/sources';
-
-    /**
-     * @param array|string $id The ID of the customer to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Customer
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Customers
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Customer The created customer.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the customer to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Customer The updated customer.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Customer The saved customer.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Customer The deleted customer.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
 
     /**
      * @param array|null $params

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -24,50 +24,9 @@ namespace Stripe;
  */
 class Dispute extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the dispute to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $options
-     *
-     * @return Dispute
-     */
-    public static function retrieve($id, $options = null)
-    {
-        return self::_retrieve($id, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return array An array of Disputes.
-     */
-    public static function all($params = null, $options = null)
-    {
-        return self::_all($params, $options);
-    }
-
-    /**
-     * @param string $id The ID of the dispute to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Dispute The updated dispute.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $options
-     *
-     * @return Dispute The saved charge.
-     */
-    public function save($options = null)
-    {
-        return $this->_save($options);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @param array|string|null $options

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -17,6 +17,8 @@ namespace Stripe;
  */
 class EphemeralKey extends ApiResource
 {
+    use ApiOperations\Delete;
+
     /**
      * This is a special case because the ephemeral key endpoint has an
      *    underscore in it. The parent `className` function strips underscores.
@@ -40,16 +42,5 @@ class EphemeralKey extends ApiResource
             throw new \InvalidArgumentException('stripe_version must be specified to create an ephemeral key');
         }
         return self::_create($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return EphemeralKey The deleted key.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
     }
 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -19,26 +19,6 @@ namespace Stripe;
  */
 class Event extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the event to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Event
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Events
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
 }

--- a/lib/ExchangeRate.php
+++ b/lib/ExchangeRate.php
@@ -9,6 +9,9 @@ namespace Stripe;
  */
 class ExchangeRate extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     /**
      * This is a special case because the exchange rates endpoint has an
      *    underscore in it. The parent `className` function strips underscores.
@@ -18,27 +21,5 @@ class ExchangeRate extends ApiResource
     public static function className()
     {
         return 'exchange_rate';
-    }
-
-    /**
-     * @param array|string $currency
-     * @param array|string|null $opts
-     *
-     * @return ExchangeRate
-     */
-    public static function retrieve($currency, $opts = null)
-    {
-        return self::_retrieve($currency, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return ExchangeRate
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/ExternalAccount.php
+++ b/lib/ExternalAccount.php
@@ -12,6 +12,8 @@ namespace Stripe;
  */
 abstract class ExternalAccount extends ApiResource
 {
+    use ApiOperations\Delete;
+
     /**
      * @return string The instance URL for this resource. It needs to be special
      *    cased because it doesn't fit into the standard resource pattern.
@@ -48,17 +50,6 @@ abstract class ExternalAccount extends ApiResource
         $parentExtn = urlencode($parent);
         $extn = urlencode($id);
         return "$base/$parentExtn/$path/$extn";
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return ExternalAccount The deleted external account.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
     }
 
     /**

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -16,6 +16,10 @@ namespace Stripe;
  */
 class FileUpload extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+
     public static function baseUrl()
     {
         return Stripe::$apiUploadBase;
@@ -24,39 +28,5 @@ class FileUpload extends ApiResource
     public static function className()
     {
         return 'file';
-    }
-
-    /**
-     * @param array|string $id The ID of the file upload to retrieve, or an
-     *     options array containing an `id key.
-     * @param array|string|null $opts
-     *
-     * @return FileUpload
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return FileUpload The created file upload.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of FileUploads
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -9,51 +9,10 @@ namespace Stripe;
  */
 class Invoice extends ApiResource
 {
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Invoice The created invoice.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param array|string $id The ID of the invoice to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Invoice
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Invoices
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the invoice to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Invoice The updated invoice.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @param array|null $params

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -9,70 +9,9 @@ namespace Stripe;
  */
 class InvoiceItem extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the invoice item to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return InvoiceItem
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of InvoiceItems
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return InvoiceItem The created invoice item.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the invoice item to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return InvoiceItem The updated invoice item.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return InvoiceItem The saved invoice item.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return InvoiceItem The deleted invoice item.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -9,61 +9,10 @@ namespace Stripe;
  */
 class Order extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the order to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Order
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Order The created Order.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the order to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Order The updated order.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Order The saved Order.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Orders
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @return Order The paid order.

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -9,6 +9,9 @@ namespace Stripe;
  */
 class OrderReturn extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     /**
      * This is a special case because the order returns endpoint has an
      *    underscore in it. The parent `className` function strips underscores.
@@ -18,28 +21,5 @@ class OrderReturn extends ApiResource
     public static function className()
     {
         return 'order_return';
-    }
-
-    /**
-     * @param array|string $id The ID of the order return to retrieve, or an
-     *     options array containing an `id` field.
-     * @param array|string|null $opts
-     *
-     * @return Order
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of OrderReturns
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
     }
 }

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -29,51 +29,10 @@ namespace Stripe;
  */
 class Payout extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the payout to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Payout
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Payouts
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Payout The created payout.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the payout to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Payout The updated payout.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @return Payout The canceled payout.
@@ -84,15 +43,5 @@ class Payout extends ApiResource
         list($response, $opts) = $this->_request('post', $url);
         $this->refreshFrom($response, $opts);
         return $this;
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Payout The saved payout.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
     }
 }

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -22,70 +22,9 @@ namespace Stripe;
  */
 class Plan extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the plan to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Plan
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Plan The created plan.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the plan to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Plan The updated plan.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Plan The deleted plan.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Plan The saved plan.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Plans
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -9,70 +9,9 @@ namespace Stripe;
  */
 class Product extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the product to retrieve, or an options
-     *     array contianing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Product
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Product The created Product.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the product to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Product The updated product.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Product The saved Product.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Products
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Product The deleted product.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -9,72 +9,11 @@ namespace Stripe;
  */
 class Recipient extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the recipient to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Recipient
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Recipients
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Recipient The created recipient.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the recipient to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Recipient The updated recipient.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Recipient The saved recipient.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     *
-     * @return Recipient The deleted recipient.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
-
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @param array|null $params

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -21,60 +21,8 @@ namespace Stripe;
  */
 class Refund extends ApiResource
 {
-
-    /**
-     * @param array|string $id The ID of the refund to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $options
-     *
-     * @return Refund
-     */
-    public static function retrieve($id, $options = null)
-    {
-        return self::_retrieve($id, $options);
-    }
-
-    /**
-     * @param string $id The ID of the refund to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Refund The updated refund.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Collection of Refunds
-     */
-    public static function all($params = null, $options = null)
-    {
-        return self::_all($params, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Refund The created refund.
-     */
-    public static function create($params = null, $options = null)
-    {
-        return self::_create($params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Refund The saved refund.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -9,70 +9,9 @@ namespace Stripe;
  */
 class SKU extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the SKU to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return SKU
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return SKU The created SKU.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the SKU to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return SKU The updated SKU.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return SKU The saved SKU.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of SKUs
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return SKU The deleted sku.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
-    }
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 }

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -9,50 +9,9 @@ namespace Stripe;
  */
 class Source extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the source to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Source
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Source The created Source.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the source to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Source The updated source.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Source The saved source.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
 
     /**
      * @param array|null $params

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -9,6 +9,11 @@ namespace Stripe;
  */
 class Subscription extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+
     /**
      * These constants are possible representations of the status field.
      *
@@ -21,52 +26,6 @@ class Subscription extends ApiResource
     const STATUS_UNPAID = 'unpaid';
 
     /**
-     * @param array|string $id The ID of the subscription to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Subscription
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Subscriptions
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Subscription The created subscription.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the subscription to retrieve.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Subscription The updated subscription.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
      * @param array|null $params
      *
      * @return Subscription The deleted subscription.
@@ -74,16 +33,6 @@ class Subscription extends ApiResource
     public function cancel($params = null, $opts = null)
     {
         return $this->_delete($params, $opts);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Subscription The saved subscription.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
     }
 
     /**

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -9,6 +9,12 @@ namespace Stripe;
  */
 class SubscriptionItem extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Delete;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+
     /**
      * This is a special case because the subscription items endpoint has an
      *    underscore in it. The parent `className` function strips underscores.
@@ -18,72 +24,5 @@ class SubscriptionItem extends ApiResource
     public static function className()
     {
         return 'subscription_item';
-    }
-
-    /**
-     * @param array|string $id The ID of the subscription item to retrieve, or
-     *     an options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return SubscriptionItem
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of SubscriptionItems
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return SubscriptionItem The created subscription item.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the subscription item to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return SubscriptionItem The updated subscription item.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return SubscriptionItem The saved subscription item.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return SubscriptionItem The deleted subscription item.
-     */
-    public function delete($params = null, $opts = null)
-    {
-        return $this->_delete($params, $opts);
     }
 }

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -4,34 +4,14 @@ namespace Stripe;
 
 class ThreeDSecure extends ApiResource
 {
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+
     /**
      * @return string The endpoint URL for the given class.
      */
     public static function classUrl()
     {
         return "/v1/3d_secure";
-    }
-
-    /**
-     * @param array|string $id The ID of the 3DS auth to retrieve, or an
-     *     options array contianing an `id` key.
-     * @param array|string|null $options
-     *
-     * @return ThreeDSecure
-     */
-    public static function retrieve($id, $options = null)
-    {
-        return self::_retrieve($id, $options);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return ThreeDSecure The created 3D Secure object.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
     }
 }

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -19,26 +19,6 @@ namespace Stripe;
  */
 class Token extends ApiResource
 {
-    /**
-     * @param array|string $id The ID of the token to retrieve, or an options
-     *     array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Token
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Token The created token.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
 }

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -25,53 +25,12 @@ namespace Stripe;
  */
 class Transfer extends ApiResource
 {
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+
     const PATH_REVERSALS = '/reversals';
-
-    /**
-     * @param array|string $id The ID of the transfer to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @return Transfer
-     */
-    public static function retrieve($id, $opts = null)
-    {
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Collection of Transfers
-     */
-    public static function all($params = null, $opts = null)
-    {
-        return self::_all($params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @return Transfer The created transfer.
-     */
-    public static function create($params = null, $opts = null)
-    {
-        return self::_create($params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the transfer to update.
-     * @param array|null $params
-     * @param array|string|null $options
-     *
-     * @return Transfer The updated transfer.
-     */
-    public static function update($id, $params = null, $options = null)
-    {
-        return self::_update($id, $params, $options);
-    }
 
     /**
      * @return TransferReversal The created transfer reversal.
@@ -93,16 +52,6 @@ class Transfer extends ApiResource
         list($response, $opts) = $this->_request('post', $url);
         $this->refreshFrom($response, $opts);
         return $this;
-    }
-
-    /**
-     * @param array|string|null $opts
-     *
-     * @return Transfer The saved transfer.
-     */
-    public function save($opts = null)
-    {
-        return $this->_save($opts);
     }
 
     /**


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

[Traits](http://php.net/manual/en/language.oop5.traits.php) are a feature available in PHP 5.4+. Now that we're dropping support for PHP <5.4, we can start using traits to factorize code.

This PR adds traits for common API operations methods (CRUD + list).
