### PR TITLE
Add more tests

### DIFF
--- a/tests/Stripe/ApplicationFeeTest.php
+++ b/tests/Stripe/ApplicationFeeTest.php
@@ -28,6 +28,18 @@ class ApplicationFeeTest extends TestCase
         $this->assertInstanceOf("Stripe\\ApplicationFee", $resource);
     }
 
+    public function testIsRefundable()
+    {
+        $fee = ApplicationFee::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'post',
+            '/v1/application_fees/' . $fee->id . '/refunds'
+        );
+        $resource = $fee->refund();
+        $this->assertInstanceOf("Stripe\\ApplicationFee", $resource);
+        $this->assertSame($resource, $fee);
+    }
+
     public function testCanCreateRefund()
     {
         $this->expectsRequest(

--- a/tests/Stripe/Error/BaseTest.php
+++ b/tests/Stripe/Error/BaseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stripe;
+
+class BaseTest extends TestCase
+{
+    public function createFixture($params = [])
+    {
+        return $this->getMockForAbstractClass('Stripe\\Error\\Base', [
+            'message',
+            200,
+            '{"key": "value"}',
+            ['key' => 'value'],
+            [
+                'Some-Header' => 'Some Value',
+                'Request-Id' => 'req_test',
+            ],
+        ]);
+    }
+
+    public function testGetters()
+    {
+        $e = $this->createFixture();
+        $this->assertSame(200, $e->getHttpStatus());
+        $this->assertSame('{"key": "value"}', $e->getHttpBody());
+        $this->assertSame(['key' => 'value'], $e->getJsonBody());
+        $this->assertSame('Some Value', $e->getHttpHeaders()['Some-Header']);
+        $this->assertSame('req_test', $e->getRequestId());
+    }
+
+    public function testToString()
+    {
+        $e = $this->createFixture();
+        $this->assertContains("from API request 'req_test'", (string)$e);
+    }
+}

--- a/tests/Stripe/Error/SignatureVerificationTest.php
+++ b/tests/Stripe/Error/SignatureVerificationTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Stripe;
+
+class SignatureVerificationTest extends TestCase
+{
+    public function testGetters()
+    {
+        $e = new Error\SignatureVerification('message', 'sig_header');
+        $this->assertSame('sig_header', $e->getSigHeader());
+    }
+}

--- a/tests/Stripe/OAuthTest.php
+++ b/tests/Stripe/OAuthTest.php
@@ -4,22 +4,6 @@ namespace Stripe;
 
 class OAuthTest extends TestCase
 {
-    /**
-     * @before
-     */
-    public function setUpClientId()
-    {
-        Stripe::setClientId('ca_test');
-    }
-
-    /**
-     * @after
-     */
-    public function tearDownClientId()
-    {
-        Stripe::setClientId(null);
-    }
-
     public function testAuthorizeUrl()
     {
         $uriStr = OAuth::authorizeUrl([
@@ -39,11 +23,21 @@ class OAuthTest extends TestCase
         $this->assertSame('connect.stripe.com', $uri['host']);
         $this->assertSame('/oauth/authorize', $uri['path']);
 
-        $this->assertSame('ca_test', $params['client_id']);
+        $this->assertSame('ca_123', $params['client_id']);
         $this->assertSame('read_write', $params['scope']);
         $this->assertSame('test@example.com', $params['stripe_user']['email']);
         $this->assertSame('https://example.com/profile/test', $params['stripe_user']['url']);
         $this->assertSame('US', $params['stripe_user']['country']);
+    }
+
+    /**
+     * @expectedException \Stripe\Error\Authentication
+     * @expectedExceptionMessageRegExp #No client_id provided#
+     */
+    public function testRaisesAuthenticationErrorWhenNoClientId()
+    {
+        Stripe::setClientId(null);
+        OAuth::authorizeUrl();
     }
 
     public function testToken()
@@ -84,7 +78,7 @@ class OAuthTest extends TestCase
             '/oauth/deauthorize',
             [
                 'stripe_user_id' => 'acct_test_deauth',
-                'client_id' => 'ca_test',
+                'client_id' => 'ca_123',
             ],
             null,
             false,

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -69,9 +69,14 @@ class SubscriptionTest extends TestCase
         $resource = Subscription::retrieve(self::TEST_RESOURCE_ID);
         $this->expectsRequest(
             'delete',
-            '/v1/subscriptions/' . $resource->id
+            '/v1/subscriptions/' . $resource->id,
+            [
+                'at_period_end' => 'true',
+            ]
         );
-        $resource->cancel();
+        $resource->cancel([
+            'at_period_end' => true,
+        ]);
         $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,12 @@ class TestCase extends \PHPUnit_Framework_TestCase
     /** @var string original client ID */
     protected $origClientId;
 
+    /** @var string original API version */
+    protected $origApiVersion;
+
+    /** @var string original account ID */
+    protected $origAccountId;
+
     /** @var object HTTP client mocker */
     protected $clientMock;
 
@@ -25,11 +31,15 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->origApiBase = Stripe::$apiBase;
         $this->origApiKey = Stripe::getApiKey();
         $this->origClientId = Stripe::getClientId();
+        $this->origApiVersion = Stripe::getApiVersion();
+        $this->origAccountId = Stripe::getAccountId();
 
         // Set up host and credentials for stripe-mock
         Stripe::$apiBase = "http://localhost:" . MOCK_PORT;
         Stripe::setApiKey("sk_test_123");
         Stripe::setClientId("ca_123");
+        Stripe::setApiVersion(null);
+        Stripe::setAccountId(null);
 
         // Set up the HTTP client mocker
         $this->clientMock = $this->getMock('\Stripe\HttpClient\ClientInterface');
@@ -44,6 +54,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
         Stripe::$apiBase = $this->origApiBase;
         Stripe::setApiKey($this->origApiKey);
         Stripe::setClientId($this->origClientId);
+        Stripe::setApiVersion($this->origApiVersion);
+        Stripe::setAccountId($this->origAccountId);
     }
 
     /**


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds a bunch of tests for previously untested codepaths.

Most of the remaining untested parts are overly defensive programming that we could arguably get rid of (e.g. handling the absence of an `id` attribute in non-singleton resources).

There are also some untested parts in `CurlClient`, mostly error conditions (connection failures, certificate verification failures, etc.). Those are not so easy to test unfortunately.
