### PR TITLE
Make `Account.deauthorize()` return the `StripeObject` from the API

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -119,7 +119,7 @@ class Account extends ApiResource
             'client_id' => $clientId,
             'stripe_user_id' => $this->id,
         ];
-        OAuth::deauthorize($params, $opts);
+        return OAuth::deauthorize($params, $opts);
     }
 
     /**


### PR DESCRIPTION
Fixes #485.

r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @fre5h

