### PR TITLE
Remove all traits from InvoiceLineItem

### DIFF
--- a/lib/InvoiceLineItem.php
+++ b/lib/InvoiceLineItem.php
@@ -26,12 +26,5 @@ namespace Stripe;
  */
 class InvoiceLineItem extends ApiResource
 {
-
     const OBJECT_NAME = "line_item";
-
-    use ApiOperations\All;
-    use ApiOperations\Create;
-    use ApiOperations\Delete;
-    use ApiOperations\Retrieve;
-    use ApiOperations\Update;
 }


### PR DESCRIPTION
cc @stripe/api-libraries @brandur-stripe @nickdnk 

I missed this when reviewing #471. `InvoiceLineItem` is only used for deserializing the objects returned in the [`lines`](https://stripe.com/docs/api#invoice_object-lines) attribute of invoice objects, there are no API methods to implement. (Technically, there is a `/v1/invoices/<INVOICE_ID>/lines` endpoint that can be used to paginate through the line items, but that's handled by the list object.)

Self-approving.
