### PR TITLE
Add support for code attribute on all Stripe exceptions

### DIFF
--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -20,9 +20,18 @@ abstract class Base extends Exception
         $this->httpHeaders = $httpHeaders;
         $this->requestId = null;
 
+        // TODO: make this a proper constructor argument in the next major
+        //       release.
+        $this->stripeCode = isset($jsonBody["error"]["code"]) ? $jsonBody["error"]["code"] : null;
+
         if ($httpHeaders && isset($httpHeaders['Request-Id'])) {
             $this->requestId = $httpHeaders['Request-Id'];
         }
+    }
+
+    public function getStripeCode()
+    {
+        return $this->stripeCode;
     }
 
     public function getHttpStatus()

--- a/lib/Error/Card.php
+++ b/lib/Error/Card.php
@@ -15,23 +15,22 @@ class Card extends Base
     ) {
         parent::__construct($message, $httpStatus, $httpBody, $jsonBody, $httpHeaders);
         $this->stripeParam = $stripeParam;
+
+        // TODO: once Error\Base accepts the error code as an argument, pass it
+        //       in the call to parent::__construct() and stop setting it here.
         $this->stripeCode = $stripeCode;
 
         // This one is not like the others because it was added later and we're
         // trying to do our best not to change the public interface of this class'
-        // constructor. We should consider changing its implementation on the
-        // next major version bump of this library.
+        // constructor.
+        // TODO: make this a proper constructor argument in the next major
+        //       release.
         $this->declineCode = isset($jsonBody["error"]["decline_code"]) ? $jsonBody["error"]["decline_code"] : null;
     }
 
     public function getDeclineCode()
     {
         return $this->declineCode;
-    }
-
-    public function getStripeCode()
-    {
-        return $this->stripeCode;
     }
 
     public function getStripeParam()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

PHP does not support overloading constructors, so I've had to resort to a slightly hackish solution to avoid modifying the constructor's signature and preserve BC. There was already a precedent for it though, for the `decline_code` attribute on card errors: https://github.com/stripe/stripe-php/blob/6791706360c98c9cb99b7ad5e1f1dc1c54f962cc/lib/Error/Card.php#L23-L28