### PR TITLE
Use short array syntax everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Simple usage looks like:
 
 ```php
 \Stripe\Stripe::setApiKey('sk_test_BQokikJOvBiI2HlWgH4olfQ2');
-$charge = \Stripe\Charge::create(array('amount' => 2000, 'currency' => 'usd', 'source' => 'tok_189fqt2eZvKYlo2CTGBeg6Uq' ));
+$charge = \Stripe\Charge::create(['amount' => 2000, 'currency' => 'usd', 'source' => 'tok_189fqt2eZvKYlo2CTGBeg6Uq']);
 echo $charge;
 ```
 
@@ -103,7 +103,7 @@ Need to set a proxy for your requests? Pass in the requisite `CURLOPT_*` array t
 
 ```php
 // set up your tweaked Curl client
-$curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_PROXY => 'proxy.local:80'));
+$curl = new \Stripe\HttpClient\CurlClient([CURLOPT_PROXY => 'proxy.local:80']);
 // tell Stripe to use the tweaked client
 \Stripe\ApiRequestor::setHttpClient($curl);
 ```
@@ -125,7 +125,7 @@ end up there instead of `error_log`:
 You can access the data from the last API response on any object via `getLastResponse()`.
 
 ```php
-$charge = \Stripe\Charge::create(array('amount' => 2000, 'currency' => 'usd', 'source' => 'tok_visa'));
+$charge = \Stripe\Charge::create(['amount' => 2000, 'currency' => 'usd', 'source' => 'tok_visa']);
 echo $charge->getLastResponse()->headers['Request-Id'];
 ```
 
@@ -136,7 +136,7 @@ Stripe's API now requires that [all connections use TLS 1.2](https://stripe.com/
 The recommended course of action is to [upgrade your cURL and OpenSSL packages](https://support.stripe.com/questions/how-do-i-upgrade-my-stripe-integration-from-tls-1-0-to-tls-1-2#php) so that TLS 1.2 is used by default, but if that is not possible, you might be able to solve the issue by setting the `CURLOPT_SSLVERSION` option to either `CURL_SSLVERSION_TLSv1` or `CURL_SSLVERSION_TLSv1_2`:
 
 ```php
-$curl = new \Stripe\HttpClient\CurlClient(array(CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1));
+$curl = new \Stripe\HttpClient\CurlClient([CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1]);
 \Stripe\ApiRequestor::setHttpClient($curl);
 ```
 

--- a/examples/oauth.php
+++ b/examples/oauth.php
@@ -11,10 +11,10 @@ if (isset($_GET['code'])) {
     $code = $_GET['code'];
 
     try {
-        $resp = \Stripe\OAuth::token(array(
+        $resp = \Stripe\OAuth::token([
             'grant_type' => 'authorization_code',
             'code' => $code,
-        ));
+        ]);
     } catch (\Stripe\Error\OAuth\OAuthBase $e) {
         exit("Error: " . $e->getMessage());
     }
@@ -37,9 +37,9 @@ if (isset($_GET['code'])) {
     $accountId = $_GET['deauth'];
 
     try {
-        \Stripe\OAuth::deauthorize(array(
+        \Stripe\OAuth::deauthorize([
             'stripe_user_id' => $accountId,
-        ));
+        ]);
     } catch (\Stripe\Error\OAuth\OAuthBase $e) {
         exit("Error: " . $e->getMessage());
     }
@@ -48,8 +48,8 @@ if (isset($_GET['code'])) {
     echo "<p>Click <a href=\"?\">here</a> to restart the OAuth flow.</p>\n";
 
 } else {
-    $url = \Stripe\OAuth::authorizeUrl(array(
+    $url = \Stripe\OAuth::authorizeUrl([
         'scope' => 'read_only',
-    ));
+    ]);
     echo "<a href=\"$url\">Connect with Stripe</a>\n";
 }

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -142,10 +142,10 @@ class Account extends ApiResource
      */
     public function deauthorize($clientId = null, $opts = null)
     {
-        $params = array(
+        $params = [
             'client_id' => $clientId,
             'stripe_user_id' => $this->id,
-        );
+        ];
         OAuth::deauthorize($params, $opts);
     }
 

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -33,7 +33,7 @@ class ApiRequestor
         } elseif ($d === false) {
             return 'false';
         } elseif (is_array($d)) {
-            $res = array();
+            $res = [];
             foreach ($d as $k => $v) {
                 $res[$k] = self::_encodeObjects($v);
             }
@@ -54,17 +54,13 @@ class ApiRequestor
      */
     public function request($method, $url, $params = null, $headers = null)
     {
-        if (!$params) {
-            $params = array();
-        }
-        if (!$headers) {
-            $headers = array();
-        }
+        $params = $params ?: [];
+        $headers = $headers ?: [];
         list($rbody, $rcode, $rheaders, $myApiKey) =
         $this->_requestRaw($method, $url, $params, $headers);
         $json = $this->_interpretResponse($rbody, $rcode, $rheaders);
         $resp = new ApiResponse($rbody, $rcode, $rheaders, $json);
-        return array($resp, $myApiKey);
+        return [$resp, $myApiKey];
     }
 
     /**
@@ -181,13 +177,13 @@ class ApiRequestor
         $uname = php_uname();
 
         $appInfo = Stripe::getAppInfo();
-        $ua = array(
+        $ua = [
             'bindings_version' => Stripe::VERSION,
             'lang' => 'php',
             'lang_version' => $langVersion,
             'publisher' => 'stripe',
             'uname' => $uname,
-        );
+        ];
         if ($clientInfo) {
             $ua = array_merge($clientInfo, $ua);
         }
@@ -196,11 +192,11 @@ class ApiRequestor
             $ua['application'] = $appInfo;
         }
 
-        $defaultHeaders = array(
+        $defaultHeaders = [
             'X-Stripe-Client-User-Agent' => json_encode($ua),
             'User-Agent' => $uaString,
             'Authorization' => 'Bearer ' . $apiKey,
-        );
+        ];
         return $defaultHeaders;
     }
 
@@ -256,7 +252,7 @@ class ApiRequestor
         }
 
         $combinedHeaders = array_merge($defaultHeaders, $headers);
-        $rawHeaders = array();
+        $rawHeaders = [];
 
         foreach ($combinedHeaders as $header => $value) {
             $rawHeaders[] = $header . ': ' . $value;
@@ -269,7 +265,7 @@ class ApiRequestor
             $params,
             $hasFile
         );
-        return array($rbody, $rcode, $rheaders, $myApiKey);
+        return [$rbody, $rcode, $rheaders, $myApiKey];
     }
 
     private function _processResourceParam($resource, $hasCurlFile)

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -9,7 +9,7 @@ namespace Stripe;
  */
 abstract class ApiResource extends StripeObject
 {
-    private static $HEADERS_TO_PERSIST = array('Stripe-Account' => true, 'Stripe-Version' => true);
+    private static $HEADERS_TO_PERSIST = ['Stripe-Account' => true, 'Stripe-Version' => true];
 
     public static function baseUrl()
     {
@@ -98,18 +98,18 @@ abstract class ApiResource extends StripeObject
         if ($params && !is_array($params)) {
             $message = "You must pass an array as the first argument to Stripe API "
                . "method calls.  (HINT: an example call to create a charge "
-               . "would be: \"Stripe\\Charge::create(array('amount' => 100, "
-               . "'currency' => 'usd', 'source' => 'tok_1234'))\")";
+               . "would be: \"Stripe\\Charge::create(['amount' => 100, "
+               . "'currency' => 'usd', 'source' => 'tok_1234'])\")";
             throw new Error\Api($message);
         }
     }
 
-    protected function _request($method, $url, $params = array(), $options = null)
+    protected function _request($method, $url, $params = [], $options = null)
     {
         $opts = $this->_opts->merge($options);
         list($resp, $options) = static::_staticRequest($method, $url, $params, $opts);
         $this->setLastResponse($resp);
-        return array($resp->json, $options);
+        return [$resp->json, $options];
     }
 
     protected static function _staticRequest($method, $url, $params, $options)
@@ -122,7 +122,7 @@ abstract class ApiResource extends StripeObject
                 unset($opts->headers[$k]);
             }
         }
-        return array($response, $opts);
+        return [$response, $opts];
     }
 
     protected static function _retrieve($id, $options = null)

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -136,7 +136,7 @@ class Charge extends ApiResource
     {
         $url = $this->instanceUrl() . '/dispute';
         list($response, $opts) = $this->_request('post', $url, $params, $options);
-        $this->refreshFrom(array('dispute' => $response), $opts, true);
+        $this->refreshFrom(['dispute' => $response], $opts, true);
         return $this->dispute;
     }
 
@@ -162,7 +162,7 @@ class Charge extends ApiResource
      */
     public function markAsFraudulent($opts = null)
     {
-        $params = array('fraud_details' => array('user_report' => 'fraudulent'));
+        $params = ['fraud_details' => ['user_report' => 'fraudulent']];
         $url = $this->instanceUrl();
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
@@ -176,7 +176,7 @@ class Charge extends ApiResource
      */
     public function markAsSafe($opts = null)
     {
-        $params = array('fraud_details' => array('user_report' => 'safe'));
+        $params = ['fraud_details' => ['user_report' => 'safe']];
         $url = $this->instanceUrl();
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -14,7 +14,7 @@ namespace Stripe;
  */
 class Collection extends ApiResource
 {
-    protected $_requestParams = array();
+    protected $_requestParams = [];
 
     public function setRequestParams($params)
     {
@@ -76,12 +76,11 @@ class Collection extends ApiResource
         if (isset($url['query'])) {
             // If the URL contains a query param, parse it out into $params so they
             // don't interact weirdly with each other.
-            $query = array();
+            $query = [];
             parse_str($url['query'], $query);
-            // PHP 5.2 doesn't support the ?: operator :(
-            $params = array_merge($params ? $params : array(), $query);
+            $params = array_merge($params ?: [], $query);
         }
 
-        return array($url['path'], $params);
+        return [$url['path'], $params];
     }
 }

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -102,9 +102,7 @@ class Customer extends ApiResource
      */
     public function addInvoiceItem($params = null)
     {
-        if (!$params) {
-            $params = array();
-        }
+        $params = $params ?: [];
         $params['customer'] = $this->id;
         $ii = InvoiceItem::create($params, $this->_opts);
         return $ii;
@@ -117,9 +115,7 @@ class Customer extends ApiResource
      */
     public function invoices($params = null)
     {
-        if (!$params) {
-            $params = array();
-        }
+        $params = $params ?: [];
         $params['customer'] = $this->id;
         $invoices = Invoice::all($params, $this->_opts);
         return $invoices;
@@ -132,9 +128,7 @@ class Customer extends ApiResource
      */
     public function invoiceItems($params = null)
     {
-        if (!$params) {
-            $params = array();
-        }
+        $params = $params ?: [];
         $params['customer'] = $this->id;
         $iis = InvoiceItem::all($params, $this->_opts);
         return $iis;
@@ -147,9 +141,7 @@ class Customer extends ApiResource
      */
     public function charges($params = null)
     {
-        if (!$params) {
-            $params = array();
-        }
+        $params = $params ?: [];
         $params['customer'] = $this->id;
         $charges = Charge::all($params, $this->_opts);
         return $charges;
@@ -164,7 +156,7 @@ class Customer extends ApiResource
     {
         $url = $this->instanceUrl() . '/subscription';
         list($response, $opts) = $this->_request('post', $url, $params);
-        $this->refreshFrom(array('subscription' => $response), $opts, true);
+        $this->refreshFrom(['subscription' => $response], $opts, true);
         return $this->subscription;
     }
 
@@ -177,7 +169,7 @@ class Customer extends ApiResource
     {
         $url = $this->instanceUrl() . '/subscription';
         list($response, $opts) = $this->_request('delete', $url, $params);
-        $this->refreshFrom(array('subscription' => $response), $opts, true);
+        $this->refreshFrom(['subscription' => $response], $opts, true);
         return $this->subscription;
     }
 
@@ -188,7 +180,7 @@ class Customer extends ApiResource
     {
         $url = $this->instanceUrl() . '/discount';
         list($response, $opts) = $this->_request('delete', $url);
-        $this->refreshFrom(array('discount' => null), $opts, true);
+        $this->refreshFrom(['discount' => null], $opts, true);
     }
 
     /**

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -12,7 +12,7 @@ interface ClientInterface
      * @param boolean $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CurlFile)
      * @throws \Stripe\Error\Api & \Stripe\Error\ApiConnection
-     * @return array($rawBody, $httpStatusCode, $httpHeader)
+     * @return [$rawBody, $httpStatusCode, $httpHeader]
      */
     public function request($method, $absUrl, $headers, $params, $hasFile);
 }

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -60,10 +60,10 @@ class CurlClient implements ClientInterface
     public function initUserAgentInfo()
     {
         $curlVersion = curl_version();
-        $this->userAgentInfo = array(
+        $this->userAgentInfo = [
             'httplib' =>  'curl ' . $curlVersion['version'],
             'ssllib' => $curlVersion['ssl_version'],
-        );
+        ];
     }
 
     public function getDefaultOptions()
@@ -113,7 +113,7 @@ class CurlClient implements ClientInterface
         $curl = curl_init();
         $method = strtolower($method);
 
-        $opts = array();
+        $opts = [];
         if (is_callable($this->defaultOptions)) { // call defaultOptions callback, set options to return value
             $opts = call_user_func_array($this->defaultOptions, func_get_args());
             if (!is_array($opts)) {
@@ -148,7 +148,7 @@ class CurlClient implements ClientInterface
         }
 
         // Create a callback to capture HTTP headers for the response
-        $rheaders = array();
+        $rheaders = [];
         $headerCallback = function ($curl, $header_line) use (&$rheaders) {
             // Ignore the HTTP request line (HTTP/1.1 200 OK)
             if (strpos($header_line, ":") === false) {
@@ -215,7 +215,7 @@ class CurlClient implements ClientInterface
 
         $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
-        return array($rbody, $rcode, $rheaders);
+        return [$rbody, $rcode, $rheaders];
     }
 
     /**

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -14,9 +14,7 @@ abstract class OAuth
      */
     public static function authorizeUrl($params = null, $opts = null)
     {
-        if (!$params) {
-            $params = array();
-        }
+        $params = $params ?: [];
 
         $base = ($opts && array_key_exists('connect_base', $opts)) ? $opts['connect_base'] : Stripe::$connectBase;
 
@@ -61,10 +59,7 @@ abstract class OAuth
      */
     public static function deauthorize($params = null, $opts = null)
     {
-        if (!$params) {
-            $params = array();
-        }
-
+        $params = $params ?: [];
         $base = ($opts && array_key_exists('connect_base', $opts)) ? $opts['connect_base'] : Stripe::$connectBase;
         $requestor = new ApiRequestor(null, $base);
         $params['client_id'] = self::_getClientId($params);

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -83,9 +83,7 @@ class Recipient extends ApiResource
      */
     public function transfers($params = null)
     {
-        if ($params === null) {
-            $params = array();
-        }
+        $params = $params ?: [];
         $params['recipient'] = $this->id;
         $transfers = Transfer::all($params, $this->_opts);
         return $transfers;

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -165,9 +165,7 @@ class Stripe
      */
     public static function setAppInfo($appName, $appVersion = null, $appUrl = null)
     {
-        if (self::$appInfo === null) {
-            self::$appInfo = array();
-        }
+        self::$appInfo = self::$appInfo ?: [];
         self::$appInfo['name'] = $appName;
         self::$appInfo['version'] = $appVersion;
         self::$appInfo['url'] = $appUrl;

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -22,8 +22,8 @@ class StripeObject implements \ArrayAccess, \JsonSerializable
 
     public static function init()
     {
-        self::$permanentAttributes = new Util\Set(array('_opts', 'id'));
-        self::$nestedUpdatableAttributes = new Util\Set(array(
+        self::$permanentAttributes = new Util\Set(['_opts', 'id']);
+        self::$nestedUpdatableAttributes = new Util\Set([
             // Numbers are in place for indexes in an `additional_owners` array.
             //
             // There's a maximum allowed additional owners of 3, but leave the
@@ -48,7 +48,7 @@ class StripeObject implements \ArrayAccess, \JsonSerializable
             'tos_acceptance',
             'transfer_schedule',
             'verification',
-        ));
+        ]);
     }
 
     /**
@@ -79,11 +79,11 @@ class StripeObject implements \ArrayAccess, \JsonSerializable
     public function __construct($id = null, $opts = null)
     {
         $this->_opts = $opts ? $opts : new Util\RequestOptions();
-        $this->_values = array();
+        $this->_values = [];
         $this->_unsavedValues = new Util\Set();
         $this->_transientValues = new Util\Set();
 
-        $this->_retrieveOptions = array();
+        $this->_retrieveOptions = [];
         if (is_array($id)) {
             foreach ($id as $key => $value) {
                 if ($key != 'id') {
@@ -255,7 +255,7 @@ class StripeObject implements \ArrayAccess, \JsonSerializable
      */
     public function serializeParameters()
     {
-        $params = array();
+        $params = [];
         if ($this->_unsavedValues) {
             foreach ($this->_unsavedValues->toArray() as $k) {
                 $v = $this->$k;

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -93,6 +93,6 @@ class Subscription extends ApiResource
     {
         $url = $this->instanceUrl() . '/discount';
         list($response, $opts) = $this->_request('delete', $url);
-        $this->refreshFrom(array('discount' => null), $opts, true);
+        $this->refreshFrom(['discount' => null], $opts, true);
     }
 }

--- a/lib/Util/AutoPagingIterator.php
+++ b/lib/Util/AutoPagingIterator.php
@@ -7,7 +7,7 @@ class AutoPagingIterator implements \Iterator
     private $lastId = null;
     private $page = null;
     private $pageOffset = 0;
-    private $params = array();
+    private $params = [];
 
     public function __construct($collection, $params)
     {
@@ -42,8 +42,8 @@ class AutoPagingIterator implements \Iterator
             $this->pageOffset += count($this->page->data);
             if ($this->page['has_more']) {
                 $this->params = array_merge(
-                    $this->params ? $this->params : array(),
-                    array('starting_after' => $this->lastId)
+                    $this->params ?: [],
+                    ['starting_after' => $this->lastId]
                 );
                 $this->page = $this->page->all($this->params);
             } else {

--- a/lib/Util/DefaultLogger.php
+++ b/lib/Util/DefaultLogger.php
@@ -8,7 +8,7 @@ namespace Stripe\Util;
  */
 class DefaultLogger implements LoggerInterface
 {
-    public function error($message, array $context = array())
+    public function error($message, array $context = [])
     {
         if (count($context) > 0) {
             throw new Exception('DefaultLogger does not currently implement context. Please implement if you need it.');

--- a/lib/Util/LoggerInterface.php
+++ b/lib/Util/LoggerInterface.php
@@ -32,5 +32,5 @@ interface LoggerInterface
      * @param array $context
      * @return null
      */
-    public function error($message, array $context = array());
+    public function error($message, array $context = []);
 }

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -9,7 +9,7 @@ class RequestOptions
     public $headers;
     public $apiKey;
 
-    public function __construct($key = null, $headers = array())
+    public function __construct($key = null, $headers = [])
     {
         $this->apiKey = $key;
         $this->headers = $headers;
@@ -45,15 +45,15 @@ class RequestOptions
         }
 
         if (is_null($options)) {
-            return new RequestOptions(null, array());
+            return new RequestOptions(null, []);
         }
 
         if (is_string($options)) {
-            return new RequestOptions($options, array());
+            return new RequestOptions($options, []);
         }
 
         if (is_array($options)) {
-            $headers = array();
+            $headers = [];
             $key = null;
             if (array_key_exists('api_key', $options)) {
                 $key = $options['api_key'];

--- a/lib/Util/Set.php
+++ b/lib/Util/Set.php
@@ -9,9 +9,9 @@ class Set implements IteratorAggregate
 {
     private $_elts;
 
-    public function __construct($members = array())
+    public function __construct($members = [])
     {
-        $this->_elts = array();
+        $this->_elts = [];
         foreach ($members as $item) {
             $this->_elts[$item] = true;
         }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -38,7 +38,7 @@ abstract class Util
      */
     public static function convertStripeObjectToArray($values)
     {
-        $results = array();
+        $results = [];
         foreach ($values as $k => $v) {
             // FIXME: this is an encapsulation violation
             if ($k[0] == '_') {
@@ -64,7 +64,7 @@ abstract class Util
      */
     public static function convertToStripeObject($resp, $opts)
     {
-        $types = array(
+        $types = [
             // data structures
             'list' => 'Stripe\\Collection',
 
@@ -109,9 +109,9 @@ abstract class Util
             'token' => 'Stripe\\Token',
             'transfer' => 'Stripe\\Transfer',
             'transfer_reversal' => 'Stripe\\TransferReversal',
-        );
+        ];
         if (self::isList($resp)) {
-            $mapped = array();
+            $mapped = [];
             foreach ($resp as $i) {
                 array_push($mapped, self::convertToStripeObject($i, $opts));
             }
@@ -195,7 +195,7 @@ abstract class Util
             return $arr;
         }
 
-        $r = array();
+        $r = [];
         foreach ($arr as $k => $v) {
             if (is_null($v)) {
                 continue;

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -103,7 +103,7 @@ abstract class WebhookSignature
      */
     private static function getSignatures($header, $scheme)
     {
-        $signatures = array();
+        $signatures = [];
         $items = explode(",", $header);
 
         foreach ($items as $item) {

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -44,7 +44,7 @@ class AccountTest extends TestCase
             'post',
             '/v1/accounts'
         );
-        $resource = Account::create(array("type" => "custom"));
+        $resource = Account::create(["type" => "custom"]);
         $this->assertSame("Stripe\\Account", get_class($resource));
     }
 
@@ -66,9 +66,9 @@ class AccountTest extends TestCase
             'post',
             '/v1/accounts/' . self::TEST_RESOURCE_ID
         );
-        $resource = Account::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Account::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Account", get_class($resource));
     }
 
@@ -90,7 +90,7 @@ class AccountTest extends TestCase
             'post',
             '/v1/accounts/' . $account->id . '/reject'
         );
-        $resource = $account->reject(array("reason" => "fraud"));
+        $resource = $account->reject(["reason" => "fraud"]);
         $this->assertSame("Stripe\\Account", get_class($resource));
         $this->assertSame($resource, $account);
     }
@@ -101,15 +101,15 @@ class AccountTest extends TestCase
         $this->stubRequest(
             'post',
             '/oauth/deauthorize',
-            array(
+            [
                 'client_id' => Stripe::getClientId(),
                 'stripe_user_id' => $resource->id,
-            ),
+            ],
             null,
             false,
-            array(
+            [
                 'stripe_user_id' => $resource->id,
-            ),
+            ],
             200,
             Stripe::$connectBase
         );
@@ -122,7 +122,9 @@ class AccountTest extends TestCase
             'post',
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
         );
-        $resource = Account::createExternalAccount(self::TEST_RESOURCE_ID, array("external_account" => "btok_123"));
+        $resource = Account::createExternalAccount(self::TEST_RESOURCE_ID, [
+            "external_account" => "btok_123",
+        ]);
         $this->assertSame("Stripe\\BankAccount", get_class($resource));
     }
 
@@ -142,7 +144,9 @@ class AccountTest extends TestCase
             'post',
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
-        $resource = Account::updateExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID, array("name" => "name"));
+        $resource = Account::updateExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID, [
+            "name" => "name",
+        ]);
         $this->assertSame("Stripe\\BankAccount", get_class($resource));
     }
 

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -12,19 +12,19 @@ class ApiRequestorTest extends TestCase
         $method = $reflector->getMethod('_encodeObjects');
         $method->setAccessible(true);
 
-        $a = array('customer' => new Customer('abcd'));
+        $a = ['customer' => new Customer('abcd')];
         $enc = $method->invoke(null, $a);
-        $this->assertSame($enc, array('customer' => 'abcd'));
+        $this->assertSame($enc, ['customer' => 'abcd']);
 
         // Preserves UTF-8
-        $v = array('customer' => "☃");
+        $v = ['customer' => "☃"];
         $enc = $method->invoke(null, $v);
         $this->assertSame($enc, $v);
 
         // Encodes latin-1 -> UTF-8
-        $v = array('customer' => "\xe9");
+        $v = ['customer' => "\xe9"];
         $enc = $method->invoke(null, $v);
-        $this->assertSame($enc, array('customer' => "\xc3\xa9"));
+        $this->assertSame($enc, ['customer' => "\xc3\xa9"]);
     }
 
     public function testHttpClientInjection()
@@ -50,7 +50,7 @@ class ApiRequestorTest extends TestCase
         // no way to stub static methods with PHPUnit 4.x :(
         Stripe::setAppInfo('MyTestApp', '1.2.34', 'https://mytestapp.example');
         $apiKey = 'sk_test_notarealkey';
-        $clientInfo = array('httplib' => 'testlib 0.1.2');
+        $clientInfo = ['httplib' => 'testlib 0.1.2'];
 
         $headers = $method->invoke(null, $apiKey, $clientInfo);
 
@@ -74,16 +74,16 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/charges',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'invalid_request_error',
                     'message' => 'Missing id',
                     'param' => 'id',
-                ),
-            ),
+                ],
+            ],
             400
         );
 
@@ -105,15 +105,15 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/charges',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'invalid_request_error',
                     'message' => 'You did not provide an API key.',
-                ),
-            ),
+                ],
+            ],
             401
         );
 
@@ -134,18 +134,18 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/charges',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'card_error',
                     'message' => 'Your card was declined.',
                     'code' => 'card_declined',
                     'decline_code' => 'generic_decline',
                     'charge' => 'ch_declined_charge',
-                ),
-            ),
+                ],
+            ],
             402
         );
 
@@ -168,15 +168,15 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'GET',
             '/v1/accounts/foo',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'invalid_request_error',
                     'message' => "The provided key 'sk_test_********************1234' does not have access to account 'foo' (or that account does not exist). Application access may have been revoked.",
-                ),
-            ),
+                ],
+            ],
             403
         );
 
@@ -197,16 +197,16 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'GET',
             '/v1/charges/foo',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'invalid_request_error',
                     'message' => 'No such charge: foo',
                     'param' => 'id',
-                ),
-            ),
+                ],
+            ],
             404
         );
 
@@ -228,14 +228,14 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/charges',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'message' => 'Too many requests',
-                ),
-            ),
+                ],
+            ],
             429
         );
 
@@ -256,13 +256,13 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/oauth/token',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'error' => 'invalid_request',
                 'error_description' => 'No grant type specified',
-            ),
+            ],
             400,
             Stripe::$connectBase
         );
@@ -284,13 +284,13 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/oauth/token',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'error' => 'invalid_client',
                 'error_description' => 'No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter.',
-            ),
+            ],
             401,
             Stripe::$connectBase
         );
@@ -312,13 +312,13 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/oauth/token',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'error' => 'invalid_grant',
                 'error_description' => 'This authorization code has already been used. All tokens issued with this code have been revoked.',
-            ),
+            ],
             400,
             Stripe::$connectBase
         );

--- a/tests/Stripe/ApplePayDomainTest.php
+++ b/tests/Stripe/ApplePayDomainTest.php
@@ -33,9 +33,9 @@ class ApplePayDomainTest extends TestCase
             'post',
             '/v1/apple_pay/domains'
         );
-        $resource = ApplePayDomain::create(array(
+        $resource = ApplePayDomain::create([
             "domain_name" => "domain",
-        ));
+        ]);
         $this->assertSame("Stripe\\ApplePayDomain", get_class($resource));
     }
 

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -9,21 +9,21 @@ class BankAccountTest extends TestCase
     public function testIsVerifiable()
     {
         $resource = BankAccount::constructFrom(
-            array(
+            [
                 'id' => self::TEST_RESOURCE_ID,
                 'object' => 'bank_account',
                 'customer' => 'cus_123',
-            ),
+            ],
             new Util\RequestOptions()
         );
         $this->expectsRequest(
             'post',
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID . "/verify",
-            array(
-                "amounts" => array(1, 2)
-            )
+            [
+                "amounts" => [1, 2]
+            ]
         );
-        $resource->verify(array("amounts" => array(1, 2)));
+        $resource->verify(["amounts" => [1, 2]]);
         $this->assertSame("Stripe\\BankAccount", get_class($resource));
     }
 }

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -33,11 +33,11 @@ class ChargeTest extends TestCase
             'post',
             '/v1/charges'
         );
-        $resource = Charge::create(array(
+        $resource = Charge::create([
             "amount" => 100,
             "currency" => "usd",
             "source" => "tok_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\Charge", get_class($resource));
     }
 
@@ -59,9 +59,9 @@ class ChargeTest extends TestCase
             'post',
             '/v1/charges/' . self::TEST_RESOURCE_ID
         );
-        $resource = Charge::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Charge::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Charge", get_class($resource));
     }
 
@@ -118,7 +118,7 @@ class ChargeTest extends TestCase
         $this->expectsRequest(
             'post',
             '/v1/charges/' . $charge->id,
-            array('fraud_details' => array('user_report' => 'fraudulent'))
+            ['fraud_details' => ['user_report' => 'fraudulent']]
         );
         $resource = $charge->markAsFraudulent();
         $this->assertSame("Stripe\\Charge", get_class($resource));
@@ -131,7 +131,7 @@ class ChargeTest extends TestCase
         $this->expectsRequest(
             'post',
             '/v1/charges/' . $charge->id,
-            array('fraud_details' => array('user_report' => 'safe'))
+            ['fraud_details' => ['user_report' => 'safe']]
         );
         $resource = $charge->markAsSafe();
         $this->assertSame("Stripe\\Charge", get_class($resource));

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -9,11 +9,11 @@ class CollectionTest extends TestCase
      */
     public function setUpFixture()
     {
-        $this->fixture = Collection::constructFrom(array(
-            'data' => array(array('id' => 1)),
+        $this->fixture = Collection::constructFrom([
+            'data' => [['id' => 1]],
             'has_more' => true,
             'url' => '/things',
-        ), new Util\RequestOptions());
+        ], new Util\RequestOptions());
     }
 
     public function testCanList()
@@ -21,14 +21,14 @@ class CollectionTest extends TestCase
         $this->stubRequest(
             'GET',
             '/things',
-            array(),
+            [],
             null,
             false,
-            array(
-                'data' => array(array('id' => 1)),
+            [
+                'data' => [['id' => 1]],
                 'has_more' => true,
                 'url' => '/things',
-            )
+            ]
         );
 
         $resources = $this->fixture->all();
@@ -40,12 +40,12 @@ class CollectionTest extends TestCase
         $this->stubRequest(
             'GET',
             '/things/1',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'id' => 1,
-            )
+            ]
         );
 
         $this->fixture->retrieve(1);
@@ -56,19 +56,19 @@ class CollectionTest extends TestCase
         $this->stubRequest(
             'POST',
             '/things',
-            array(
+            [
                 'foo' => 'bar',
-            ),
+            ],
             null,
             false,
-            array(
+            [
                 'id' => 2,
-            )
+            ]
         );
 
-        $this->fixture->create(array(
+        $this->fixture->create([
             'foo' => 'bar',
-        ));
+        ]);
     }
 
     public function testProvidesAutoPagingIterator()
@@ -76,23 +76,23 @@ class CollectionTest extends TestCase
         $this->stubRequest(
             'GET',
             '/things',
-            array(
+            [
                 'starting_after' => 1,
-            ),
+            ],
             null,
             false,
-            array(
-                'data' => array(array('id' => 2), array('id' => 3)),
+            [
+                'data' => [['id' => 2], ['id' => 3]],
                 'has_more' => false,
-            )
+            ]
         );
 
-        $seen = array();
+        $seen = [];
         foreach ($this->fixture->autoPagingIterator() as $item) {
             array_push($seen, $item['id']);
         }
 
-        $this->assertSame(array(1, 2, 3), $seen);
+        $this->assertSame([1, 2, 3], $seen);
     }
 
     public function testSupportsIteratorToArray()
@@ -100,22 +100,22 @@ class CollectionTest extends TestCase
         $this->stubRequest(
             'GET',
             '/things',
-            array(
+            [
                 'starting_after' => 1,
-            ),
+            ],
             null,
             false,
-            array(
-                'data' => array(array('id' => 2), array('id' => 3)),
+            [
+                'data' => [['id' => 2], ['id' => 3]],
                 'has_more' => false,
-            )
+            ]
         );
 
-        $seen = array();
+        $seen = [];
         foreach (iterator_to_array($this->fixture->autoPagingIterator()) as $item) {
             array_push($seen, $item['id']);
         }
 
-        $this->assertSame(array(1, 2, 3), $seen);
+        $this->assertSame([1, 2, 3], $seen);
     }
 }

--- a/tests/Stripe/CouponTest.php
+++ b/tests/Stripe/CouponTest.php
@@ -33,12 +33,12 @@ class CouponTest extends TestCase
             'post',
             '/v1/coupons'
         );
-        $resource = Coupon::create(array(
+        $resource = Coupon::create([
             "percent_off" => 25,
             "duration" => "repeating",
             "duration_in_months" => 3,
             "id" => self::TEST_RESOURCE_ID,
-        ));
+        ]);
         $this->assertSame("Stripe\\Coupon", get_class($resource));
     }
 
@@ -60,9 +60,9 @@ class CouponTest extends TestCase
             'post',
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
-        $resource = Coupon::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Coupon::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Coupon", get_class($resource));
     }
 

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -56,9 +56,9 @@ class CustomerTest extends TestCase
             'post',
             '/v1/customers/' . self::TEST_RESOURCE_ID
         );
-        $resource = Customer::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Customer::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Customer", get_class($resource));
     }
 
@@ -79,16 +79,16 @@ class CustomerTest extends TestCase
         $this->expectsRequest(
             'post',
             '/v1/invoiceitems',
-            array(
+            [
                 "amount" => 100,
                 "currency" => "usd",
                 "customer" => $customer->id
-            )
+            ]
         );
-        $resource = $customer->addInvoiceItem(array(
+        $resource = $customer->addInvoiceItem([
             "amount" => 100,
             "currency" => "usd"
-        ));
+        ]);
         $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
     }
 
@@ -98,7 +98,7 @@ class CustomerTest extends TestCase
         $this->expectsRequest(
             'get',
             '/v1/invoices',
-            array("customer" => $customer->id)
+            ["customer" => $customer->id]
         );
         $resources = $customer->invoices();
         $this->assertTrue(is_array($resources->data));
@@ -111,7 +111,7 @@ class CustomerTest extends TestCase
         $this->expectsRequest(
             'get',
             '/v1/invoiceitems',
-            array("customer" => $customer->id)
+            ["customer" => $customer->id]
         );
         $resources = $customer->invoiceItems();
         $this->assertTrue(is_array($resources->data));
@@ -124,7 +124,7 @@ class CustomerTest extends TestCase
         $this->expectsRequest(
             'get',
             '/v1/charges',
-            array("customer" => $customer->id)
+            ["customer" => $customer->id]
         );
         $resources = $customer->charges();
         $this->assertTrue(is_array($resources->data));
@@ -137,15 +137,15 @@ class CustomerTest extends TestCase
         $this->stubRequest(
             'post',
             '/v1/customers/' . $customer->id . '/subscription',
-            array("plan" => "plan"),
+            ["plan" => "plan"],
             null,
             false,
-            array(
+            [
                 "object" => "subscription",
                 "id" => "sub_foo"
-            )
+            ]
         );
-        $resource = $customer->updateSubscription(array("plan" => "plan"));
+        $resource = $customer->updateSubscription(["plan" => "plan"]);
         $this->assertSame("Stripe\\Subscription", get_class($resource));
         $this->assertSame("sub_foo", $customer->subscription->id);
     }
@@ -156,13 +156,13 @@ class CustomerTest extends TestCase
         $this->stubRequest(
             'delete',
             '/v1/customers/' . $customer->id . '/subscription',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 "object" => "subscription",
                 "id" => "sub_foo"
-            )
+            ]
         );
         $resource = $customer->cancelSubscription();
         $this->assertSame("Stripe\\Subscription", get_class($resource));
@@ -186,7 +186,7 @@ class CustomerTest extends TestCase
             'post',
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
         );
-        $resource = Customer::createSource(self::TEST_RESOURCE_ID, array("source" => "btok_123"));
+        $resource = Customer::createSource(self::TEST_RESOURCE_ID, ["source" => "btok_123"]);
         $this->assertSame("Stripe\\BankAccount", get_class($resource));
     }
 
@@ -206,7 +206,7 @@ class CustomerTest extends TestCase
             'post',
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
         );
-        $resource = Customer::updateSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, array("name" => "name"));
+        $resource = Customer::updateSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, ["name" => "name"]);
         // stripe-mock returns a Card on this method and not a bank account
         $this->assertSame("Stripe\\Card", get_class($resource));
     }

--- a/tests/Stripe/DisputeTest.php
+++ b/tests/Stripe/DisputeTest.php
@@ -45,9 +45,9 @@ class DisputeTest extends TestCase
             'post',
             '/v1/disputes/' . self::TEST_RESOURCE_ID
         );
-        $resource = Dispute::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Dispute::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Dispute", get_class($resource));
     }
 

--- a/tests/Stripe/EphemeralKeyTest.php
+++ b/tests/Stripe/EphemeralKeyTest.php
@@ -10,11 +10,11 @@ class EphemeralKeyTest extends TestCase
             'post',
             '/v1/ephemeral_keys',
             null,
-            array("Stripe-Version: 2017-05-25")
+            ["Stripe-Version: 2017-05-25"]
         );
-        $resource = EphemeralKey::create(array(
+        $resource = EphemeralKey::create([
             "customer" => "cus_123",
-        ), array("stripe_version" => "2017-05-25"));
+        ], ["stripe_version" => "2017-05-25"]);
         $this->assertSame("Stripe\\EphemeralKey", get_class($resource));
     }
 
@@ -23,16 +23,16 @@ class EphemeralKeyTest extends TestCase
      */
     public function testIsNotCreatableWithoutAnExplicitApiVersion()
     {
-        $resource = EphemeralKey::create(array(
+        $resource = EphemeralKey::create([
             "customer" => "cus_123",
-        ));
+        ]);
     }
 
     public function testIsDeletable()
     {
-        $key = EphemeralKey::create(array(
+        $key = EphemeralKey::create([
             "customer" => "cus_123",
-        ), array("stripe_version" => "2017-05-25"));
+        ], ["stripe_version" => "2017-05-25"]);
         $this->expectsRequest(
             'delete',
             '/v1/ephemeral_keys/' . $key->id

--- a/tests/Stripe/ExchangeRateTest.php
+++ b/tests/Stripe/ExchangeRateTest.php
@@ -9,24 +9,24 @@ class ExchangeRateTest extends TestCase
         $this->stubRequest(
             'get',
             '/v1/exchange_rates',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'object' => 'list',
-                'data' => array(
-                    array(
+                'data' => [
+                    [
                         'id' => 'eur',
                         'object' => 'exchange_rate',
-                        'rates' => array('usd' => 1.18221),
-                    ),
-                    array(
+                        'rates' => ['usd' => 1.18221],
+                    ],
+                    [
                         'id' => 'usd',
                         'object' => 'exchange_rate',
-                        'rates' => array('eur' => 0.845876),
-                    ),
-                ),
-            )
+                        'rates' => ['eur' => 0.845876],
+                    ],
+                ],
+            ]
         );
 
         $listRates = ExchangeRate::all();
@@ -39,14 +39,14 @@ class ExchangeRateTest extends TestCase
         $this->stubRequest(
             'get',
             '/v1/exchange_rates/usd',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'id' => 'usd',
                 'object' => 'exchange_rate',
-                'rates' => array('eur' => 0.845876),
-            )
+                'rates' => ['eur' => 0.845876],
+            ]
         );
         $rates = ExchangeRate::retrieve("usd");
         $this->assertEquals('exchange_rate', $rates->object);

--- a/tests/Stripe/FileUploadTest.php
+++ b/tests/Stripe/FileUploadTest.php
@@ -13,10 +13,10 @@ class FileUploadTest extends TestCase
     {
         // PHP <= 5.5 does not support arrays as class constants, so we set up
         // the fixture as an instance variable.
-        $this->fixture = array(
+        $this->fixture = [
             'id' => self::TEST_RESOURCE_ID,
             'object' => 'file_upload',
-        );
+        ];
     }
 
     public function testIsListable()
@@ -24,14 +24,14 @@ class FileUploadTest extends TestCase
         $this->stubRequest(
             'get',
             '/v1/files',
-            array(),
+            [],
             null,
             false,
-            array(
+            [
                 'object' => 'list',
-                'data' => array($this->fixture),
+                'data' => [$this->fixture],
                 'resource_url' => '/v1/files',
-            ),
+            ],
             200,
             Stripe::$apiUploadBase
         );
@@ -46,7 +46,7 @@ class FileUploadTest extends TestCase
         $this->stubRequest(
             'get',
             '/v1/files/' . self::TEST_RESOURCE_ID,
-            array(),
+            [],
             null,
             false,
             $this->fixture,
@@ -63,17 +63,17 @@ class FileUploadTest extends TestCase
             'post',
             '/v1/files',
             null,
-            array('Content-Type: multipart/form-data'),
+            ['Content-Type: multipart/form-data'],
             true,
             $this->fixture,
             200,
             Stripe::$apiUploadBase
         );
         $fp = fopen(dirname(__FILE__) . '/../data/test.png', 'r');
-        $resource = FileUpload::create(array(
+        $resource = FileUpload::create([
             "purpose" => "dispute_evidence",
             "file" => $fp,
-        ));
+        ]);
         $this->assertSame("Stripe\\FileUpload", get_class($resource));
     }
 
@@ -88,17 +88,17 @@ class FileUploadTest extends TestCase
             'post',
             '/v1/files',
             null,
-            array('Content-Type: multipart/form-data'),
+            ['Content-Type: multipart/form-data'],
             true,
             $this->fixture,
             200,
             Stripe::$apiUploadBase
         );
         $curlFile = new \CurlFile(dirname(__FILE__) . '/../data/test.png');
-        $resource = FileUpload::create(array(
+        $resource = FileUpload::create([
             "purpose" => "dispute_evidence",
             "file" => $curlFile,
-        ));
+        ]);
         $this->assertSame("Stripe\\FileUpload", get_class($resource));
     }
 }

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -35,7 +35,7 @@ class CurlClientTest extends TestCase
     public function testDefaultOptions()
     {
         // make sure options array loads/saves properly
-        $optionsArray = array(CURLOPT_PROXY => 'localhost:80');
+        $optionsArray = [CURLOPT_PROXY => 'localhost:80'];
         $withOptionsArray = new CurlClient($optionsArray);
         $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
 
@@ -43,24 +43,24 @@ class CurlClientTest extends TestCase
         $ref = null;
         $withClosure = new CurlClient(function ($method, $absUrl, $headers, $params, $hasFile) use (&$ref) {
             $ref = func_get_args();
-            return array();
+            return [];
         });
 
-        $withClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
-        $this->assertSame($ref, array('get', 'https://httpbin.org/status/200', array(), array(), false));
+        $withClosure->request('get', 'https://httpbin.org/status/200', [], [], false);
+        $this->assertSame($ref, ['get', 'https://httpbin.org/status/200', [], [], false]);
 
         // this is the last test case that will run, since it'll throw an exception at the end
         $withBadClosure = new CurlClient(function () {
             return 'thisShouldNotWork';
         });
         $this->setExpectedException('Stripe\Error\Api', "Non-array value returned by defaultOptions CurlClient callback");
-        $withBadClosure->request('get', 'https://httpbin.org/status/200', array(), array(), false);
+        $withBadClosure->request('get', 'https://httpbin.org/status/200', [], [], false);
     }
 
     public function testSslOption()
     {
         // make sure options array loads/saves properly
-        $optionsArray = array(CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1);
+        $optionsArray = [CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1];
         $withOptionsArray = new CurlClient($optionsArray);
         $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
     }

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -33,11 +33,11 @@ class InvoiceItemTest extends TestCase
             'post',
             '/v1/invoiceitems'
         );
-        $resource = InvoiceItem::create(array(
+        $resource = InvoiceItem::create([
             "amount" => 100,
             "currency" => "usd",
             "customer" => "cus_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
     }
 
@@ -59,9 +59,9 @@ class InvoiceItemTest extends TestCase
             'post',
             '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
         );
-        $resource = InvoiceItem::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = InvoiceItem::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
     }
 

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -33,9 +33,9 @@ class InvoiceTest extends TestCase
             'post',
             '/v1/invoices'
         );
-        $resource = Invoice::create(array(
+        $resource = Invoice::create([
             "customer" => "cus_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\Invoice", get_class($resource));
     }
 
@@ -57,9 +57,9 @@ class InvoiceTest extends TestCase
             'post',
             '/v1/invoices/' . self::TEST_RESOURCE_ID
         );
-        $resource = Invoice::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Invoice::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Invoice", get_class($resource));
     }
 
@@ -69,7 +69,7 @@ class InvoiceTest extends TestCase
             'get',
             '/v1/invoices/upcoming'
         );
-        $resource = Invoice::upcoming(array("customer" => "cus_123"));
+        $resource = Invoice::upcoming(["customer" => "cus_123"]);
         $this->assertSame("Stripe\\Invoice", get_class($resource));
     }
 

--- a/tests/Stripe/OAuthTest.php
+++ b/tests/Stripe/OAuthTest.php
@@ -22,15 +22,15 @@ class OAuthTest extends TestCase
 
     public function testAuthorizeUrl()
     {
-        $uriStr = OAuth::authorizeUrl(array(
+        $uriStr = OAuth::authorizeUrl([
             'scope' => 'read_write',
             'state' => 'csrf_token',
-            'stripe_user' => array(
+            'stripe_user' => [
                 'email' => 'test@example.com',
                 'url' => 'https://example.com/profile/test',
                 'country' => 'US',
-            ),
-        ));
+            ],
+        ]);
 
         $uri = parse_url($uriStr);
         parse_str($uri['query'], $params);
@@ -51,13 +51,13 @@ class OAuthTest extends TestCase
         $this->stubRequest(
             'POST',
             '/oauth/token',
-            array(
+            [
                 'grant_type' => 'authorization_code',
                 'code' => 'this_is_an_authorization_code',
-            ),
+            ],
             null,
             false,
-            array(
+            [
                 'access_token' => 'sk_access_token',
                 'scope' => 'read_only',
                 'livemode' => false,
@@ -65,15 +65,15 @@ class OAuthTest extends TestCase
                 'refresh_token' => 'sk_refresh_token',
                 'stripe_user_id' => 'acct_test',
                 'stripe_publishable_key' => 'pk_test',
-            ),
+            ],
             200,
             Stripe::$connectBase
         );
 
-        $resp = OAuth::token(array(
+        $resp = OAuth::token([
             'grant_type' => 'authorization_code',
             'code' => 'this_is_an_authorization_code',
-        ));
+        ]);
         $this->assertSame('sk_access_token', $resp->access_token);
     }
 
@@ -82,22 +82,22 @@ class OAuthTest extends TestCase
         $this->stubRequest(
             'POST',
             '/oauth/deauthorize',
-            array(
+            [
                 'stripe_user_id' => 'acct_test_deauth',
                 'client_id' => 'ca_test',
-            ),
+            ],
             null,
             false,
-            array(
+            [
                 'stripe_user_id' => 'acct_test_deauth',
-            ),
+            ],
             200,
             Stripe::$connectBase
         );
 
-        $resp = OAuth::deauthorize(array(
+        $resp = OAuth::deauthorize([
                 'stripe_user_id' => 'acct_test_deauth',
-        ));
+        ]);
         $this->assertSame('acct_test_deauth', $resp->stripe_user_id);
     }
 }

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -33,9 +33,9 @@ class OrderTest extends TestCase
             'post',
             '/v1/orders'
         );
-        $resource = Order::create(array(
+        $resource = Order::create([
             'currency' => 'usd'
-        ));
+        ]);
         $this->assertSame("Stripe\\Order", get_class($resource));
     }
 
@@ -57,9 +57,9 @@ class OrderTest extends TestCase
             'post',
             '/v1/orders/' . self::TEST_RESOURCE_ID
         );
-        $resource = Order::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Order::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Order", get_class($resource));
     }
 

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -33,10 +33,10 @@ class PayoutTest extends TestCase
             'post',
             '/v1/payouts'
         );
-        $resource = Payout::create(array(
+        $resource = Payout::create([
             "amount" => 100,
             "currency" => "usd"
-        ));
+        ]);
         $this->assertSame("Stripe\\Payout", get_class($resource));
     }
 
@@ -58,9 +58,9 @@ class PayoutTest extends TestCase
             'post',
             '/v1/payouts/' . self::TEST_RESOURCE_ID
         );
-        $resource = Payout::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Payout::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Payout", get_class($resource));
     }
 

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -33,13 +33,13 @@ class PlanTest extends TestCase
             'post',
             '/v1/plans'
         );
-        $resource = Plan::create(array(
+        $resource = Plan::create([
             'amount' => 100,
             'interval' => 'month',
             'currency' => 'usd',
             'name' => self::TEST_RESOURCE_ID,
             'id' => self::TEST_RESOURCE_ID
-        ));
+        ]);
         $this->assertSame("Stripe\\Plan", get_class($resource));
     }
 
@@ -61,9 +61,9 @@ class PlanTest extends TestCase
             'post',
             '/v1/plans/' . self::TEST_RESOURCE_ID
         );
-        $resource = Plan::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Plan::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Plan", get_class($resource));
     }
 

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -33,9 +33,9 @@ class ProductTest extends TestCase
             'post',
             '/v1/products'
         );
-        $resource = Product::create(array(
+        $resource = Product::create([
             'name' => 'name'
-        ));
+        ]);
         $this->assertSame("Stripe\\Product", get_class($resource));
     }
 
@@ -57,9 +57,9 @@ class ProductTest extends TestCase
             'post',
             '/v1/products/' . self::TEST_RESOURCE_ID
         );
-        $resource = Product::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Product::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Product", get_class($resource));
     }
 

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -33,10 +33,10 @@ class RecipientTest extends TestCase
             'post',
             '/v1/recipients'
         );
-        $resource = Recipient::create(array(
+        $resource = Recipient::create([
             "name" => "name",
             "type" => "individual"
-        ));
+        ]);
         $this->assertSame("Stripe\\Recipient", get_class($resource));
     }
 
@@ -58,9 +58,9 @@ class RecipientTest extends TestCase
             'post',
             '/v1/recipients/' . self::TEST_RESOURCE_ID
         );
-        $resource = Recipient::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Recipient::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Recipient", get_class($resource));
     }
 
@@ -81,7 +81,7 @@ class RecipientTest extends TestCase
         $this->expectsRequest(
             'get',
             '/v1/transfers',
-            array("recipient" => $recipient->id)
+            ["recipient" => $recipient->id]
         );
         $resources = $recipient->transfers();
         $this->assertTrue(is_array($resources->data));

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -33,9 +33,9 @@ class RefundTest extends TestCase
             'post',
             '/v1/refunds'
         );
-        $resource = Refund::create(array(
+        $resource = Refund::create([
             "charge" => "ch_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\Refund", get_class($resource));
     }
 
@@ -57,9 +57,9 @@ class RefundTest extends TestCase
             'post',
             '/v1/refunds/' . self::TEST_RESOURCE_ID
         );
-        $resource = Refund::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Refund::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Refund", get_class($resource));
     }
 }

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -33,15 +33,15 @@ class SKUTest extends TestCase
             'post',
             '/v1/skus'
         );
-        $resource = SKU::create(array(
+        $resource = SKU::create([
             'currency'  => 'usd',
-            'inventory' => array(
+            'inventory' => [
                 'type'     => 'finite',
                 'quantity' => 1
-            ),
+            ],
             'price'     => 100,
             'product'   => "prod_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\SKU", get_class($resource));
     }
 
@@ -63,9 +63,9 @@ class SKUTest extends TestCase
             'post',
             '/v1/skus/' . self::TEST_RESOURCE_ID
         );
-        $resource = SKU::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = SKU::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\SKU", get_class($resource));
     }
 

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -22,9 +22,9 @@ class SourceTest extends TestCase
             'post',
             '/v1/sources'
         );
-        $resource = Source::create(array(
+        $resource = Source::create([
             "type" => "card"
-        ));
+        ]);
         $this->assertSame("Stripe\\Source", get_class($resource));
     }
 
@@ -46,22 +46,22 @@ class SourceTest extends TestCase
             'post',
             '/v1/sources/' . self::TEST_RESOURCE_ID
         );
-        $resource = Source::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Source::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Source", get_class($resource));
     }
 
     public function testCanSaveCardExpiryDate()
     {
-        $response = array(
+        $response = [
             'id' => 'src_foo',
             'object' => 'source',
-            'card' => array(
+            'card' => [
                 'exp_month' => 8,
                 'exp_year' => 2019,
-            ),
-        );
+            ],
+        ];
         $source = Source::constructFrom(
             $response,
             new Util\RequestOptions()
@@ -72,12 +72,12 @@ class SourceTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/sources/src_foo',
-            array(
-                'card' => array(
+            [
+                'card' => [
                     'exp_month' => 12,
                     'exp_year' => 2022,
-                )
-            ),
+                ]
+            ],
             null,
             false,
             $response
@@ -131,7 +131,7 @@ class SourceTest extends TestCase
             'post',
             '/v1/sources/' . self::TEST_RESOURCE_ID . "/verify"
         );
-        $resource->verify(array("values" => array(32,45)));
+        $resource->verify(["values" => [32, 45]]);
         $this->assertSame("Stripe\\Source", get_class($resource));
     }
 }

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -38,7 +38,7 @@ class StripeObjectTest extends TestCase
     {
         $s = new StripeObject();
         $s->foo = 'a';
-        $this->assertSame($s->keys(), array('foo'));
+        $this->assertSame($s->keys(), ['foo']);
     }
 
     public function testToArray()
@@ -94,91 +94,91 @@ class StripeObjectTest extends TestCase
     {
         $s = new StripeObject();
 
-        $s->metadata = array('bar');
-        $this->assertSame($s->metadata, array('bar'));
-        $s->metadata = array('baz', 'qux');
-        $this->assertSame($s->metadata, array('baz', 'qux'));
+        $s->metadata = ['bar'];
+        $this->assertSame($s->metadata, ['bar']);
+        $s->metadata = ['baz', 'qux'];
+        $this->assertSame($s->metadata, ['baz', 'qux']);
     }
 
     public function testSerializeParametersEmptyObject()
     {
         $obj = new StripeObject();
-        $this->assertSame(array(), $obj->serializeParameters());
+        $this->assertSame([], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnNewObjectWithSubObject()
     {
         $obj = new StripeObject();
-        $obj->metadata = array('foo' => 'bar');
-        $this->assertSame(array('metadata' => array('foo' => 'bar')), $obj->serializeParameters());
+        $obj->metadata = ['foo' => 'bar'];
+        $this->assertSame(['metadata' => ['foo' => 'bar']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnMoreComplexObject()
     {
-        $obj = StripeObject::constructFrom(array(
-            'metadata' => StripeObject::constructFrom(array(
+        $obj = StripeObject::constructFrom([
+            'metadata' => StripeObject::constructFrom([
                 'bar' => null,
                 'baz' => null,
-            ), new Util\RequestOptions()),
-        ), new Util\RequestOptions());
+            ], new Util\RequestOptions()),
+        ], new Util\RequestOptions());
         $obj->metadata->bar = 'newbar';
-        $this->assertSame(array('metadata' => array('bar' => 'newbar')), $obj->serializeParameters());
+        $this->assertSame(['metadata' => ['bar' => 'newbar']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArray()
     {
-        $obj = StripeObject::constructFrom(array(
+        $obj = StripeObject::constructFrom([
             'foo' => null,
-        ), new Util\RequestOptions());
-        $obj->foo = array('new-value');
-        $this->assertSame(array('foo' => array('new-value')), $obj->serializeParameters());
+        ], new Util\RequestOptions());
+        $obj->foo = ['new-value'];
+        $this->assertSame(['foo' => ['new-value']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayThatShortens()
     {
-        $obj = StripeObject::constructFrom(array(
-            'foo' => array('0-index', '1-index', '2-index'),
-        ), new Util\RequestOptions());
-        $obj->foo = array('new-value');
-        $this->assertSame(array('foo' => array('new-value')), $obj->serializeParameters());
+        $obj = StripeObject::constructFrom([
+            'foo' => ['0-index', '1-index', '2-index'],
+        ], new Util\RequestOptions());
+        $obj->foo = ['new-value'];
+        $this->assertSame(['foo' => ['new-value']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayThatLengthens()
     {
-        $obj = StripeObject::constructFrom(array(
-            'foo' => array('0-index', '1-index', '2-index'),
-        ), new Util\RequestOptions());
+        $obj = StripeObject::constructFrom([
+            'foo' => ['0-index', '1-index', '2-index'],
+        ], new Util\RequestOptions());
         $obj->foo = array_fill(0, 4, 'new-value');
-        $this->assertSame(array('foo' => array_fill(0, 4, 'new-value')), $obj->serializeParameters());
+        $this->assertSame(['foo' => array_fill(0, 4, 'new-value')], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayOfHashes()
     {
-        $obj = StripeObject::constructFrom(array(
-            'additional_owners' => array(
-                StripeObject::constructFrom(array('bar' => null), new Util\RequestOptions())
-            ),
-        ), new Util\RequestOptions());
+        $obj = StripeObject::constructFrom([
+            'additional_owners' => [
+                StripeObject::constructFrom(['bar' => null], new Util\RequestOptions())
+            ],
+        ], new Util\RequestOptions());
         $obj->additional_owners[0]->bar = 'baz';
-        $this->assertSame(array('additional_owners' => array(array('bar' => 'baz'))), $obj->serializeParameters());
+        $this->assertSame(['additional_owners' => [['bar' => 'baz']]], $obj->serializeParameters());
     }
 
     public function testSerializeParametersDoesNotIncludeUnchangedValues()
     {
-        $obj = StripeObject::constructFrom(array(
+        $obj = StripeObject::constructFrom([
             'foo' => null,
-        ), new Util\RequestOptions());
-        $this->assertSame(array(), $obj->serializeParameters());
+        ], new Util\RequestOptions());
+        $this->assertSame([], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnReplacedAttachedObject()
     {
-        $obj = StripeObject::constructFrom(array(
-            'metadata' => AttachedObject::constructFrom(array(
+        $obj = StripeObject::constructFrom([
+            'metadata' => AttachedObject::constructFrom([
                 'bar' => 'foo',
-            ), new Util\RequestOptions()),
-        ), new Util\RequestOptions());
-        $obj->metadata = array('baz' => 'foo');
-        $this->assertSame(array('metadata' => array('bar' => '', 'baz' => 'foo')), $obj->serializeParameters());
+            ], new Util\RequestOptions()),
+        ], new Util\RequestOptions());
+        $obj->metadata = ['baz' => 'foo'];
+        $this->assertSame(['metadata' => ['bar' => '', 'baz' => 'foo']], $obj->serializeParameters());
     }
 }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -33,10 +33,10 @@ class SubscriptionItemTest extends TestCase
             'post',
             '/v1/subscription_items'
         );
-        $resource = SubscriptionItem::create(array(
+        $resource = SubscriptionItem::create([
             "plan" => "plan",
             "subscription" => "sub_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
     }
 
@@ -58,9 +58,9 @@ class SubscriptionItemTest extends TestCase
             'post',
             '/v1/subscription_items/' . self::TEST_RESOURCE_ID
         );
-        $resource = SubscriptionItem::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = SubscriptionItem::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
     }
 

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -33,10 +33,10 @@ class SubscriptionTest extends TestCase
             'post',
             '/v1/subscriptions'
         );
-        $resource = Subscription::create(array(
+        $resource = Subscription::create([
             "customer" => "cus_123",
             "plan" => "plan"
-        ));
+        ]);
         $this->assertSame("Stripe\\Subscription", get_class($resource));
     }
 
@@ -58,9 +58,9 @@ class SubscriptionTest extends TestCase
             'post',
             '/v1/subscriptions/' . self::TEST_RESOURCE_ID
         );
-        $resource = Subscription::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Subscription::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Subscription", get_class($resource));
     }
 

--- a/tests/Stripe/ThreeDSecureTest.php
+++ b/tests/Stripe/ThreeDSecureTest.php
@@ -22,11 +22,11 @@ class ThreeDSecureTest extends TestCase
             'post',
             '/v1/3d_secure'
         );
-        $resource = ThreeDSecure::create(array(
+        $resource = ThreeDSecure::create([
             "amount" => 100,
             "currency" => "usd",
             "return_url" => "url"
-        ));
+        ]);
         $this->assertSame("Stripe\\ThreeDSecure", get_class($resource));
     }
 }

--- a/tests/Stripe/TokenTest.php
+++ b/tests/Stripe/TokenTest.php
@@ -22,7 +22,7 @@ class TokenTest extends TestCase
             'post',
             '/v1/tokens'
         );
-        $resource = Token::create(array("card" => "tok_visa"));
+        $resource = Token::create(["card" => "tok_visa"]);
         $this->assertSame("Stripe\\Token", get_class($resource));
     }
 }

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -34,11 +34,11 @@ class TransferTest extends TestCase
             'post',
             '/v1/transfers'
         );
-        $resource = Transfer::create(array(
+        $resource = Transfer::create([
             "amount" => 100,
             "currency" => "usd",
             "destination" => "acct_123"
-        ));
+        ]);
         $this->assertSame("Stripe\\Transfer", get_class($resource));
     }
 
@@ -60,9 +60,9 @@ class TransferTest extends TestCase
             'post',
             '/v1/transfers/' . self::TEST_RESOURCE_ID
         );
-        $resource = Transfer::update(self::TEST_RESOURCE_ID, array(
-            "metadata" => array("key" => "value"),
-        ));
+        $resource = Transfer::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
         $this->assertSame("Stripe\\Transfer", get_class($resource));
     }
 
@@ -120,9 +120,9 @@ class TransferTest extends TestCase
         $resource = Transfer::updateReversal(
             self::TEST_RESOURCE_ID,
             self::TEST_REVERSAL_ID,
-            array(
-                "metadata" => array("key" => "value"),
-            )
+            [
+                "metadata" => ["key" => "value"],
+            ]
         );
         $this->assertSame("Stripe\\TransferReversal", get_class($resource));
     }

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -8,55 +8,55 @@ class RequestOptionsTest extends TestCase
     {
         $opts = Util\RequestOptions::parse("foo");
         $this->assertSame("foo", $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testNull()
     {
         $opts = Util\RequestOptions::parse(null);
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testEmptyArray()
     {
-        $opts = Util\RequestOptions::parse(array());
+        $opts = Util\RequestOptions::parse([]);
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testAPIKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'api_key' => 'foo',
-            )
+            ]
         );
         $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame(array(), $opts->headers);
+        $this->assertSame([], $opts->headers);
     }
 
     public function testIdempotentKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'idempotency_key' => 'foo',
-            )
+            ]
         );
         $this->assertSame(null, $opts->apiKey);
-        $this->assertSame(array('Idempotency-Key' => 'foo'), $opts->headers);
+        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     public function testKeyArray()
     {
         $opts = Util\RequestOptions::parse(
-            array(
+            [
                 'idempotency_key' => 'foo',
                 'api_key' => 'foo'
-            )
+            ]
         );
         $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame(array('Idempotency-Key' => 'foo'), $opts->headers);
+        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     /**

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -6,16 +6,16 @@ class UtilTest extends TestCase
 {
     public function testIsList()
     {
-        $list = array(5, 'nstaoush', array());
+        $list = [5, 'nstaoush', []];
         $this->assertTrue(Util\Util::isList($list));
 
-        $notlist = array(5, 'nstaoush', array(), 'bar' => 'baz');
+        $notlist = [5, 'nstaoush', [], 'bar' => 'baz'];
         $this->assertFalse(Util\Util::isList($notlist));
     }
 
     public function testThatPHPHasValueSemanticsForArrays()
     {
-        $original = array('php-arrays' => 'value-semantics');
+        $original = ['php-arrays' => 'value-semantics'];
         $derived = $original;
         $derived['php-arrays'] = 'reference-semantics';
 
@@ -24,10 +24,10 @@ class UtilTest extends TestCase
 
     public function testConvertStripeObjectToArrayIncludesId()
     {
-        $customer = Util\Util::convertToStripeObject(array(
+        $customer = Util\Util::convertToStripeObject([
             'id' => 'cus_123',
             'object' => 'customer',
-        ), null);
+        ], null);
         $this->assertTrue(array_key_exists("id", $customer->__toArray(true)));
     }
 
@@ -48,30 +48,30 @@ class UtilTest extends TestCase
 
     public function testUrlEncode()
     {
-        $a = array(
+        $a = [
             'my' => 'value',
-            'that' => array('your' => 'example'),
+            'that' => ['your' => 'example'],
             'bar' => 1,
             'baz' => null
-        );
+        ];
 
         $enc = Util\Util::urlEncode($a);
         $this->assertSame('my=value&that%5Byour%5D=example&bar=1', $enc);
 
-        $a = array('that' => array('your' => 'example', 'foo' => null));
+        $a = ['that' => ['your' => 'example', 'foo' => null]];
         $enc = Util\Util::urlEncode($a);
         $this->assertSame('that%5Byour%5D=example', $enc);
 
-        $a = array('that' => 'example', 'foo' => array('bar', 'baz'));
+        $a = ['that' => 'example', 'foo' => ['bar', 'baz']];
         $enc = Util\Util::urlEncode($a);
         $this->assertSame('that=example&foo%5B%5D=bar&foo%5B%5D=baz', $enc);
 
-        $a = array(
+        $a = [
             'my' => 'value',
-            'that' => array('your' => array('cheese', 'whiz', null)),
+            'that' => ['your' => ['cheese', 'whiz', null]],
             'bar' => 1,
             'baz' => null
-        );
+        ];
 
         $enc = Util\Util::urlEncode($a);
         $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
@@ -79,11 +79,11 @@ class UtilTest extends TestCase
         $this->assertSame($expected, $enc);
 
         // Ignores an empty array
-        $enc = Util\Util::urlEncode(array('foo' => array(), 'bar' => 'baz'));
+        $enc = Util\Util::urlEncode(['foo' => [], 'bar' => 'baz']);
         $expected = 'bar=baz';
         $this->assertSame($expected, $enc);
 
-        $a = array('foo' => array(array('bar' => 'baz'), array('bar' => 'bin')));
+        $a = ['foo' => [['bar' => 'baz'], ['bar' => 'bin']]];
         $enc = Util\Util::urlEncode($a);
         $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
     }

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -10,7 +10,7 @@ class WebhookTest extends TestCase
 }";
     const SECRET = "whsec_test_secret";
 
-    private function generateHeader($opts = array())
+    private function generateHeader($opts = [])
     {
         $timestamp = array_key_exists('timestamp', $opts) ? $opts['timestamp'] : time();
         $payload = array_key_exists('payload', $opts) ? $opts['payload'] : self::EVENT_PAYLOAD;
@@ -37,7 +37,7 @@ class WebhookTest extends TestCase
     public function testInvalidJson()
     {
         $payload = "this is not valid JSON";
-        $sigHeader = $this->generateHeader(array("payload" => $payload));
+        $sigHeader = $this->generateHeader(["payload" => $payload]);
         Webhook::constructEvent($payload, $sigHeader, self::SECRET);
     }
 
@@ -66,7 +66,7 @@ class WebhookTest extends TestCase
      */
     public function testNoSignaturesWithExpectedScheme()
     {
-        $sigHeader = $this->generateHeader(array("scheme" => "v0"));
+        $sigHeader = $this->generateHeader(["scheme" => "v0"]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
@@ -76,7 +76,7 @@ class WebhookTest extends TestCase
      */
     public function testNoValidSignatureForPayload()
     {
-        $sigHeader = $this->generateHeader(array("signature" => "bad_signature"));
+        $sigHeader = $this->generateHeader(["signature" => "bad_signature"]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
@@ -86,7 +86,7 @@ class WebhookTest extends TestCase
      */
     public function testTimestampOutsideTolerance()
     {
-        $sigHeader = $this->generateHeader(array("timestamp" => time() - 15));
+        $sigHeader = $this->generateHeader(["timestamp" => time() - 15]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10);
     }
 
@@ -104,7 +104,7 @@ class WebhookTest extends TestCase
 
     public function testTimestampOffButNoTolerance()
     {
-        $sigHeader = $this->generateHeader(array("timestamp" => 12345));
+        $sigHeader = $this->generateHeader(["timestamp" => 12345]);
         $this->assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -101,12 +101,12 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $params = null,
         $headers = null,
         $hasFile = false,
-        $response = array(),
+        $response = [],
         $rcode = 200,
         $base = null
     ) {
         $this->prepareRequestMock($method, $path, $params, $headers, $hasFile, $base)
-            ->willReturn(array(json_encode($response), $rcode, array()));
+            ->willReturn([json_encode($response), $rcode, []]);
     }
 
     /**


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @arcanedev-maroc 

Now that we're dropping support for <5.4, we can start using the short array syntax.
