### PR TITLE
Use HTTP/2 only for HTTPS requests

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -22,8 +22,8 @@ if (!defined('CURL_SSLVERSION_TLSv1_2')) {
 }
 // @codingStandardsIgnoreEnd
 
-if (!defined('CURL_HTTP_VERSION_2_0')) {
-    define('CURL_HTTP_VERSION_2_0', 3);
+if (!defined('CURL_HTTP_VERSION_2TLS')) {
+    define('CURL_HTTP_VERSION_2TLS', 4);
 }
 
 class CurlClient implements ClientInterface
@@ -197,8 +197,8 @@ class CurlClient implements ClientInterface
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
 
-        // Enable HTTP/2, if supported
-        $opts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
+        // For HTTPS requests, enable HTTP/2, if supported
+        $opts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2TLS;
 
         list($rbody, $rcode) = $this->executeRequestWithRetries($opts, $absUrl);
 


### PR DESCRIPTION
The previously used flag tried to upgrade *any* request to HTTP/2, by sending an `Upgrade: h2c` header. Some HTTP servers (such as PHP's built-in one, which I use for mocking HTTP requests) apparently cannot deal with it. Using the `CURL_HTTP_VERSION_2TLS` flag instead makes Curl attempt an upgrade for HTTPS requests (e.g. to Stripe's API endpoint), but not for HTTP ones.

See https://ec.haxx.se/http-http2.html and https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html.

(Plus, see my previous comments in PR #494 which introduced this feature.)