### PR TITLE
Escape unsanitized input in OAuth example

### DIFF
--- a/examples/oauth.php
+++ b/examples/oauth.php
@@ -29,7 +29,7 @@ if (isset($_GET['code'])) {
     $error = $_GET['error'];
     $error_description = $_GET['error_description'];
 
-    echo "<p>Error: code=$error, description=$error_description</p>\n";
+    echo "<p>Error: code=" . htmlspecialchars($error, ENT_QUOTES) . ", description=" . htmlspecialchars($error_description, ENT_QUOTES) . "</p>\n";
     echo "<p>Click <a href=\"?\">here</a> to restart the OAuth flow.</p>\n";
 
 } elseif (isset($_GET['deauth'])) {
@@ -44,7 +44,7 @@ if (isset($_GET['code'])) {
         exit("Error: " . $e->getMessage());
     }
 
-    echo "<p>Success! Account <code>$accountId</code> is disonnected.</p>\n";
+    echo "<p>Success! Account <code>" . htmlspecialchars($accountId, ENT_QUOTES) . "</code> is disconnected.</p>\n";
     echo "<p>Click <a href=\"?\">here</a> to restart the OAuth flow.</p>\n";
 
 } else {


### PR DESCRIPTION
Here we run unsanitized input through `htmlspecialchars` before echoing
it to screen. Most of these fields will come from our own processes, but
because they're taken from `$_GET`, they could potentially contain
content set by a malicious user.

I think `htmlspecialchars` is the right thing to do here. It just
escapes HTML-related characters instead of anything that has an HTML
equivalent like `htmlentities` (which is probably overkill here).

r? @ob-stripe