### PR TITLE
Invoice missing amount_paid and amount_remaining properties

### DIFF
--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -8,6 +8,8 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount_due
+ * @property int $amount_paid
+ * @property int $amount_remaining
  * @property int $application_fee
  * @property int $attempt_count
  * @property bool $attempted


### PR DESCRIPTION
For some reason I missed these in my phpdoc frenzy. Probably because they're also not listed on https://stripe.com/docs/api#invoice_object in the left section, only in the example on the right.

Just a minor edit.