### PR TITLE
Move Scheduled Query Run to stripe-mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.23.0
+    - STRIPE_MOCK_VERSION=0.24.1
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/tests/Stripe/Issuing/TransactionTest.php
+++ b/tests/Stripe/Issuing/TransactionTest.php
@@ -6,21 +6,6 @@ class TransactionTest extends \Stripe\TestCase
 {
     const TEST_RESOURCE_ID = 'ipi_123';
 
-    // stripe-mock does not support /v1/issuing/transactions yet so we stub it
-    // and create a fixture for it
-    public function createFixture()
-    {
-        $base = [
-            'id' => self::TEST_RESOURCE_ID,
-            'object' => 'issuing.transaction',
-            'metadata' => [],
-        ];
-        return Transaction::constructFrom(
-            $base,
-            new \Stripe\Util\RequestOptions()
-        );
-    }
-
     public function testIsListable()
     {
         $this->expectsRequest(

--- a/tests/Stripe/Sigma/ScheduledQueryRunTest.php
+++ b/tests/Stripe/Sigma/ScheduledQueryRunTest.php
@@ -6,36 +6,8 @@ class AuthorizationTest extends \Stripe\TestCase
 {
     const TEST_RESOURCE_ID = 'sqr_123';
 
-    // stripe-mock does not support /v1/sigma/scheduled_query_runs yet so we stub it
-    // and create a fixture for it
-    public function createFixture()
-    {
-        $base = [
-            'id' => self::TEST_RESOURCE_ID,
-            'object' => 'scheduled_query_run',
-            'metadata' => [],
-        ];
-        return ScheduledQueryRun::constructFrom(
-            $base,
-            new \Stripe\Util\RequestOptions()
-        );
-    }
-
     public function testIsListable()
     {
-        $this->stubRequest(
-            'get',
-            '/v1/sigma/scheduled_query_runs',
-            [],
-            null,
-            false,
-            [
-                "object" => "list",
-                "data" => [
-                    $this->createFixture()
-                ]
-            ]
-        );
         $resources = ScheduledQueryRun::all();
         $this->assertTrue(is_array($resources->data));
         $this->assertInstanceOf("Stripe\\Sigma\\ScheduledQueryRun", $resources->data[0]);
@@ -43,14 +15,6 @@ class AuthorizationTest extends \Stripe\TestCase
 
     public function testIsRetrievable()
     {
-        $this->stubRequest(
-            'get',
-            '/v1/sigma/scheduled_query_runs/' . self::TEST_RESOURCE_ID,
-            [],
-            null,
-            false,
-            $this->createFixture()
-        );
         $resource = ScheduledQueryRun::retrieve(self::TEST_RESOURCE_ID);
         $this->assertInstanceOf("Stripe\\Sigma\\ScheduledQueryRun", $resource);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-define("MOCK_MINIMUM_VERSION", "0.23.0");
+define("MOCK_MINIMUM_VERSION", "0.24.1");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
 
 // Send a request to stripe-mock


### PR DESCRIPTION
Also remove a fixture that is not needed anymore

r? @ob-stripe 
cc @stripe/api-libraries 