### PR TITLE
Use assertInstanceOf where possible

### DIFF
--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -15,7 +15,7 @@ class AccountTest extends TestCase
         );
         $resources = Account::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Account", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Account", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID
         );
         $resource = Account::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsRetrievableWithoutId()
@@ -35,7 +35,7 @@ class AccountTest extends TestCase
             '/v1/account'
         );
         $resource = Account::retrieve();
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsCreatable()
@@ -45,7 +45,7 @@ class AccountTest extends TestCase
             '/v1/accounts'
         );
         $resource = Account::create(array("type" => "custom"));
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsSaveable()
@@ -57,7 +57,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsUpdatable()
@@ -69,7 +69,7 @@ class AccountTest extends TestCase
         $resource = Account::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsDeletable()
@@ -80,7 +80,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
     }
 
     public function testIsRejectable()
@@ -91,7 +91,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $account->id . '/reject'
         );
         $resource = $account->reject(array("reason" => "fraud"));
-        $this->assertSame("Stripe\\Account", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Account", $resource);
         $this->assertSame($resource, $account);
     }
 
@@ -123,7 +123,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
         );
         $resource = Account::createExternalAccount(self::TEST_RESOURCE_ID, array("external_account" => "btok_123"));
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanRetrieveExternalAccount()
@@ -133,7 +133,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
         $resource = Account::retrieveExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanUpdateExternalAccount()
@@ -143,7 +143,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
         $resource = Account::updateExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID, array("name" => "name"));
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanDeleteExternalAccount()
@@ -153,7 +153,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
         $resource = Account::deleteExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanListExternalAccounts()
@@ -173,6 +173,6 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/login_links'
         );
         $resource = Account::createLoginLink(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\LoginLink", get_class($resource));
+        $this->assertInstanceOf("Stripe\\LoginLink", $resource);
     }
 }

--- a/tests/Stripe/ApplePayDomainTest.php
+++ b/tests/Stripe/ApplePayDomainTest.php
@@ -14,7 +14,7 @@ class ApplePayDomainTest extends TestCase
         );
         $resources = ApplePayDomain::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\ApplePayDomain", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\ApplePayDomain", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains/' . self::TEST_RESOURCE_ID
         );
         $resource = ApplePayDomain::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\ApplePayDomain", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplePayDomain", $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class ApplePayDomainTest extends TestCase
         $resource = ApplePayDomain::create(array(
             "domain_name" => "domain",
         ));
-        $this->assertSame("Stripe\\ApplePayDomain", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplePayDomain", $resource);
     }
 
     public function testIsDeletable()
@@ -47,6 +47,6 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\ApplePayDomain", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplePayDomain", $resource);
     }
 }

--- a/tests/Stripe/ApplicationFeeRefundTest.php
+++ b/tests/Stripe/ApplicationFeeRefundTest.php
@@ -16,6 +16,6 @@ class ApplicationFeeRefundTest extends TestCase
             '/v1/application_fees/' . $resource->fee . '/refunds/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\ApplicationFeeRefund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplicationFeeRefund", $resource);
     }
 }

--- a/tests/Stripe/ApplicationFeeTest.php
+++ b/tests/Stripe/ApplicationFeeTest.php
@@ -15,7 +15,7 @@ class ApplicationFeeTest extends TestCase
         );
         $resources = ApplicationFee::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\ApplicationFee", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\ApplicationFee", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID
         );
         $resource = ApplicationFee::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\ApplicationFee", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplicationFee", $resource);
     }
 
     public function testCanCreateRefund()
@@ -35,7 +35,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
         );
         $resource = ApplicationFee::createRefund(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\ApplicationFeeRefund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplicationFeeRefund", $resource);
     }
 
     public function testCanRetrieveRefund()
@@ -45,7 +45,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
         );
         $resource = ApplicationFee::retrieveRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
-        $this->assertSame("Stripe\\ApplicationFeeRefund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplicationFeeRefund", $resource);
     }
 
     public function testCanUpdateRefund()
@@ -55,7 +55,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
         );
         $resource = ApplicationFee::updateRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
-        $this->assertSame("Stripe\\ApplicationFeeRefund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ApplicationFeeRefund", $resource);
     }
 
     public function testCanListRefunds()
@@ -66,6 +66,6 @@ class ApplicationFeeTest extends TestCase
         );
         $resources = ApplicationFee::allRefunds(self::TEST_RESOURCE_ID);
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\ApplicationFeeRefund", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\ApplicationFeeRefund", $resources->data[0]);
     }
 }

--- a/tests/Stripe/BalanceTest.php
+++ b/tests/Stripe/BalanceTest.php
@@ -11,6 +11,6 @@ class BalanceTest extends TestCase
             '/v1/balance'
         );
         $resource = Balance::retrieve();
-        $this->assertSame("Stripe\\Balance", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Balance", $resource);
     }
 }

--- a/tests/Stripe/BalanceTransactionTest.php
+++ b/tests/Stripe/BalanceTransactionTest.php
@@ -14,7 +14,7 @@ class BalanceTransactionTest extends TestCase
         );
         $resources = BalanceTransaction::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\BalanceTransaction", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\BalanceTransaction", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class BalanceTransactionTest extends TestCase
             '/v1/balance/history/' . self::TEST_RESOURCE_ID
         );
         $resource = BalanceTransaction::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\BalanceTransaction", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BalanceTransaction", $resource);
     }
 }

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -24,6 +24,6 @@ class BankAccountTest extends TestCase
             )
         );
         $resource->verify(array("amounts" => array(1, 2)));
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 }

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -14,7 +14,7 @@ class ChargeTest extends TestCase
         );
         $resources = Charge::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Charge", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Charge", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . self::TEST_RESOURCE_ID
         );
         $resource = Charge::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class ChargeTest extends TestCase
             "currency" => "usd",
             "source" => "tok_123"
         ));
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
     }
 
     public function testIsUpdatable()
@@ -62,7 +62,7 @@ class ChargeTest extends TestCase
         $resource = Charge::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
     }
 
     public function testCanRefund()
@@ -73,7 +73,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $charge->id . '/refund'
         );
         $resource = $charge->refund();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
         $this->assertSame($resource, $charge);
     }
 
@@ -85,7 +85,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $charge->id . '/capture'
         );
         $resource = $charge->capture();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
         $this->assertSame($resource, $charge);
     }
 
@@ -97,7 +97,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $charge->id . '/dispute'
         );
         $resource = $charge->updateDispute();
-        $this->assertSame("Stripe\\Dispute", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Dispute", $resource);
     }
 
     public function testCanCloseDispute()
@@ -108,7 +108,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $charge->id . '/dispute/close'
         );
         $resource = $charge->closeDispute();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
         $this->assertSame($resource, $charge);
     }
 
@@ -121,7 +121,7 @@ class ChargeTest extends TestCase
             array('fraud_details' => array('user_report' => 'fraudulent'))
         );
         $resource = $charge->markAsFraudulent();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
         $this->assertSame($resource, $charge);
     }
 
@@ -134,7 +134,7 @@ class ChargeTest extends TestCase
             array('fraud_details' => array('user_report' => 'safe'))
         );
         $resource = $charge->markAsSafe();
-        $this->assertSame("Stripe\\Charge", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
         $this->assertSame($resource, $charge);
     }
 }

--- a/tests/Stripe/CountrySpecTest.php
+++ b/tests/Stripe/CountrySpecTest.php
@@ -14,7 +14,7 @@ class CountrySpecTest extends TestCase
         );
         $resources = CountrySpec::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\CountrySpec", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\CountrySpec", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class CountrySpecTest extends TestCase
             '/v1/country_specs/' . self::TEST_RESOURCE_ID
         );
         $resource = CountrySpec::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\CountrySpec", get_class($resource));
+        $this->assertInstanceOf("Stripe\\CountrySpec", $resource);
     }
 }

--- a/tests/Stripe/CouponTest.php
+++ b/tests/Stripe/CouponTest.php
@@ -14,7 +14,7 @@ class CouponTest extends TestCase
         );
         $resources = Coupon::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Coupon", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Coupon", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource = Coupon::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Coupon", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Coupon", $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class CouponTest extends TestCase
             "duration_in_months" => 3,
             "id" => self::TEST_RESOURCE_ID,
         ));
-        $this->assertSame("Stripe\\Coupon", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Coupon", $resource);
     }
 
     public function testIsSaveable()
@@ -51,7 +51,7 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Coupon", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Coupon", $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class CouponTest extends TestCase
         $resource = Coupon::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Coupon", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Coupon", $resource);
     }
 
     public function testIsDeletable()
@@ -74,6 +74,6 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Coupon", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Coupon", $resource);
     }
 }

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -15,7 +15,7 @@ class CustomerTest extends TestCase
         );
         $resources = Customer::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Customer", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Customer", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID
         );
         $resource = Customer::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Customer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
     public function testIsCreatable()
@@ -35,7 +35,7 @@ class CustomerTest extends TestCase
             '/v1/customers'
         );
         $resource = Customer::create();
-        $this->assertSame("Stripe\\Customer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
     public function testIsSaveable()
@@ -47,7 +47,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Customer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
     public function testIsUpdatable()
@@ -59,7 +59,7 @@ class CustomerTest extends TestCase
         $resource = Customer::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Customer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
     public function testIsDeletable()
@@ -70,7 +70,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Customer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
     public function testCanAddInvoiceItem()
@@ -89,7 +89,7 @@ class CustomerTest extends TestCase
             "amount" => 100,
             "currency" => "usd"
         ));
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 
     public function testCanListInvoices()
@@ -102,7 +102,7 @@ class CustomerTest extends TestCase
         );
         $resources = $customer->invoices();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Invoice", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Invoice", $resources->data[0]);
     }
 
     public function testCanListInvoiceItems()
@@ -115,7 +115,7 @@ class CustomerTest extends TestCase
         );
         $resources = $customer->invoiceItems();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resources->data[0]);
     }
 
     public function testCanListCharges()
@@ -128,7 +128,7 @@ class CustomerTest extends TestCase
         );
         $resources = $customer->charges();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Charge", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Charge", $resources->data[0]);
     }
 
     public function testCanUpdateSubscription()
@@ -146,7 +146,7 @@ class CustomerTest extends TestCase
             )
         );
         $resource = $customer->updateSubscription(array("plan" => "plan"));
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
         $this->assertSame("sub_foo", $customer->subscription->id);
     }
 
@@ -165,7 +165,7 @@ class CustomerTest extends TestCase
             )
         );
         $resource = $customer->cancelSubscription();
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
         $this->assertSame("sub_foo", $customer->subscription->id);
     }
 
@@ -187,7 +187,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
         );
         $resource = Customer::createSource(self::TEST_RESOURCE_ID, array("source" => "btok_123"));
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanRetrieveSource()
@@ -197,7 +197,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
         );
         $resource = Customer::retrieveSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID);
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanUpdateSource()
@@ -208,7 +208,7 @@ class CustomerTest extends TestCase
         );
         $resource = Customer::updateSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, array("name" => "name"));
         // stripe-mock returns a Card on this method and not a bank account
-        $this->assertSame("Stripe\\Card", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Card", $resource);
     }
 
     public function testCanDeleteSource()
@@ -218,7 +218,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
         );
         $resource = Customer::deleteSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID);
-        $this->assertSame("Stripe\\BankAccount", get_class($resource));
+        $this->assertInstanceOf("Stripe\\BankAccount", $resource);
     }
 
     public function testCanListSources()

--- a/tests/Stripe/DisputeTest.php
+++ b/tests/Stripe/DisputeTest.php
@@ -14,7 +14,7 @@ class DisputeTest extends TestCase
         );
         $resources = Dispute::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Dispute", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Dispute", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . self::TEST_RESOURCE_ID
         );
         $resource = Dispute::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Dispute", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Dispute", $resource);
     }
 
     public function testIsSaveable()
@@ -36,7 +36,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Dispute", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Dispute", $resource);
     }
 
     public function testIsUpdatable()
@@ -48,7 +48,7 @@ class DisputeTest extends TestCase
         $resource = Dispute::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Dispute", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Dispute", $resource);
     }
 
     public function testIsClosable()
@@ -59,7 +59,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . $dispute->id . '/close'
         );
         $resource = $dispute->close();
-        $this->assertSame("Stripe\\Dispute", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Dispute", $resource);
         $this->assertSame($resource, $dispute);
     }
 }

--- a/tests/Stripe/EphemeralKeyTest.php
+++ b/tests/Stripe/EphemeralKeyTest.php
@@ -15,7 +15,7 @@ class EphemeralKeyTest extends TestCase
         $resource = EphemeralKey::create(array(
             "customer" => "cus_123",
         ), array("stripe_version" => "2017-05-25"));
-        $this->assertSame("Stripe\\EphemeralKey", get_class($resource));
+        $this->assertInstanceOf("Stripe\\EphemeralKey", $resource);
     }
 
     /**
@@ -38,6 +38,6 @@ class EphemeralKeyTest extends TestCase
             '/v1/ephemeral_keys/' . $key->id
         );
         $resource = $key->delete();
-        $this->assertSame("Stripe\\EphemeralKey", get_class($resource));
+        $this->assertInstanceOf("Stripe\\EphemeralKey", $resource);
     }
 }

--- a/tests/Stripe/EventTest.php
+++ b/tests/Stripe/EventTest.php
@@ -14,7 +14,7 @@ class EventTest extends TestCase
         );
         $resources = Event::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Event", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Event", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class EventTest extends TestCase
             '/v1/events/' . self::TEST_RESOURCE_ID
         );
         $resource = Event::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Event", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Event", $resource);
     }
 }

--- a/tests/Stripe/FileUploadTest.php
+++ b/tests/Stripe/FileUploadTest.php
@@ -38,7 +38,7 @@ class FileUploadTest extends TestCase
 
         $resources = FileUpload::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\FileUpload", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\FileUpload", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -54,7 +54,7 @@ class FileUploadTest extends TestCase
             Stripe::$apiUploadBase
         );
         $resource = FileUpload::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\FileUpload", get_class($resource));
+        $this->assertInstanceOf("Stripe\\FileUpload", $resource);
     }
 
     public function testIsCreatableWithFileHandle()
@@ -74,7 +74,7 @@ class FileUploadTest extends TestCase
             "purpose" => "dispute_evidence",
             "file" => $fp,
         ));
-        $this->assertSame("Stripe\\FileUpload", get_class($resource));
+        $this->assertInstanceOf("Stripe\\FileUpload", $resource);
     }
 
     public function testIsCreatableWithCurlFile()
@@ -99,6 +99,6 @@ class FileUploadTest extends TestCase
             "purpose" => "dispute_evidence",
             "file" => $curlFile,
         ));
-        $this->assertSame("Stripe\\FileUpload", get_class($resource));
+        $this->assertInstanceOf("Stripe\\FileUpload", $resource);
     }
 }

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -14,7 +14,7 @@ class InvoiceItemTest extends TestCase
         );
         $resources = InvoiceItem::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
         );
         $resource = InvoiceItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class InvoiceItemTest extends TestCase
             "currency" => "usd",
             "customer" => "cus_123"
         ));
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 
     public function testIsUpdatable()
@@ -62,7 +62,7 @@ class InvoiceItemTest extends TestCase
         $resource = InvoiceItem::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 
     public function testIsDeletable()
@@ -73,6 +73,6 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . $invoiceItem->id
         );
         $resource = $invoiceItem->delete();
-        $this->assertSame("Stripe\\InvoiceItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\InvoiceItem", $resource);
     }
 }

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -14,7 +14,7 @@ class InvoiceTest extends TestCase
         );
         $resources = Invoice::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Invoice", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Invoice", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID
         );
         $resource = Invoice::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class InvoiceTest extends TestCase
         $resource = Invoice::create(array(
             "customer" => "cus_123"
         ));
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
     }
 
     public function testIsUpdatable()
@@ -60,7 +60,7 @@ class InvoiceTest extends TestCase
         $resource = Invoice::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
     }
 
     public function testCanRetrieveUpcoming()
@@ -70,7 +70,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/upcoming'
         );
         $resource = Invoice::upcoming(array("customer" => "cus_123"));
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
     }
 
     public function testIsPayable()
@@ -81,7 +81,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/pay'
         );
         $resource = $invoice->pay();
-        $this->assertSame("Stripe\\Invoice", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Invoice", $resource);
         $this->assertSame($resource, $invoice);
     }
 }

--- a/tests/Stripe/OrderReturnTest.php
+++ b/tests/Stripe/OrderReturnTest.php
@@ -14,7 +14,7 @@ class OrderReturnTest extends TestCase
         );
         $resources = OrderReturn::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\OrderReturn", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\OrderReturn", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class OrderReturnTest extends TestCase
             '/v1/order_returns/' . self::TEST_RESOURCE_ID
         );
         $resource = OrderReturn::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\OrderReturn", get_class($resource));
+        $this->assertInstanceOf("Stripe\\OrderReturn", $resource);
     }
 }

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -14,7 +14,7 @@ class OrderTest extends TestCase
         );
         $resources = Order::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Order", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Order", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . self::TEST_RESOURCE_ID
         );
         $resource = Order::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Order", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Order", $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class OrderTest extends TestCase
         $resource = Order::create(array(
             'currency' => 'usd'
         ));
-        $this->assertSame("Stripe\\Order", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Order", $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Order", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Order", $resource);
     }
 
     public function testIsUpdatable()
@@ -60,7 +60,7 @@ class OrderTest extends TestCase
         $resource = Order::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Order", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Order", $resource);
     }
 
     public function testIsPayable()
@@ -71,7 +71,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . self::TEST_RESOURCE_ID . '/pay'
         );
         $resource->pay();
-        $this->assertSame("Stripe\\Order", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Order", $resource);
     }
 
     public function testIsReturnable()
@@ -82,6 +82,6 @@ class OrderTest extends TestCase
             '/v1/orders/' . self::TEST_RESOURCE_ID . '/returns'
         );
         $resource = $order->returnOrder();
-        $this->assertSame("Stripe\\OrderReturn", get_class($resource));
+        $this->assertInstanceOf("Stripe\\OrderReturn", $resource);
     }
 }

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -14,7 +14,7 @@ class PayoutTest extends TestCase
         );
         $resources = Payout::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Payout", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Payout", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . self::TEST_RESOURCE_ID
         );
         $resource = Payout::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Payout", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Payout", $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class PayoutTest extends TestCase
             "amount" => 100,
             "currency" => "usd"
         ));
-        $this->assertSame("Stripe\\Payout", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Payout", $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Payout", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Payout", $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class PayoutTest extends TestCase
         $resource = Payout::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Payout", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Payout", $resource);
     }
 
     public function testIsCancelable()
@@ -72,6 +72,6 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . $resource->id . '/cancel'
         );
         $resource->cancel();
-        $this->assertSame("Stripe\\Payout", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Payout", $resource);
     }
 }

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -14,7 +14,7 @@ class PlanTest extends TestCase
         );
         $resources = Plan::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Plan", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Plan", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class PlanTest extends TestCase
             '/v1/plans/' . self::TEST_RESOURCE_ID
         );
         $resource = Plan::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Plan", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Plan", $resource);
     }
 
     public function testIsCreatable()
@@ -40,7 +40,7 @@ class PlanTest extends TestCase
             'name' => self::TEST_RESOURCE_ID,
             'id' => self::TEST_RESOURCE_ID
         ));
-        $this->assertSame("Stripe\\Plan", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Plan", $resource);
     }
 
     public function testIsSaveable()
@@ -52,7 +52,7 @@ class PlanTest extends TestCase
             '/v1/plans/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Plan", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Plan", $resource);
     }
 
     public function testIsUpdatable()
@@ -64,7 +64,7 @@ class PlanTest extends TestCase
         $resource = Plan::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Plan", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Plan", $resource);
     }
 
     public function testIsDeletable()
@@ -75,6 +75,6 @@ class PlanTest extends TestCase
             '/v1/plans/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Plan", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Plan", $resource);
     }
 }

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -14,7 +14,7 @@ class ProductTest extends TestCase
         );
         $resources = Product::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Product", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Product", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ProductTest extends TestCase
             '/v1/products/' . self::TEST_RESOURCE_ID
         );
         $resource = Product::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Product", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Product", $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class ProductTest extends TestCase
         $resource = Product::create(array(
             'name' => 'name'
         ));
-        $this->assertSame("Stripe\\Product", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Product", $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class ProductTest extends TestCase
             '/v1/products/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Product", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Product", $resource);
     }
 
     public function testIsUpdatable()
@@ -60,7 +60,7 @@ class ProductTest extends TestCase
         $resource = Product::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Product", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Product", $resource);
     }
 
     public function testIsDeletable()
@@ -71,6 +71,6 @@ class ProductTest extends TestCase
             '/v1/products/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Product", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Product", $resource);
     }
 }

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -14,7 +14,7 @@ class RecipientTest extends TestCase
         );
         $resources = Recipient::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Recipient", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Recipient", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . self::TEST_RESOURCE_ID
         );
         $resource = Recipient::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Recipient", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Recipient", $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class RecipientTest extends TestCase
             "name" => "name",
             "type" => "individual"
         ));
-        $this->assertSame("Stripe\\Recipient", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Recipient", $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Recipient", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Recipient", $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class RecipientTest extends TestCase
         $resource = Recipient::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Recipient", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Recipient", $resource);
     }
 
     public function testIsDeletable()
@@ -72,7 +72,7 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Recipient", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Recipient", $resource);
     }
 
     public function testCanListTransfers()
@@ -85,6 +85,6 @@ class RecipientTest extends TestCase
         );
         $resources = $recipient->transfers();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Transfer", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Transfer", $resources->data[0]);
     }
 }

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -14,7 +14,7 @@ class RefundTest extends TestCase
         );
         $resources = Refund::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Refund", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Refund", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class RefundTest extends TestCase
             '/v1/refunds/' . self::TEST_RESOURCE_ID
         );
         $resource = Refund::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Refund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Refund", $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class RefundTest extends TestCase
         $resource = Refund::create(array(
             "charge" => "ch_123"
         ));
-        $this->assertSame("Stripe\\Refund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Refund", $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class RefundTest extends TestCase
             '/v1/refunds/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Refund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Refund", $resource);
     }
 
     public function testIsUpdatable()
@@ -60,6 +60,6 @@ class RefundTest extends TestCase
         $resource = Refund::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Refund", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Refund", $resource);
     }
 }

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -14,7 +14,7 @@ class SKUTest extends TestCase
         );
         $resources = SKU::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\SKU", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\SKU", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SKUTest extends TestCase
             '/v1/skus/' . self::TEST_RESOURCE_ID
         );
         $resource = SKU::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\SKU", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SKU", $resource);
     }
 
     public function testIsCreatable()
@@ -42,7 +42,7 @@ class SKUTest extends TestCase
             'price'     => 100,
             'product'   => "prod_123"
         ));
-        $this->assertSame("Stripe\\SKU", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SKU", $resource);
     }
 
     public function testIsSaveable()
@@ -54,7 +54,7 @@ class SKUTest extends TestCase
             '/v1/skus/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\SKU", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SKU", $resource);
     }
 
     public function testIsUpdatable()
@@ -66,7 +66,7 @@ class SKUTest extends TestCase
         $resource = SKU::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\SKU", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SKU", $resource);
     }
 
     public function testIsDeletable()
@@ -77,6 +77,6 @@ class SKUTest extends TestCase
             '/v1/skus/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\SKU", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SKU", $resource);
     }
 }

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -13,7 +13,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID
         );
         $resource = Source::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 
     public function testIsCreatable()
@@ -25,7 +25,7 @@ class SourceTest extends TestCase
         $resource = Source::create(array(
             "type" => "card"
         ));
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 
     public function testIsUpdatable()
@@ -49,7 +49,7 @@ class SourceTest extends TestCase
         $resource = Source::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 
     public function testCanSaveCardExpiryDate()
@@ -100,7 +100,7 @@ class SourceTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 
     /**
@@ -121,7 +121,7 @@ class SourceTest extends TestCase
         );
         $resources = $source->sourceTransactions();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\SourceTransaction", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\SourceTransaction", $resources->data[0]);
     }
 
     public function testCanVerify()
@@ -132,6 +132,6 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID . "/verify"
         );
         $resource->verify(array("values" => array(32,45)));
-        $this->assertSame("Stripe\\Source", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Source", $resource);
     }
 }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -14,7 +14,7 @@ class SubscriptionItemTest extends TestCase
         );
         $resources = SubscriptionItem::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . self::TEST_RESOURCE_ID
         );
         $resource = SubscriptionItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class SubscriptionItemTest extends TestCase
             "plan" => "plan",
             "subscription" => "sub_123"
         ));
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class SubscriptionItemTest extends TestCase
         $resource = SubscriptionItem::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id
         );
         $resource->delete();
-        $this->assertSame("Stripe\\SubscriptionItem", get_class($resource));
+        $this->assertInstanceOf("Stripe\\SubscriptionItem", $resource);
     }
 }

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -14,7 +14,7 @@ class SubscriptionTest extends TestCase
         );
         $resources = Subscription::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Subscription", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Subscription", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . self::TEST_RESOURCE_ID
         );
         $resource = Subscription::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class SubscriptionTest extends TestCase
             "customer" => "cus_123",
             "plan" => "plan"
         ));
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class SubscriptionTest extends TestCase
         $resource = Subscription::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 
     public function testIsCancelable()
@@ -72,7 +72,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . $resource->id
         );
         $resource->cancel();
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 
     public function testCanDeleteDiscount()
@@ -83,6 +83,6 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . $resource->id . '/discount'
         );
         $resource->deleteDiscount();
-        $this->assertSame("Stripe\\Subscription", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 }

--- a/tests/Stripe/ThreeDSecureTest.php
+++ b/tests/Stripe/ThreeDSecureTest.php
@@ -13,7 +13,7 @@ class ThreeDSecureTest extends TestCase
             '/v1/3d_secure/' . self::TEST_RESOURCE_ID
         );
         $resource = ThreeDSecure::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\ThreeDSecure", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ThreeDSecure", $resource);
     }
 
     public function testIsCreatable()
@@ -27,6 +27,6 @@ class ThreeDSecureTest extends TestCase
             "currency" => "usd",
             "return_url" => "url"
         ));
-        $this->assertSame("Stripe\\ThreeDSecure", get_class($resource));
+        $this->assertInstanceOf("Stripe\\ThreeDSecure", $resource);
     }
 }

--- a/tests/Stripe/TokenTest.php
+++ b/tests/Stripe/TokenTest.php
@@ -13,7 +13,7 @@ class TokenTest extends TestCase
             '/v1/tokens/' . self::TEST_RESOURCE_ID
         );
         $resource = Token::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Token", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Token", $resource);
     }
 
     public function testIsCreatable()
@@ -23,6 +23,6 @@ class TokenTest extends TestCase
             '/v1/tokens'
         );
         $resource = Token::create(array("card" => "tok_visa"));
-        $this->assertSame("Stripe\\Token", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Token", $resource);
     }
 }

--- a/tests/Stripe/TransferReversalTest.php
+++ b/tests/Stripe/TransferReversalTest.php
@@ -16,6 +16,6 @@ class TransferReversalTest extends TestCase
             '/v1/transfers/' . $resource->transfer . '/reversals/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\TransferReversal", get_class($resource));
+        $this->assertInstanceOf("Stripe\\TransferReversal", $resource);
     }
 }

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -15,7 +15,7 @@ class TransferTest extends TestCase
         );
         $resources = Transfer::all();
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\Transfer", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\Transfer", $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID
         );
         $resource = Transfer::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class TransferTest extends TestCase
             "currency" => "usd",
             "destination" => "acct_123"
         ));
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
     }
 
     public function testIsSaveable()
@@ -51,7 +51,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . $resource->id
         );
         $resource->save();
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class TransferTest extends TestCase
         $resource = Transfer::update(self::TEST_RESOURCE_ID, array(
             "metadata" => array("key" => "value"),
         ));
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
     }
 
     public function testIsReversable()
@@ -74,7 +74,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . $resource->id . '/reversals'
         );
         $resource->reverse();
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
     }
 
     public function testIsCancelable()
@@ -87,7 +87,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . $transfer->id . '/cancel'
         );
         $resource = $transfer->cancel();
-        $this->assertSame("Stripe\\Transfer", get_class($resource));
+        $this->assertInstanceOf("Stripe\\Transfer", $resource);
         $this->assertSame($resource, $transfer);
     }
 
@@ -98,7 +98,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
         );
         $resource = Transfer::createReversal(self::TEST_RESOURCE_ID);
-        $this->assertSame("Stripe\\TransferReversal", get_class($resource));
+        $this->assertInstanceOf("Stripe\\TransferReversal", $resource);
     }
 
     public function testCanRetrieveReversal()
@@ -108,7 +108,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals/' . self::TEST_REVERSAL_ID
         );
         $resource = Transfer::retrieveReversal(self::TEST_RESOURCE_ID, self::TEST_REVERSAL_ID);
-        $this->assertSame("Stripe\\TransferReversal", get_class($resource));
+        $this->assertInstanceOf("Stripe\\TransferReversal", $resource);
     }
 
     public function testCanUpdateReversal()
@@ -124,7 +124,7 @@ class TransferTest extends TestCase
                 "metadata" => array("key" => "value"),
             )
         );
-        $this->assertSame("Stripe\\TransferReversal", get_class($resource));
+        $this->assertInstanceOf("Stripe\\TransferReversal", $resource);
     }
 
     public function testCanListReversal()
@@ -135,6 +135,6 @@ class TransferTest extends TestCase
         );
         $resources = Transfer::allReversals(self::TEST_RESOURCE_ID);
         $this->assertTrue(is_array($resources->data));
-        $this->assertSame("Stripe\\TransferReversal", get_class($resources->data[0]));
+        $this->assertInstanceOf("Stripe\\TransferReversal", $resources->data[0]);
     }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Just a small improvement to make the tests slightly cleaner: use `assertInstanceOf($class_name, $instance)` instead of `assertSame($class_name, get_class($instance))`.
