### PR TITLE
Automatic request retries

### DIFF
--- a/init.php
+++ b/init.php
@@ -7,6 +7,7 @@ require(dirname(__FILE__) . '/lib/Stripe.php');
 require(dirname(__FILE__) . '/lib/Util/AutoPagingIterator.php');
 require(dirname(__FILE__) . '/lib/Util/LoggerInterface.php');
 require(dirname(__FILE__) . '/lib/Util/DefaultLogger.php');
+require(dirname(__FILE__) . '/lib/Util/RandomGenerator.php');
 require(dirname(__FILE__) . '/lib/Util/RequestOptions.php');
 require(dirname(__FILE__) . '/lib/Util/Set.php');
 require(dirname(__FILE__) . '/lib/Util/Util.php');

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -51,9 +51,10 @@ class CurlClient implements ClientInterface
      *
      * @param array|callable|null $defaultOptions
      */
-    public function __construct($defaultOptions = null)
+    public function __construct($defaultOptions = null, $randomGenerator = null)
     {
         $this->defaultOptions = $defaultOptions;
+        $this->randomGenerator = $randomGenerator ?: new Util\RandomGenerator();
         $this->initUserAgentInfo();
     }
 
@@ -110,7 +111,6 @@ class CurlClient implements ClientInterface
 
     public function request($method, $absUrl, $headers, $params, $hasFile)
     {
-        $curl = curl_init();
         $method = strtolower($method);
 
         $opts = [];
@@ -145,6 +145,14 @@ class CurlClient implements ClientInterface
             }
         } else {
             throw new Error\Api("Unrecognized method $method");
+        }
+
+        // It is only safe to retry network failures on POST requests if we
+        // add an Idempotency-Key header
+        if (($method == 'post') && (Stripe::$maxNetworkRetries > 0)) {
+            if (!isset($headers['Idempotency-Key'])) {
+                array_push($headers, 'Idempotency-Key: ' . $this->randomGenerator->uuid());
+            }
         }
 
         // Create a callback to capture HTTP headers for the response
@@ -185,27 +193,58 @@ class CurlClient implements ClientInterface
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
 
-        curl_setopt_array($curl, $opts);
-        $rbody = curl_exec($curl);
+        list($rbody, $rcode) = $this->executeRequestWithRetries($opts, $absUrl);
 
-        if ($rbody === false) {
-            $errno = curl_errno($curl);
-            $message = curl_error($curl);
-            curl_close($curl);
-            $this->handleCurlError($absUrl, $errno, $message);
-        }
-
-        $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        curl_close($curl);
         return [$rbody, $rcode, $rheaders];
     }
 
     /**
+     * @param array $opts cURL options
+     */
+    private function executeRequestWithRetries($opts, $absUrl)
+    {
+        $numRetries = 0;
+
+        while (true) {
+            $rcode = 0;
+            $errno = 0;
+
+            $curl = curl_init();
+            curl_setopt_array($curl, $opts);
+            $rbody = curl_exec($curl);
+
+            if ($rbody === false) {
+                $errno = curl_errno($curl);
+                $message = curl_error($curl);
+            } else {
+                $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+            }
+            curl_close($curl);
+
+            if ($this->shouldRetry($errno, $rcode, $numRetries)) {
+                $numRetries += 1;
+                $sleepSeconds = $this->sleepTime($numRetries);
+                usleep(intval($sleepSeconds * 1000000));
+            } else {
+                break;
+            }
+        }
+
+        if ($rbody === false) {
+            $this->handleCurlError($absUrl, $errno, $message, $numRetries);
+        }
+
+        return [$rbody, $rcode];
+    }
+
+    /**
+     * @param string $url
      * @param number $errno
      * @param string $message
+     * @param int $numRetries
      * @throws Error\ApiConnection
      */
-    private function handleCurlError($url, $errno, $message)
+    private function handleCurlError($url, $errno, $message, $numRetries)
     {
         switch ($errno) {
             case CURLE_COULDNT_CONNECT:
@@ -230,6 +269,66 @@ class CurlClient implements ClientInterface
         $msg .= " let us know at support@stripe.com.";
 
         $msg .= "\n\n(Network error [errno $errno]: $message)";
+
+        if ($numRetries > 0) {
+            $msg .= "\n\nRequest was retried $numRetries times.";
+        }
+
         throw new Error\ApiConnection($msg);
+    }
+
+    /**
+     * Checks if an error is a problem that we should retry on. This includes both
+     * socket errors that may represent an intermittent problem and some special
+     * HTTP statuses.
+     * @param int $errno
+     * @param int $rcode
+     * @param int $numRetries
+     * @return bool
+     */
+    private function shouldRetry($errno, $rcode, $numRetries)
+    {
+        if ($numRetries >= Stripe::getMaxNetworkRetries()) {
+            return false;
+        }
+
+        // Retry on timeout-related problems (either on open or read).
+        if ($errno === CURLE_OPERATION_TIMEOUTED) {
+            return true;
+        }
+
+        // Destination refused the connection, the connection was reset, or a
+        // variety of other connection failures. This could occur from a single
+        // saturated server, so retry in case it's intermittent.
+        if ($errno === CURLE_COULDNT_CONNECT) {
+            return true;
+        }
+
+        // 409 conflict
+        if ($rcode === 409) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function sleepTime($numRetries)
+    {
+        // Apply exponential backoff with $initialNetworkRetryDelay on the
+        // number of $numRetries so far as inputs. Do not allow the number to exceed
+        // $maxNetworkRetryDelay.
+        $sleepSeconds = min(
+            Stripe::getInitialNetworkRetryDelay() * 1.0 * pow(2, $numRetries - 1),
+            Stripe::getMaxNetworkRetryDelay()
+        );
+
+        // Apply some jitter by randomizing the value in the range of
+        // ($sleepSeconds / 2) to ($sleepSeconds).
+        $sleepSeconds *= 0.5 * (1 + $this->randomGenerator->randFloat());
+
+        // But never sleep less than the base sleep seconds.
+        $sleepSeconds = max(Stripe::getInitialNetworkRetryDelay(), $sleepSeconds);
+
+        return $sleepSeconds;
     }
 }

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -43,6 +43,15 @@ class Stripe
     //   produce messages.
     public static $logger = null;
 
+    // @var int Maximum number of request retries
+    public static $maxNetworkRetries = 0;
+
+    // @var float Maximum delay between retries, in seconds
+    private static $maxNetworkRetryDelay = 2.0;
+
+    // @var float Initial delay between retries, in seconds
+    private static $initialNetworkRetryDelay = 0.5;
+
     const VERSION = '5.8.0';
 
     /**
@@ -196,5 +205,37 @@ class Stripe
         self::$appInfo['name'] = $appName;
         self::$appInfo['version'] = $appVersion;
         self::$appInfo['url'] = $appUrl;
+    }
+
+    /**
+     * @return int Maximum number of request retries
+     */
+    public static function getMaxNetworkRetries()
+    {
+        return self::$maxNetworkRetries;
+    }
+
+    /**
+     * @param int $maxNetworkRetries Maximum number of request retries
+     */
+    public static function setMaxNetworkRetries($maxNetworkRetries)
+    {
+        self::$maxNetworkRetries = $maxNetworkRetries;
+    }
+
+    /**
+     * @return float Maximum delay between retries, in seconds
+     */
+    public static function getMaxNetworkRetryDelay()
+    {
+        return self::$maxNetworkRetryDelay;
+    }
+
+    /**
+     * @return float Initial delay between retries, in seconds
+     */
+    public static function getInitialNetworkRetryDelay()
+    {
+        return self::$initialNetworkRetryDelay;
     }
 }

--- a/lib/Util/RandomGenerator.php
+++ b/lib/Util/RandomGenerator.php
@@ -2,6 +2,10 @@
 
 namespace Stripe\Util;
 
+/**
+ * A basic random generator. This is in a separate class so we the generator
+ * can be injected as a dependency and replaced with a mock in tests.
+ */
 class RandomGenerator
 {
     /**

--- a/lib/Util/RandomGenerator.php
+++ b/lib/Util/RandomGenerator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stripe\Util;
+
+class RandomGenerator
+{
+    /**
+     * Returns a random value between 0 and $max.
+     *
+     * @param float $max (optional)
+     * @return float
+     */
+    public function randFloat($max = 1.0)
+    {
+        return mt_rand() / mt_getrandmax() * $max;
+    }
+
+    /**
+     * Returns a v4 UUID.
+     *
+     * @return string
+     */
+    public function uuid()
+    {
+        $arr = array_values(unpack('N1a/n4b/N1c', openssl_random_pseudo_bytes(16)));
+        $arr[2] = ($arr[2] & 0x0fff) | 0x4000;
+        $arr[3] = ($arr[3] & 0x3fff) | 0x8000;
+        return vsprintf('%08x-%04x-%04x-%04x-%04x%08x', $arr);
+    }
+}

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -6,6 +6,45 @@ use Stripe\HttpClient\CurlClient;
 
 class CurlClientTest extends TestCase
 {
+    /**
+     * @before
+     */
+    public function saveOriginalNetworkValues()
+    {
+        $this->origMaxNetworkRetries = Stripe::getMaxNetworkRetries();
+        $this->origMaxNetworkRetryDelay = Stripe::getMaxNetworkRetryDelay();
+        $this->origInitialNetworkRetryDelay = Stripe::getInitialNetworkRetryDelay();
+    }
+
+    /**
+     * @after
+     */
+    public function restoreOriginalNetworkValues()
+    {
+        Stripe::setMaxNetworkRetries($this->origMaxNetworkRetries);
+        $this->setMaxNetworkRetryDelay($this->origMaxNetworkRetryDelay);
+        $this->setInitialNetworkRetryDelay($this->origInitialNetworkRetryDelay);
+    }
+
+    private function setMaxNetworkRetryDelay($maxNetworkRetryDelay)
+    {
+        $property = $this->getPrivateProperty('Stripe\Stripe', 'maxNetworkRetryDelay');
+        $property->setValue(null, $maxNetworkRetryDelay);
+    }
+
+    private function setInitialNetworkRetryDelay($initialNetworkRetryDelay)
+    {
+        $property = $this->getPrivateProperty('Stripe\Stripe', 'initialNetworkRetryDelay');
+        $property->setValue(null, $initialNetworkRetryDelay);
+    }
+
+    private function createFakeRandomGenerator($returnValue = 1.0)
+    {
+        $fakeRandomGenerator = $this->getMock('Stripe\Util\RandomGenetator', ['randFloat']);
+        $fakeRandomGenerator->method('randFloat')->willReturn($returnValue);
+        return $fakeRandomGenerator;
+    }
+
     public function testTimeout()
     {
         $curl = new CurlClient();
@@ -63,5 +102,103 @@ class CurlClientTest extends TestCase
         $optionsArray = [CURLOPT_SSLVERSION => CURL_SSLVERSION_TLSv1];
         $withOptionsArray = new CurlClient($optionsArray);
         $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+    }
+
+    public function testShouldRetryOnTimeout()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+        $shouldRetryReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'shouldRetry');
+
+        $this->assertTrue($shouldRetryReflector->invoke($curlClient, CURLE_OPERATION_TIMEOUTED, 0, 0));
+    }
+
+    public function testShouldRetryOnConnectionFailure()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+        $shouldRetryReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'shouldRetry');
+
+        $this->assertTrue($shouldRetryReflector->invoke($curlClient, CURLE_COULDNT_CONNECT, 0, 0));
+    }
+
+    public function testShouldRetryOnConflict()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+        $shouldRetryReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'shouldRetry');
+
+        $this->assertTrue($shouldRetryReflector->invoke($curlClient, 0, 409, 0));
+    }
+
+    public function testShouldNotRetryAtMaximumCount()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+        $shouldRetryReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'shouldRetry');
+
+        $this->assertFalse($shouldRetryReflector->invoke($curlClient, 0, 0, Stripe::getMaxNetworkRetries()));
+    }
+
+    public function testShouldNotRetryOnCertValidationError()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+        $shouldRetryReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'shouldRetry');
+
+        $this->assertFalse($shouldRetryReflector->invoke($curlClient, CURLE_SSL_PEER_CERTIFICATE, -1, 0));
+    }
+
+    public function testSleepTimeShouldGrowExponentially()
+    {
+        $this->setMaxNetworkRetryDelay(999);
+
+        $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
+        $sleepTimeReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'sleepTime');
+
+        $this->assertEquals(Stripe::getInitialNetworkRetryDelay() * 1, $sleepTimeReflector->invoke($curlClient, 1));
+        $this->assertEquals(Stripe::getInitialNetworkRetryDelay() * 2, $sleepTimeReflector->invoke($curlClient, 2));
+        $this->assertEquals(Stripe::getInitialNetworkRetryDelay() * 4, $sleepTimeReflector->invoke($curlClient, 3));
+        $this->assertEquals(Stripe::getInitialNetworkRetryDelay() * 8, $sleepTimeReflector->invoke($curlClient, 4));
+    }
+
+    public function testSleepTimeShouldEnforceMaxNetworkRetryDelay()
+    {
+        $this->setInitialNetworkRetryDelay(1);
+        $this->setMaxNetworkRetryDelay(2);
+
+        $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
+        $sleepTimeReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'sleepTime');
+
+        $this->assertEquals(1, $sleepTimeReflector->invoke($curlClient, 1));
+        $this->assertEquals(2, $sleepTimeReflector->invoke($curlClient, 2));
+        $this->assertEquals(2, $sleepTimeReflector->invoke($curlClient, 3));
+        $this->assertEquals(2, $sleepTimeReflector->invoke($curlClient, 4));
+    }
+
+    public function testSleepTimeShouldAddSomeRandomness()
+    {
+        $randomValue = 0.8;
+        $this->setInitialNetworkRetryDelay(1);
+        $this->setMaxNetworkRetryDelay(8);
+
+        $curlClient = new CurlClient(null, $this->createFakeRandomGenerator($randomValue));
+        $sleepTimeReflector = $this->getPrivateMethod('Stripe\HttpClient\CurlClient', 'sleepTime');
+
+        $baseValue = Stripe::getInitialNetworkRetryDelay() * (0.5 * (1 + $randomValue));
+
+        // the initial value cannot be smaller than the base,
+        // so the randomness is ignored
+        $this->assertEquals(Stripe::getInitialNetworkRetryDelay(), $sleepTimeReflector->invoke($curlClient, 1));
+
+        // after the first one, the randomness is applied
+        $this->assertEquals($baseValue * 2, $sleepTimeReflector->invoke($curlClient, 2));
+        $this->assertEquals($baseValue * 4, $sleepTimeReflector->invoke($curlClient, 3));
+        $this->assertEquals($baseValue * 8, $sleepTimeReflector->invoke($curlClient, 4));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -174,4 +174,32 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 $this->identicalTo($hasFile)
             );
     }
+
+    /**
+     * @param string $className
+     * @param string $methodName
+     *
+     * @return ReflectionMethod
+     */
+    public function getPrivateMethod($className, $methodName)
+    {
+        $reflector = new \ReflectionClass($className);
+        $method = $reflector->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method;
+    }
+
+    /**
+     * @param string $className
+     * @param string $propertyName
+     *
+     * @return ReflectionProperty
+     */
+    public function getPrivateProperty($className, $propertyName)
+    {
+        $reflector = new \ReflectionClass($className);
+        $method = $reflector->getProperty($propertyName);
+        $method->setAccessible(true);
+        return $method;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -174,32 +174,4 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 $this->identicalTo($hasFile)
             );
     }
-
-    /**
-     * @param string $className
-     * @param string $methodName
-     *
-     * @return ReflectionMethod
-     */
-    public function getPrivateMethod($className, $methodName)
-    {
-        $reflector = new \ReflectionClass($className);
-        $method = $reflector->getMethod($methodName);
-        $method->setAccessible(true);
-        return $method;
-    }
-
-    /**
-     * @param string $className
-     * @param string $propertyName
-     *
-     * @return ReflectionProperty
-     */
-    public function getPrivateProperty($className, $propertyName)
-    {
-        $reflector = new \ReflectionClass($className);
-        $method = $reflector->getProperty($propertyName);
-        $method->setAccessible(true);
-        return $method;
-    }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #394.

Implements automatic request retries, a la stripe-ruby.

As discussed IRL, I'm not totally happy with this implementation as it's not possible to fully test it -- we would need to be able to mock `curl_exec()` and other curl functions to do so, which isn't really possible in PHP.

Ideally, this feature should be implemented in `ApiRequestor` and not directly in `CurlClient`, but doing so would require substantial changes to the `HttpClient` interface -- for starters, we'd need to have a standard way of raising connection errors so that `ApiRequestor` could decide whether to retry or not. (Right now `CurlClient` just raises an `Error\ApiConnection` exception for all connection errors.)
