### PR TITLE
Fix header persistence on Collection objects

### DIFF
--- a/lib/ApiOperations/Request.php
+++ b/lib/ApiOperations/Request.php
@@ -54,11 +54,7 @@ trait Request
         $opts = \Stripe\Util\RequestOptions::parse($options);
         $requestor = new \Stripe\ApiRequestor($opts->apiKey, static::baseUrl());
         list($response, $opts->apiKey) = $requestor->request($method, $url, $params, $opts->headers);
-        foreach ($opts->headers as $k => $v) {
-            if (!array_key_exists($k, self::$HEADERS_TO_PERSIST)) {
-                unset($opts->headers[$k]);
-            }
-        }
+        $opts->discardNonPersistentHeaders();
         return [$response, $opts];
     }
 }

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -28,14 +28,6 @@ abstract class ApiResource extends StripeObject
     }
 
     /**
-     * @var array A list of headers that should be persisted across requests.
-     */
-    private static $HEADERS_TO_PERSIST = [
-        'Stripe-Account' => true,
-        'Stripe-Version' => true
-    ];
-
-    /**
      * @var boolean A flag that can be set a behavior that will cause this
      * resource to be encoded and sent up along with an update of its parent
      * resource. This is usually not desirable because resources are updated

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -6,6 +6,14 @@ use Stripe\Error;
 
 class RequestOptions
 {
+    /**
+     * @var array A list of headers that should be persisted across requests.
+     */
+    public static $HEADERS_TO_PERSIST = [
+        'Stripe-Account',
+        'Stripe-Version',
+    ];
+
     public $headers;
     public $apiKey;
 
@@ -30,6 +38,18 @@ class RequestOptions
         }
         $other_options->headers = array_merge($this->headers, $other_options->headers);
         return $other_options;
+    }
+
+    /**
+     * Discards all headers that we don't want to persist across requests.
+     */
+    public function discardNonPersistentHeaders()
+    {
+        foreach ($this->headers as $k => $v) {
+            if (!in_array($k, self::$HEADERS_TO_PERSIST)) {
+                unset($this->headers[$k]);
+            }
+        }
     }
 
     /**

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -118,4 +118,30 @@ class CollectionTest extends TestCase
 
         $this->assertSame([1, 2, 3], $seen);
     }
+
+    public function testHeaders()
+    {
+        $this->stubRequest(
+            'POST',
+            '/things',
+            [
+                'foo' => 'bar',
+            ],
+            [
+                'Stripe-Account: acct_foo',
+                'Idempotency-Key: qwertyuiop',
+            ],
+            false,
+            [
+                'id' => 2,
+            ]
+        );
+
+        $this->fixture->create([
+            'foo' => 'bar',
+        ], [
+            'stripe_account' => 'acct_foo',
+            'idempotency_key' => 'qwertyuiop',
+        ]);
+    }
 }

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -66,4 +66,16 @@ class RequestOptionsTest extends TestCase
     {
         $opts = Util\RequestOptions::parse(5);
     }
+
+    public function testDiscardNonPersistentHeaders()
+    {
+        $opts = Util\RequestOptions::parse(
+            [
+                'stripe_account' => 'foo',
+                'idempotency_key' => 'foo',
+            ]
+        );
+        $opts->discardNonPersistentHeaders();
+        $this->assertSame(['Stripe-Account' => 'foo'], $opts->headers);
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @rs-sliske

Fixes #434.

In 6.0.0, `Collection` is no longer a subclass of `ApiResource` (cf. #404). Because the list of persistent headers was stored on `ApiResource`, this broke API requests on collection objects that used headers.

Since we have a dedicated class in stripe-php to store request options (`Util\RequestOptions`), I've moved the header persistence logic there.
