### PR TITLE
Make Travis builds more resilient to network errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ cache:
     - stripe-mock
 
 before_install:
+  # Install various build dependencies. We use `travis_retry` because Composer
+  # will occasionally fail intermittently.
+  - travis_retry composer install
+
   # Unpack and start stripe-mock so that the test suite can talk to it
   - |
     if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then

--- a/build.php
+++ b/build.php
@@ -13,7 +13,7 @@ if (!$autoload) {
     file_put_contents('composer.json', json_encode($composer, JSON_PRETTY_PRINT));
 }
 
-passthru('composer install', $returnStatus);
+passthru('composer update', $returnStatus);
 if ($returnStatus !== 0) {
     exit(1);
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Make Travis builds more resilient to network errors by using `travis_retry` to install dependencies.

Because `build.php` can modify `composer.json`, I modified its `composer install` command to `composer update` to ensure that the changes are applied.
