### PR TITLE
Fix some parameters being sent in tests

### DIFF
--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -34,8 +34,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions'
         );
         $resource = Subscription::create([
-            "customer" => "cus_123",
-            "plan" => "plan"
+            "customer" => "cus_123"
         ]);
         $this->assertInstanceOf("Stripe\\Subscription", $resource);
     }


### PR DESCRIPTION
Fixes one parameter being sent so that the suite is compliant with a
version of stripe-mock that's checking for extra parameters.

See https://github.com/stripe/stripe-ruby/pull/650 as another sample
with more context.