### PR TITLE
Automatic retry for rate-limited requests

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -304,8 +304,8 @@ class CurlClient implements ClientInterface
             return true;
         }
 
-        // 409 conflict
-        if ($rcode === 409) {
+        // 409 conflict or 429 too many requests
+        if ($rcode === 409 || $rcode === 429) {
             return true;
         }
 

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -151,6 +151,15 @@ class CurlClientTest extends TestCase
         $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, 0));
     }
 
+    public function testShouldRetryOnTooManyRequests()
+    {
+        Stripe::setMaxNetworkRetries(2);
+
+        $curlClient = new CurlClient();
+
+        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 429, 0));
+    }
+
     public function testShouldNotRetryAtMaximumCount()
     {
         Stripe::setMaxNetworkRetries(2);


### PR DESCRIPTION
Hello everyone, very happy to see #428 land, it's a great feature! I noticed that [the docs](https://stripe.com/docs/testing#rate-limits) mention that it's safe to retry rate-limited requests with exponential backoff, so it'd be nice to also handle the 429 status code.