### PR TITLE
Add support for /v1/topups endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.5.0
+    - STRIPE_MOCK_VERSION=0.8.0
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/init.php
+++ b/init.php
@@ -92,6 +92,7 @@ require(dirname(__FILE__) . '/lib/Subscription.php');
 require(dirname(__FILE__) . '/lib/SubscriptionItem.php');
 require(dirname(__FILE__) . '/lib/ThreeDSecure.php');
 require(dirname(__FILE__) . '/lib/Token.php');
+require(dirname(__FILE__) . '/lib/Topup.php');
 require(dirname(__FILE__) . '/lib/Transfer.php');
 require(dirname(__FILE__) . '/lib/TransferReversal.php');
 

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class Topup
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $amount
+ * @property string $balance_transaction
+ * @property int $created
+ * @property string $currency
+ * @property string $description
+ * @property int $expected_availability_date
+ * @property string $failure_code
+ * @property string $failure_message
+ * @property bool $livemode
+ * @property StripeObject $metadata
+ * @property mixed $source
+ * @property string $statement_descriptor
+ * @property string $status
+ *
+ * @package Stripe
+ */
+class Topup extends ApiResource
+{
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -108,6 +108,7 @@ abstract class Util
             'subscription_item' => 'Stripe\\SubscriptionItem',
             'three_d_secure' => 'Stripe\\ThreeDSecure',
             'token' => 'Stripe\\Token',
+            'topup' => 'Stripe\\Topup',
             'transfer' => 'Stripe\\Transfer',
             'transfer_reversal' => 'Stripe\\TransferReversal',
         ];

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -34,7 +34,8 @@ class ProductTest extends TestCase
             '/v1/products'
         );
         $resource = Product::create([
-            'name' => 'name'
+            'name' => 'name',
+            'type' => 'good'
         ]);
         $this->assertInstanceOf("Stripe\\Product", $resource);
     }

--- a/tests/Stripe/TopupTest.php
+++ b/tests/Stripe/TopupTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Stripe;
+
+class TopupTest extends TestCase
+{
+    const TEST_RESOURCE_ID = 'tu_123';
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/topups'
+        );
+        $resources = Topup::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Topup", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/topups/' . self::TEST_RESOURCE_ID
+        );
+        $resource = Topup::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Topup", $resource);
+    }
+
+    public function testIsCreatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/topups'
+        );
+        $resource = Topup::create([
+            "amount" => 100,
+            "currency" => "usd",
+            "source" => "tok_123",
+            "description" => "description",
+            "statement_descriptor" => "statement descriptor"
+        ]);
+        $this->assertInstanceOf("Stripe\\Topup", $resource);
+    }
+
+    public function testIsSaveable()
+    {
+        $resource = Topup::retrieve(self::TEST_RESOURCE_ID);
+        $resource->metadata["key"] = "value";
+        $this->expectsRequest(
+            'post',
+            '/v1/topups/' . $resource->id
+        );
+        $resource->save();
+        $this->assertInstanceOf("Stripe\\Topup", $resource);
+    }
+
+    public function testIsUpdatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/topups/' . self::TEST_RESOURCE_ID
+        );
+        $resource = Topup::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf("Stripe\\Topup", $resource);
+    }
+}


### PR DESCRIPTION
This add standard retrieve, create and update client support for the new `/v1/topups` endpoint.

r? @apakulov-stripe @ccontinanza-stripe @chellman-stripe @kenneth-stripe @miguel-stripe
r? @stripe/api-libraries 