### PR TITLE
Introduce new `Idempotency` error class

### DIFF
--- a/init.php
+++ b/init.php
@@ -22,6 +22,7 @@ require(dirname(__FILE__) . '/lib/Error/Api.php');
 require(dirname(__FILE__) . '/lib/Error/ApiConnection.php');
 require(dirname(__FILE__) . '/lib/Error/Authentication.php');
 require(dirname(__FILE__) . '/lib/Error/Card.php');
+require(dirname(__FILE__) . '/lib/Error/Idempotency.php');
 require(dirname(__FILE__) . '/lib/Error/InvalidRequest.php');
 require(dirname(__FILE__) . '/lib/Error/Permission.php');
 require(dirname(__FILE__) . '/lib/Error/RateLimit.php');

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -70,6 +70,7 @@ class ApiRequestor
      * @param array $resp
      *
      * @throws Error\InvalidRequest if the error is caused by the user.
+     * @throws Error\Idempotency if the error is caused by an idempotency key.
      * @throws Error\Authentication if the error is caused by a lack of
      *    permissions.
      * @throws Error\Permission if the error is caused by insufficient
@@ -106,6 +107,7 @@ class ApiRequestor
         $msg = isset($errorData['message']) ? $errorData['message'] : null;
         $param = isset($errorData['param']) ? $errorData['param'] : null;
         $code = isset($errorData['code']) ? $errorData['code'] : null;
+        $type = isset($errorData['type']) ? $errorData['type'] : null;
 
         switch ($rcode) {
             case 400:
@@ -113,6 +115,9 @@ class ApiRequestor
                 // for API versions earlier than 2015-09-08
                 if ($code == 'rate_limit') {
                     return new Error\RateLimit($msg, $param, $rcode, $rbody, $resp, $rheaders);
+                }
+                if ($type == 'idempotency_error') {
+                    return new Error\Idempotency($msg, $rcode, $rbody, $resp, $rheaders);
                 }
 
                 // intentional fall-through

--- a/lib/Error/Idempotency.php
+++ b/lib/Error/Idempotency.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Stripe\Error;
+
+class Idempotency extends Base
+{
+}

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -119,6 +119,35 @@ class ApiRequestorTest extends TestCase
         }
     }
 
+    public function testRaisesIdempotencyErrorOn400AndTypeIdempotencyError()
+    {
+        $this->stubRequest(
+            'POST',
+            '/v1/charges',
+            array(),
+            null,
+            false,
+            array(
+                'error' => array(
+                    'type' => 'idempotency_error',
+                    'message' => "Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.",
+                ),
+            ),
+            400
+        );
+
+        try {
+            Charge::create();
+            $this->fail("Did not raise error");
+        } catch (Error\Idempotency $e) {
+            $this->assertSame(400, $e->getHttpStatus());
+            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertSame("Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.", $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail("Unexpected exception: " . get_class($e));
+        }
+    }
+
     public function testRaisesAuthenticationErrorOn401()
     {
         $this->stubRequest(


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds support for the `idempotency_error` error type. Cf. https://github.com/stripe/stripe-ruby/pull/613.