### PR TITLE
Use AspectMock in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",
+    "codeception/aspect-mock": "~0.5.5",
     "satooshi/php-coveralls": "~0.6.1",
     "squizlabs/php_codesniffer": "~2.0"
   },

--- a/phpunit.no_autoload.xml
+++ b/phpunit.no_autoload.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap.no_autoload.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.no_autoload.php" backupGlobals="false" colors="true">
     <testsuites>
         <testsuite name="Stripe PHP Test Suite">
             <directory suffix="Test.php">tests</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true">
     <testsuites>
         <testsuite name="Stripe PHP Test Suite">
             <directory suffix="Test.php">tests</directory>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace Stripe;
 
+use AspectMock\Test as test;
+
 /**
  * Base class for Stripe test cases.
  */
@@ -50,6 +52,9 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
+        // Remove all registered test doubles
+        test::clean();
+
         // Restore original values
         Stripe::$apiBase = $this->origApiBase;
         Stripe::setApiKey($this->origApiKey);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,15 @@
 <?php
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Initialize AspectMock
+$kernel = \AspectMock\Kernel::getInstance();
+$kernel->init([
+    'debug' => true,
+    'includePaths' => [__DIR__ . '/../lib']
+]);
+
+// Initialize stripe-mock
 define("MOCK_MINIMUM_VERSION", "0.5.0");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for the [AspectMock](https://github.com/Codeception/AspectMock) library in tests.

AspectMock allows for some things that PHPUnit itself cannot handle, most notable mocking/stubbing static methods. Since we use a lot of static methods throughout the library, we will be able to use AspectMock to write better tests.
