### PR TITLE
API 2018-05-21 changes and new charge.expired event

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -37,6 +37,7 @@ class Event extends ApiResource
     const APPLICATION_FEE_REFUND_UPDATED       = 'application_fee.refund.updated';
     const BALANCE_AVAILABLE                    = 'balance.available';
     const CHARGE_CAPTURED                      = 'charge.captured';
+    const CHARGE_EXPIRED                       = 'charge.expired';
     const CHARGE_FAILED                        = 'charge.failed';
     const CHARGE_PENDING                       = 'charge.pending';
     const CHARGE_REFUNDED                      = 'charge.refunded';

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -19,9 +19,9 @@ namespace Stripe;
  * @property string $name
  * @property mixed $package_dimensions
  * @property bool $shippable
- * @property Collection $skus
  * @property string $statement_descriptor
  * @property string $type
+ * @property string $unit_label
  * @property int $updated
  * @property string $url
  *


### PR DESCRIPTION
Hello guys

Just a few minor edits here.

According to the 2018-05-21 update, the `skus` collection has been removed entirely from the `Product` object. I've fixed that in phpdocs.

I've also added the `unit_label` property which was missing from `Product` as well.

I've also added the `charge.expired` event that's now possible to receive from webhooks (https://stripe.com/blog/changelog - https://stripe.com/docs/api#event_types-charge.expired).

Cheers