### PR TITLE
Register autoload instead of requiring all classes

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,122 +1,32 @@
 <?php
 
-// Stripe singleton
-require(dirname(__FILE__) . '/lib/Stripe.php');
+/**
+ * Based on https://www.php-fig.org/psr/psr-4/examples/.
+ */
+spl_autoload_register(function ($class) {
+    // project-specific namespace prefix
+    $prefix = 'Stripe\\';
 
-// Utilities
-require(dirname(__FILE__) . '/lib/Util/AutoPagingIterator.php');
-require(dirname(__FILE__) . '/lib/Util/LoggerInterface.php');
-require(dirname(__FILE__) . '/lib/Util/DefaultLogger.php');
-require(dirname(__FILE__) . '/lib/Util/RandomGenerator.php');
-require(dirname(__FILE__) . '/lib/Util/RequestOptions.php');
-require(dirname(__FILE__) . '/lib/Util/Set.php');
-require(dirname(__FILE__) . '/lib/Util/Util.php');
+    // base directory for the namespace prefix
+    $base_dir = __DIR__.'/lib/';
 
-// HttpClient
-require(dirname(__FILE__) . '/lib/HttpClient/ClientInterface.php');
-require(dirname(__FILE__) . '/lib/HttpClient/CurlClient.php');
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (0 !== strncmp($prefix, $class, $len)) {
+        // no, move to the next registered autoloader
+        return;
+    }
 
-// Errors
-require(dirname(__FILE__) . '/lib/Error/Base.php');
-require(dirname(__FILE__) . '/lib/Error/Api.php');
-require(dirname(__FILE__) . '/lib/Error/ApiConnection.php');
-require(dirname(__FILE__) . '/lib/Error/Authentication.php');
-require(dirname(__FILE__) . '/lib/Error/Card.php');
-require(dirname(__FILE__) . '/lib/Error/Idempotency.php');
-require(dirname(__FILE__) . '/lib/Error/InvalidRequest.php');
-require(dirname(__FILE__) . '/lib/Error/Permission.php');
-require(dirname(__FILE__) . '/lib/Error/RateLimit.php');
-require(dirname(__FILE__) . '/lib/Error/SignatureVerification.php');
+    // get the relative class name
+    $relative_class = substr($class, $len);
 
-// OAuth errors
-require(dirname(__FILE__) . '/lib/Error/OAuth/OAuthBase.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidClient.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidGrant.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidRequest.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/InvalidScope.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedGrantType.php');
-require(dirname(__FILE__) . '/lib/Error/OAuth/UnsupportedResponseType.php');
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $base_dir.str_replace('\\', '/', $relative_class).'.php';
 
-// API operations
-require(dirname(__FILE__) . '/lib/ApiOperations/All.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/Create.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/Delete.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/NestedResource.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/Request.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/Retrieve.php');
-require(dirname(__FILE__) . '/lib/ApiOperations/Update.php');
-
-// Plumbing
-require(dirname(__FILE__) . '/lib/ApiResponse.php');
-require(dirname(__FILE__) . '/lib/StripeObject.php');
-require(dirname(__FILE__) . '/lib/ApiRequestor.php');
-require(dirname(__FILE__) . '/lib/ApiResource.php');
-require(dirname(__FILE__) . '/lib/SingletonApiResource.php');
-
-// Stripe API Resources
-require(dirname(__FILE__) . '/lib/Account.php');
-require(dirname(__FILE__) . '/lib/AlipayAccount.php');
-require(dirname(__FILE__) . '/lib/ApplePayDomain.php');
-require(dirname(__FILE__) . '/lib/ApplicationFee.php');
-require(dirname(__FILE__) . '/lib/ApplicationFeeRefund.php');
-require(dirname(__FILE__) . '/lib/Balance.php');
-require(dirname(__FILE__) . '/lib/BalanceTransaction.php');
-require(dirname(__FILE__) . '/lib/BankAccount.php');
-require(dirname(__FILE__) . '/lib/BitcoinReceiver.php');
-require(dirname(__FILE__) . '/lib/BitcoinTransaction.php');
-require(dirname(__FILE__) . '/lib/Card.php');
-require(dirname(__FILE__) . '/lib/Charge.php');
-require(dirname(__FILE__) . '/lib/Collection.php');
-require(dirname(__FILE__) . '/lib/CountrySpec.php');
-require(dirname(__FILE__) . '/lib/Coupon.php');
-require(dirname(__FILE__) . '/lib/Customer.php');
-require(dirname(__FILE__) . '/lib/Discount.php');
-require(dirname(__FILE__) . '/lib/Dispute.php');
-require(dirname(__FILE__) . '/lib/EphemeralKey.php');
-require(dirname(__FILE__) . '/lib/Event.php');
-require(dirname(__FILE__) . '/lib/ExchangeRate.php');
-require(dirname(__FILE__) . '/lib/FileLink.php');
-require(dirname(__FILE__) . '/lib/FileUpload.php');
-require(dirname(__FILE__) . '/lib/Invoice.php');
-require(dirname(__FILE__) . '/lib/InvoiceItem.php');
-require(dirname(__FILE__) . '/lib/InvoiceLineItem.php');
-require(dirname(__FILE__) . '/lib/IssuerFraudRecord.php');
-require(dirname(__FILE__) . '/lib/Issuing/Authorization.php');
-require(dirname(__FILE__) . '/lib/Issuing/Card.php');
-require(dirname(__FILE__) . '/lib/Issuing/CardDetails.php');
-require(dirname(__FILE__) . '/lib/Issuing/Cardholder.php');
-require(dirname(__FILE__) . '/lib/Issuing/Dispute.php');
-require(dirname(__FILE__) . '/lib/Issuing/Transaction.php');
-require(dirname(__FILE__) . '/lib/LoginLink.php');
-require(dirname(__FILE__) . '/lib/Order.php');
-require(dirname(__FILE__) . '/lib/OrderItem.php');
-require(dirname(__FILE__) . '/lib/OrderReturn.php');
-require(dirname(__FILE__) . '/lib/PaymentIntent.php');
-require(dirname(__FILE__) . '/lib/Payout.php');
-require(dirname(__FILE__) . '/lib/Plan.php');
-require(dirname(__FILE__) . '/lib/Product.php');
-require(dirname(__FILE__) . '/lib/Recipient.php');
-require(dirname(__FILE__) . '/lib/RecipientTransfer.php');
-require(dirname(__FILE__) . '/lib/Refund.php');
-require(dirname(__FILE__) . '/lib/Reporting/ReportRun.php');
-require(dirname(__FILE__) . '/lib/Reporting/ReportType.php');
-require(dirname(__FILE__) . '/lib/SKU.php');
-require(dirname(__FILE__) . '/lib/Sigma/ScheduledQueryRun.php');
-require(dirname(__FILE__) . '/lib/Source.php');
-require(dirname(__FILE__) . '/lib/SourceTransaction.php');
-require(dirname(__FILE__) . '/lib/Subscription.php');
-require(dirname(__FILE__) . '/lib/SubscriptionItem.php');
-require(dirname(__FILE__) . '/lib/ThreeDSecure.php');
-require(dirname(__FILE__) . '/lib/Token.php');
-require(dirname(__FILE__) . '/lib/Topup.php');
-require(dirname(__FILE__) . '/lib/Transfer.php');
-require(dirname(__FILE__) . '/lib/TransferReversal.php');
-require(dirname(__FILE__) . '/lib/UsageRecord.php');
-require(dirname(__FILE__) . '/lib/UsageRecordSummary.php');
-
-// OAuth
-require(dirname(__FILE__) . '/lib/OAuth.php');
-
-// Webhooks
-require(dirname(__FILE__) . '/lib/Webhook.php');
-require(dirname(__FILE__) . '/lib/WebhookSignature.php');
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
Hi 👋 ,

I work at Algolia and I'm currently writing our PHP API Client. I was looking at yours because I believe we have similar requirements: maintaining old verison of PHP (I even maintain 5.3), powerful enough for Enterprise customer but as easy as possible for self-serve users and such.

I was looking at your `init.php`, I maintain something similar for WordPress or Drupal users. For the v2 I went for an autoloader instead of requiring all the classes. As far as I tested, it works great.

I created this PR to open the conversation, what do you think of this solution? Do you know a reason why it wouldn't work that I'm missing?