### PR TITLE
Add support for the Reporting resources

### DIFF
--- a/init.php
+++ b/init.php
@@ -98,6 +98,8 @@ require(dirname(__FILE__) . '/lib/Product.php');
 require(dirname(__FILE__) . '/lib/Recipient.php');
 require(dirname(__FILE__) . '/lib/RecipientTransfer.php');
 require(dirname(__FILE__) . '/lib/Refund.php');
+require(dirname(__FILE__) . '/lib/Reporting/ReportRun.php');
+require(dirname(__FILE__) . '/lib/Reporting/ReportType.php');
 require(dirname(__FILE__) . '/lib/SKU.php');
 require(dirname(__FILE__) . '/lib/Sigma/ScheduledQueryRun.php');
 require(dirname(__FILE__) . '/lib/Source.php');

--- a/lib/Reporting/ReportRun.php
+++ b/lib/Reporting/ReportRun.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Stripe\Reporting;
+
+/**
+ * Class ReportRun
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $created
+ * @property string $error
+ * @property bool $livemode
+ * @property mixed $parameters
+ * @property string $report_type
+ * @property mixed $result
+ * @property string $status
+ * @property int $succeeded_at
+ *
+ * @package Stripe\Reporting
+ */
+class ReportRun extends \Stripe\ApiResource
+{
+    const OBJECT_NAME = "reporting.report_run";
+
+    use \Stripe\ApiOperations\All;
+    use \Stripe\ApiOperations\Create;
+    use \Stripe\ApiOperations\Retrieve;
+}

--- a/lib/Reporting/ReportType.php
+++ b/lib/Reporting/ReportType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Stripe\Reporting;
+
+/**
+ * Class ReportType
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $data_available_end
+ * @property int $data_available_start
+ * @property string $name
+ * @property int $updated
+ * @property string $version
+ *
+ * @package Stripe\Reporting
+ */
+class ReportType extends \Stripe\ApiResource
+{
+    const OBJECT_NAME = "reporting.report_type";
+
+    use \Stripe\ApiOperations\All;
+    use \Stripe\ApiOperations\Retrieve;
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -113,6 +113,8 @@ abstract class Util
             \Stripe\Recipient::OBJECT_NAME => 'Stripe\\Recipient',
             \Stripe\RecipientTransfer::OBJECT_NAME => 'Stripe\\RecipientTransfer',
             \Stripe\Refund::OBJECT_NAME => 'Stripe\\Refund',
+            \Stripe\Reporting\ReportRun::OBJECT_NAME => 'Stripe\\Reporting\\ReportRun',
+            \Stripe\Reporting\ReportType::OBJECT_NAME => 'Stripe\\Reporting\\ReportType',
             \Stripe\SKU::OBJECT_NAME => 'Stripe\\SKU',
             \Stripe\Sigma\ScheduledQueryRun::OBJECT_NAME => 'Stripe\\Sigma\\ScheduledQueryRun',
             \Stripe\Source::OBJECT_NAME => 'Stripe\\Source',

--- a/tests/Stripe/Reporting/ReportRunTest.php
+++ b/tests/Stripe/Reporting/ReportRunTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Stripe\Reporting;
+
+class ReportRunTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = 'frr_123';
+
+    public function testIsCreatable()
+    {
+        $params = [
+            "parameters" => [
+                "connected_account" => "acct_123"
+            ],
+            "report_type" => "activity.summary.1",
+        ];
+
+        $this->expectsRequest(
+            'post',
+            '/v1/reporting/report_runs',
+            $params
+        );
+        $resource = ReportRun::create($params);
+        $this->assertInstanceOf("Stripe\\Reporting\\ReportRun", $resource);
+    }
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_runs'
+        );
+        $resources = ReportRun::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Reporting\\ReportRun", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_runs/' . self::TEST_RESOURCE_ID
+        );
+        $resource = ReportRun::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Reporting\\ReportRun", $resource);
+    }
+}

--- a/tests/Stripe/Reporting/ReportTypeTest.php
+++ b/tests/Stripe/Reporting/ReportTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Stripe\Reporting;
+
+class ReportTypeTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = 'activity.summary.1';
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_types'
+        );
+        $resources = ReportType::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Reporting\\ReportType", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_types/' . self::TEST_RESOURCE_ID
+        );
+        $resource = ReportType::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Reporting\\ReportType", $resource);
+    }
+}


### PR DESCRIPTION
Adding support for the new Reporting resources. Those are in OpenAPI but not yet public but since they are starting to be used and are stable we should merge them.

It's WIP for now while I get some feedback on the implementation and the shape of the resources.

cc @stripe/api-libraries 
cc @brahn-stripe 