### PR TITLE
Allow stripe-mock version identifying as `master`

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,7 +33,7 @@ if ($version === null) {
     exit(1);
 }
 
-if (version_compare($version, MOCK_MINIMUM_VERSION) == -1) {
+if ($version != "master" && version_compare($version, MOCK_MINIMUM_VERSION) == -1) {
     echo "Your version of stripe-mock (" . $version . ") is too old. The minimum " .
          "version to run this test suite is " . MOCK_MINIMUM_VERSION . ". " .
          "Please see its repository for upgrade instructions.\n";


### PR DESCRIPTION
As in other API libraries testing against stripe-mock, allow `master` as
a catch all version so that we can test the library against the `master`
branch without getting caught by the minimum version check.