### PR TITLE
Enable HTTP/2 support

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -22,6 +22,10 @@ if (!defined('CURL_SSLVERSION_TLSv1_2')) {
 }
 // @codingStandardsIgnoreEnd
 
+if (!defined('CURL_HTTP_VERSION_2_0')) {
+    define('CURL_HTTP_VERSION_2_0', 3);
+}
+
 class CurlClient implements ClientInterface
 {
     private static $instance;
@@ -192,6 +196,9 @@ class CurlClient implements ClientInterface
         if (!Stripe::getVerifySslCerts()) {
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
+
+        // Enable HTTP/2, if supported
+        $opts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
 
         list($rbody, $rcode) = $this->executeRequestWithRetries($opts, $absUrl);
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The API doesn't support HTTP/2, but it will Soon™.

This should be safe to merge now. Per curl's [documentation](https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html):
> libcurl will fall back to HTTP 1.1 if HTTP 2 can't be negotiated with the server. 
