### PR TITLE
Add support for the PaymentIntent resource

### DIFF
--- a/init.php
+++ b/init.php
@@ -84,6 +84,7 @@ require(dirname(__FILE__) . '/lib/LoginLink.php');
 require(dirname(__FILE__) . '/lib/Order.php');
 require(dirname(__FILE__) . '/lib/OrderItem.php');
 require(dirname(__FILE__) . '/lib/OrderReturn.php');
+require(dirname(__FILE__) . '/lib/PaymentIntent.php');
 require(dirname(__FILE__) . '/lib/Payout.php');
 require(dirname(__FILE__) . '/lib/Plan.php');
 require(dirname(__FILE__) . '/lib/Product.php');

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class PaymentIntent
+ *
+ * @property string $id
+ * @property string $object
+ * @property string[] $allowed_source_types
+ * @property int $amount
+ * @property int $amount_capturable
+ * @property int $amount_received
+ * @property string $application
+ * @property int $application_fee
+ * @property int $canceled_at
+ * @property string $capture_method
+ * @property Collection $charges
+ * @property string $client_secret
+ * @property int $created
+ * @property string $currency
+ * @property string $customer
+ * @property string $description
+ * @property bool $livemode
+ * @property StripeObject $metadata
+ * @property mixed $next_source_action
+ * @property string $on_behalf_of
+ * @property string $receipt_email
+ * @property string $return_url
+ * @property mixed $shipping
+ * @property string $source
+ * @property string $statement_descriptor
+ * @property string $status
+ * @property mixed $transfer_data
+ * @property string $transfer_group
+ *
+ * @package Stripe
+ */
+class PaymentIntent extends ApiResource
+{
+
+    const OBJECT_NAME = "payment_intent";
+
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+
+    /**
+     * This is a special case because the payment intents endpoint has an
+     *    underscore in it. The parent `className` function strips underscores.
+     *
+     * @return string The name of the class.
+     */
+    public static function className()
+    {
+        return 'payment_intent';
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return PaymentIntent The canceled payment intent.
+     */
+    public function cancel($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/cancel';
+        list($response, $opts) = $this->_request('post', $url);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return PaymentIntent The captured payment intent.
+     */
+    public function capture($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/capture';
+        list($response, $opts) = $this->_request('post', $url);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return PaymentIntent The confirmed payment intent.
+     */
+    public function confirm($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/confirm';
+        list($response, $opts) = $this->_request('post', $url);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -99,6 +99,7 @@ abstract class Util
             \Stripe\Order::OBJECT_NAME => 'Stripe\\Order',
             \Stripe\OrderItem::OBJECT_NAME => 'Stripe\\OrderItem',
             \Stripe\OrderReturn::OBJECT_NAME => 'Stripe\\OrderReturn',
+            \Stripe\PaymentIntent::OBJECT_NAME => 'Stripe\\PaymentIntent',
             \Stripe\Payout::OBJECT_NAME => 'Stripe\\Payout',
             \Stripe\Plan::OBJECT_NAME => 'Stripe\\Plan',
             \Stripe\Product::OBJECT_NAME => 'Stripe\\Product',

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Stripe;
+
+class PaymentIntentTest extends TestCase
+{
+    const TEST_RESOURCE_ID = 'pi_123';
+
+    // stripe-mock does not support /v1/payment_intents yet so we stub it
+    // and create a fixture for it
+    public function createFixture()
+    {
+        $base = [
+            'id' => self::TEST_RESOURCE_ID,
+            'object' => 'payment_intent',
+            'metadata' => [],
+        ];
+        return PaymentIntent::constructFrom(
+            $base,
+            new Util\RequestOptions()
+        );
+    }
+
+    public function testIsListable()
+    {
+        $this->stubRequest(
+            'get',
+            '/v1/payment_intents',
+            [],
+            null,
+            false,
+            [
+                "object" => "list",
+                "data" => [
+                    $this->createFixture()
+                ]
+            ]
+        );
+        $resources = PaymentIntent::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->stubRequest(
+            'get',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID,
+            [],
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource = PaymentIntent::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsCreatable()
+    {
+        $params = [
+            "allowed_source_types" => ["card"],
+            "amount" => 100,
+            "currency" => "usd",
+        ];
+
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents',
+            $params,
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource = PaymentIntent::create($params);
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsSaveable()
+    {
+        $params = [
+            "metadata" => ["key" => "value"],
+        ];
+
+        $resource = $this->createFixture();
+        $resource->metadata["key"] = "value";
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents/' . $resource->id,
+            $params,
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource->save();
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsUpdatable()
+    {
+        $params = [
+            "metadata" => ["key" => "value"],
+        ];
+
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID,
+            $params,
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource = PaymentIntent::update(self::TEST_RESOURCE_ID, $params);
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsCancelable()
+    {
+        $resource = $this->createFixture();
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents/' . $resource->id . '/cancel',
+            [],
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource->cancel();
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsCapturable()
+    {
+        $resource = $this->createFixture();
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents/' . $resource->id . '/capture',
+            [],
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource->capture();
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+
+    public function testIsConfirmable()
+    {
+        $resource = $this->createFixture();
+        $this->stubRequest(
+            'post',
+            '/v1/payment_intents/' . $resource->id . '/confirm',
+            [],
+            null,
+            false,
+            $this->createFixture()
+        );
+        $resource->confirm();
+        $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
+    }
+}


### PR DESCRIPTION
This feature is currently gated so the tests are stubbed for now.

r? @ob-stripe 
cc @stripe/api-libraries 
cc @jenan-stripe @michelle-stripe