### PR TITLE
Adds support for 'partner_id' to 'setAppInfo'

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -199,12 +199,13 @@ class Stripe
      * @param string $appVersion The application's version
      * @param string $appUrl The application's URL
      */
-    public static function setAppInfo($appName, $appVersion = null, $appUrl = null)
+    public static function setAppInfo($appName, $appVersion = null, $appUrl = null, $appPartnerId = null)
     {
         self::$appInfo = self::$appInfo ?: [];
         self::$appInfo['name'] = $appName;
-        self::$appInfo['version'] = $appVersion;
+        self::$appInfo['partner_id'] = $appPartnerId;
         self::$appInfo['url'] = $appUrl;
+        self::$appInfo['version'] = $appVersion;
     }
 
     /**

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -57,7 +57,7 @@ class ApiRequestorTest extends TestCase
         $method->setAccessible(true);
 
         // no way to stub static methods with PHPUnit 4.x :(
-        Stripe::setAppInfo('MyTestApp', '1.2.34', 'https://mytestapp.example');
+        Stripe::setAppInfo('MyTestApp', '1.2.34', 'https://mytestapp.example', 'partner_1234');
         $apiKey = 'sk_test_notarealkey';
         $clientInfo = ['httplib' => 'testlib 0.1.2'];
 
@@ -67,6 +67,7 @@ class ApiRequestorTest extends TestCase
         $this->assertSame($ua->application->name, 'MyTestApp');
         $this->assertSame($ua->application->version, '1.2.34');
         $this->assertSame($ua->application->url, 'https://mytestapp.example');
+        $this->assertSame($ua->application->partner_id, 'partner_1234');
 
         $this->assertSame($ua->httplib, 'testlib 0.1.2');
 


### PR DESCRIPTION
This adds support for an optional partner_id attribute in the setAppInfo hash.