### PR TITLE
Added $account property for connect webhook events

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -7,6 +7,7 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
+ * @property string $account
  * @property string $api_version
  * @property int $created
  * @property mixed $data


### PR DESCRIPTION
Hello

According to https://stripe.com/docs/connect/webhooks, the Event class has a property called `account` when the event comes from a connected account. I've just added this to phpdocs.