### PR TITLE
Fixed namespaces in docblocks

### DIFF
--- a/lib/ApiOperations/All.php
+++ b/lib/ApiOperations/All.php
@@ -13,7 +13,7 @@ trait All
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return Collection of ApiResources
+     * @return \Stripe\Collection of ApiResources
      */
     public static function all($params = null, $opts = null)
     {

--- a/lib/ApiOperations/Create.php
+++ b/lib/ApiOperations/Create.php
@@ -13,7 +13,7 @@ trait Create
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return ApiResource The created resource.
+     * @return \Stripe\ApiResource The created resource.
      */
     public static function create($params = null, $options = null)
     {

--- a/lib/ApiOperations/Delete.php
+++ b/lib/ApiOperations/Delete.php
@@ -13,7 +13,7 @@ trait Delete
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return ApiResource The deleted resource.
+     * @return \Stripe\ApiResource The deleted resource.
      */
     public function delete($params = null, $opts = null)
     {

--- a/lib/ApiOperations/NestedResource.php
+++ b/lib/ApiOperations/NestedResource.php
@@ -15,7 +15,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _nestedResourceOperation($method, $url, $params = null, $options = null)
     {
@@ -49,7 +49,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _createNestedResource($id, $nestedPath, $params = null, $options = null)
     {
@@ -63,7 +63,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _retrieveNestedResource($id, $nestedPath, $nestedId, $params = null, $options = null)
     {
@@ -77,7 +77,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _updateNestedResource($id, $nestedPath, $nestedId, $params = null, $options = null)
     {
@@ -91,7 +91,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _deleteNestedResource($id, $nestedPath, $nestedId, $params = null, $options = null)
     {
@@ -105,7 +105,7 @@ trait NestedResource
      * @param array|null $params
      * @param array|string|null $options
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     protected static function _allNestedResources($id, $nestedPath, $params = null, $options = null)
     {

--- a/lib/ApiOperations/Request.php
+++ b/lib/ApiOperations/Request.php
@@ -12,7 +12,7 @@ trait Request
     /**
      * @param array|null|mixed $params The list of parameters to validate
      *
-     * @throws Stripe\Error\Api if $params exists and is not an array
+     * @throws \Stripe\Error\Api if $params exists and is not an array
      */
     protected static function _validateParams($params = null)
     {

--- a/lib/ApiOperations/Retrieve.php
+++ b/lib/ApiOperations/Retrieve.php
@@ -15,7 +15,7 @@ trait Retrieve
      *     or an options array containing an `id` key.
      * @param array|string|null $opts
      *
-     * @return Stripe\StripeObject
+     * @return \Stripe\StripeObject
      */
     public static function retrieve($id, $opts = null)
     {

--- a/lib/ApiOperations/Update.php
+++ b/lib/ApiOperations/Update.php
@@ -15,7 +15,7 @@ trait Update
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return ApiResource The updated resource.
+     * @return \Stripe\ApiResource The updated resource.
      */
     public static function update($id, $params = null, $opts = null)
     {
@@ -31,7 +31,7 @@ trait Update
     /**
      * @param array|string|null $opts
      *
-     * @return ApiResource The saved resource.
+     * @return \Stripe\ApiResource The saved resource.
      */
     public function save($opts = null)
     {

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -12,7 +12,7 @@ abstract class ApiResource extends StripeObject
     use ApiOperations\Request;
 
     /**
-     * @return Stripe\Util\Set A list of fields that can be their own type of
+     * @return \Stripe\Util\Set A list of fields that can be their own type of
      * API resource (say a nested card under an account for example), and if
      * that resource is set, it should be transmitted to the API on a create or
      * update. Doing so is not the default behavior because API resources

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -239,7 +239,7 @@ class CurlClient implements ClientInterface
 
     /**
      * @param string $url
-     * @param number $errno
+     * @param int $errno
      * @param string $message
      * @param int $numRetries
      * @throws Error\ApiConnection


### PR DESCRIPTION
Fixed a number of unqualified/wrongly qualified class references in
docblocks identified by static analysis.

Also fixed one param docblock that used `number` as a type (which is not
according to phpdoc docs).