### PR TITLE
Use vendored CA bundle for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ $curl = new \Stripe\HttpClient\CurlClient([CURLOPT_SSLVERSION => CURL_SSLVERSION
 \Stripe\ApiRequestor::setHttpClient($curl);
 ```
 
+### Configuring CA Bundles
+
+By default, the library will use its own internal bundle of known CA
+certificates, but it's possible to configure your own:
+
+```php
+\Stripe\Stripe::setCABundlePath("path/to/ca/bundle");
+```
+
 ## Development
 
 Install dependencies:

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -30,6 +30,9 @@ class Stripe
     // @var string|null The account ID for connected accounts requests.
     public static $accountId = null;
 
+    // @var string Path to the CA bundle used to verify SSL certificates
+    public static $caBundlePath = null;
+
     // @var boolean Defaults to true.
     public static $verifySslCerts = true;
 
@@ -114,6 +117,30 @@ class Stripe
     public static function setApiVersion($apiVersion)
     {
         self::$apiVersion = $apiVersion;
+    }
+
+    /**
+     * @return string
+     */
+    private static function getDefaultCABundlePath()
+    {
+        return realpath(dirname(__FILE__) . '/../data/ca-certificates.crt');
+    }
+
+    /**
+     * @return string
+     */
+    public static function getCABundlePath()
+    {
+        return self::$caBundlePath ?: self::getDefaultCABundlePath();
+    }
+
+    /**
+     * @param string $caBundlePath
+     */
+    public static function setCABundlePath($caBundlePath)
+    {
+        self::$caBundlePath = $caBundlePath;
     }
 
     /**

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stripe;
+
+class StripeTest extends TestCase
+{
+    /**
+     * @before
+     */
+    public function saveOriginalValues()
+    {
+        $this->orig = [
+            'caBundlePath' => Stripe::$caBundlePath,
+        ];
+    }
+
+    /**
+     * @after
+     */
+    public function restoreOriginalValues()
+    {
+        Stripe::$caBundlePath = $this->orig['caBundlePath'];
+    }
+
+    public function testCABundlePathAccessors()
+    {
+        Stripe::setCABundlePath('path/to/ca/bundle');
+        $this->assertEquals('path/to/ca/bundle', Stripe::getCABundlePath());
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Currently, the library sends requests using the environment's default CA bundle. If the request fails due to an SSL verification error, the library will automatically retry the request using the vendored bundle.

This PR changes the behavior to use the vendored bundle by default for all requests, and adds an option to configure the path to a custom bundle too. This makes the PHP implementation consistent with the Ruby implementation.

While this should not have any user impact, I'm tagging it as WIP because I'm slightly nervous about this change given the number of TLS issues we've observed in the past. Part of me is definitely like "if it ain't broke don't fix it" 😐 

For context, I'm working on adding request retries as requested in #394 and wanted to simplify the logic in order to avoid having two different retry mechanisms (one for cert verification issues and one for other connection/409 issues).
