### PR TITLE
Add `isDeleted()` method to `StripeObject`

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -507,4 +507,16 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     {
         $this->_lastResponse = $resp;
     }
+
+    /**
+     * Indicates whether or not the resource has been deleted on the server.
+     * Note that some, but not all, resources can indicate whether they have
+     * been deleted.
+     *
+     * @return bool Whether the resource is deleted.
+     */
+    public function isDeleted()
+    {
+        return isset($this->_values['deleted']) ? $this->_values['deleted'] : false;
+    }
 }

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -461,4 +461,16 @@ EOS;
         $copyCharge = $this->deepCopyReflector->invoke(null, $charge);
         $this->assertEquals(get_class($charge), get_class($copyCharge));
     }
+
+    public function testIsDeleted()
+    {
+        $obj = StripeObject::constructFrom([]);
+        $this->assertFalse($obj->isDeleted());
+
+        $obj = StripeObject::constructFrom(['deleted' => false]);
+        $this->assertFalse($obj->isDeleted());
+
+        $obj = StripeObject::constructFrom(['deleted' => true]);
+        $this->assertTrue($obj->isDeleted());
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Adds a `isDeleted()` method to `StripeObject` that returns `true` if the resource has been deleted and `false` otherwise.

This is similar to what we have in stripe-ruby: https://github.com/stripe/stripe-ruby/blob/ec66c3f0f44274f885de8d13de5dce2657932121/lib/stripe/stripe_object.rb#L99-L104
