### PR TITLE
Better `classUrl()`

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -67,30 +67,6 @@ abstract class ApiResource extends StripeObject
     }
 
     /**
-     * @return string The name of the class, with namespacing and underscores
-     *    stripped.
-     */
-    public static function className()
-    {
-        $class = get_called_class();
-        // Useful for namespaces: Foo\Charge
-        if ($postfixNamespaces = strrchr($class, '\\')) {
-            $class = substr($postfixNamespaces, 1);
-        }
-        // Useful for underscored 'namespaces': Foo_Charge
-        if ($postfixFakeNamespaces = strrchr($class, '')) {
-            $class = $postfixFakeNamespaces;
-        }
-        if (substr($class, 0, strlen('Stripe')) == 'Stripe') {
-            $class = substr($class, strlen('Stripe'));
-        }
-        $class = str_replace('_', '', $class);
-        $name = urlencode($class);
-        $name = strtolower($name);
-        return $name;
-    }
-
-    /**
      * @return string The base URL for the given class.
      */
     public static function baseUrl()
@@ -103,7 +79,9 @@ abstract class ApiResource extends StripeObject
      */
     public static function classUrl()
     {
-        $base = static::className();
+        // Replace dots with slashes for namespaced resources, e.g. if the object's name is
+        // "foo.bar", then its URL will be "/v1/foo/bars".
+        $base = str_replace('.', '/', static::OBJECT_NAME);
         return "/v1/${base}s";
     }
 

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -34,17 +34,6 @@ class ApplicationFee extends ApiResource
     const PATH_REFUNDS = '/refunds';
 
     /**
-     * This is a special case because the application fee endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'application_fee';
-    }
-
-    /**
      * @param array|null $params
      * @param array|string|null $opts
      *

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -22,15 +22,4 @@ class CountrySpec extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;
-
-    /**
-     * This is a special case because the country specs endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'country_spec';
-    }
 }

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -26,17 +26,6 @@ class EphemeralKey extends ApiResource
     use ApiOperations\Delete;
 
     /**
-     * This is a special case because the ephemeral key endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'ephemeral_key';
-    }
-
-    /**
      * @param array|null $params
      * @param array|string|null $opts
      *

--- a/lib/ExchangeRate.php
+++ b/lib/ExchangeRate.php
@@ -14,15 +14,4 @@ class ExchangeRate extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;
-
-    /**
-     * This is a special case because the exchange rates endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'exchange_rate';
-    }
 }

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -30,8 +30,8 @@ class FileUpload extends ApiResource
         return Stripe::$apiUploadBase;
     }
 
-    public static function className()
+    public static function classUrl()
     {
-        return 'file';
+        return '/v1/files';
     }
 }

--- a/lib/IssuerFraudRecord.php
+++ b/lib/IssuerFraudRecord.php
@@ -22,9 +22,4 @@ class IssuerFraudRecord extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;
-
-    public static function classUrl()
-    {
-        return "/v1/issuer_fraud_records";
-    }
 }

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -24,15 +24,4 @@ class OrderReturn extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;
-
-    /**
-     * This is a special case because the order returns endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'order_return';
-    }
 }

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -47,17 +47,6 @@ class PaymentIntent extends ApiResource
     use ApiOperations\Update;
 
     /**
-     * This is a special case because the payment intents endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'payment_intent';
-    }
-
-    /**
      * @param array|null $params
      * @param array|string|null $options
      *

--- a/lib/SingletonApiResource.php
+++ b/lib/SingletonApiResource.php
@@ -22,7 +22,9 @@ abstract class SingletonApiResource extends ApiResource
      */
     public static function classUrl()
     {
-        $base = static::className();
+        // Replace dots with slashes for namespaced resources, e.g. if the object's name is
+        // "foo.bar", then its URL will be "/v1/foo/bar".
+        $base = str_replace('.', '/', static::OBJECT_NAME);
         return "/v1/${base}";
     }
 

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -25,15 +25,4 @@ class SubscriptionItem extends ApiResource
     use ApiOperations\Delete;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
-
-    /**
-     * This is a special case because the subscription items endpoint has an
-     *    underscore in it. The parent `className` function strips underscores.
-     *
-     * @return string The name of the class.
-     */
-    public static function className()
-    {
-        return 'subscription_item';
-    }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Simplifies `classUrl()` by using the recently-added `OBJECT_NAME` class constants. Removes `className()` entirely.
