### PR TITLE
Integer-index encode all sequential arrays

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -135,16 +135,16 @@ class CurlClient implements ClientInterface
             }
             $opts[CURLOPT_HTTPGET] = 1;
             if (count($params) > 0) {
-                $encoded = Util\Util::urlEncode($params);
+                $encoded = Util\Util::encodeParameters($params);
                 $absUrl = "$absUrl?$encoded";
             }
         } elseif ($method == 'post') {
             $opts[CURLOPT_POST] = 1;
-            $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : Util\Util::urlEncode($params);
+            $opts[CURLOPT_POSTFIELDS] = $hasFile ? $params : Util\Util::encodeParameters($params);
         } elseif ($method == 'delete') {
             $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
             if (count($params) > 0) {
-                $encoded = Util\Util::urlEncode($params);
+                $encoded = Util\Util::encodeParameters($params);
                 $absUrl = "$absUrl?$encoded";
             }
         } else {

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -22,7 +22,7 @@ abstract class OAuth
         if (!array_key_exists('response_type', $params)) {
             $params['response_type'] = 'code';
         }
-        $query = Util\Util::urlEncode($params);
+        $query = Util\Util::encodeParameters($params);
 
         return $base . '/oauth/authorize?' . $query;
     }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -203,42 +203,85 @@ abstract class Util
     }
 
     /**
-     * @param array $arr A map of param keys to values.
-     * @param string|null $prefix
+     * @param array $params
      *
-     * @return string A querystring, essentially.
+     * @return string
      */
-    public static function urlEncode($arr, $prefix = null)
+    public static function encodeParameters($params)
     {
-        if (!is_array($arr)) {
-            return $arr;
+        $flattenedParams = self::flattenParams($params);
+        $pieces = [];
+        foreach ($flattenedParams as $param) {
+            list($k, $v) = $param;
+            array_push($pieces, self::urlEncode($k) . '=' . self::urlEncode($v));
         }
+        return implode('&', $pieces);
+    }
 
-        $r = [];
-        foreach ($arr as $k => $v) {
-            if (is_null($v)) {
-                continue;
-            }
+    /**
+     * @param array $params
+     * @param string|null $parentKey
+     *
+     * @return array
+     */
+    public static function flattenParams($params, $parentKey = null)
+    {
+        $result = [];
 
-            if ($prefix) {
-                if ($k !== null && (!is_int($k) || is_array($v))) {
-                    $k = $prefix."[".$k."]";
-                } else {
-                    $k = $prefix."[]";
-                }
-            }
+        foreach ($params as $key => $value) {
+            $calculatedKey = $parentKey ? "{$parentKey}[{$key}]" : $key;
 
-            if (is_array($v)) {
-                $enc = self::urlEncode($v, $k);
-                if ($enc) {
-                    $r[] = $enc;
-                }
+            if (self::isList($value)) {
+                $result = array_merge($result, self::flattenParamsList($value, $calculatedKey));
+            } elseif (is_array($value)) {
+                $result = array_merge($result, self::flattenParams($value, $calculatedKey));
             } else {
-                $r[] = urlencode($k)."=".urlencode($v);
+                array_push($result, [$calculatedKey, $value]);
             }
         }
 
-        return implode("&", $r);
+        return $result;
+    }
+
+    /**
+     * @param array $value
+     * @param string $calculatedKey
+     *
+     * @return array
+     */
+    public static function flattenParamsList($value, $calculatedKey)
+    {
+        $result = [];
+
+        foreach ($value as $i => $elem) {
+            if (self::isList($elem)) {
+                $result = array_merge($result, self::flattenParamsList($elem, $calculatedKey));
+            } elseif (is_array($elem)) {
+                $result = array_merge($result, self::flattenParams($elem, "{$calculatedKey}[{$i}]"));
+            } else {
+                array_push($result, ["{$calculatedKey}[{$i}]", $elem]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $key A string to URL-encode.
+     *
+     * @return string The URL-encoded string.
+     */
+    public static function urlEncode($key)
+    {
+        $s = urlencode($key);
+
+        // Don't use strict form encoding by changing the square bracket control
+        // characters back to their literals. This is fine by the server, and
+        // makes these parameter strings easier to read.
+        $s = str_replace('%5B', '[', $s);
+        $s = str_replace('%5D', ']', $s);
+
+        return $s;
     }
 
     public static function normalizeId($id)

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -46,45 +46,63 @@ class UtilTest extends TestCase
         $this->assertSame(Util\Util::utf8($x), $x);
     }
 
+    public function testEncodeParameters()
+    {
+        $params = [
+            'a' => 3,
+            'b' => '+foo?',
+            'c' => 'bar&baz',
+            'd' => ['a' => 'a', 'b' => 'b'],
+            'e' => [0, 1],
+            'f' => '',
+
+            // note the empty hash won't even show up in the request
+            'g' => [],
+        ];
+
+        $this->assertSame(
+            "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[0]=0&e[1]=1&f=",
+            Util\Util::encodeParameters($params)
+        );
+    }
+
     public function testUrlEncode()
     {
-        $a = [
-            'my' => 'value',
-            'that' => ['your' => 'example'],
-            'bar' => 1,
-            'baz' => null
+        $this->assertSame("foo", Util\Util::urlEncode("foo"));
+        $this->assertSame("foo%2B", Util\Util::urlEncode("foo+"));
+        $this->assertSame("foo%26", Util\Util::urlEncode("foo&"));
+        $this->assertSame("foo[bar]", Util\Util::urlEncode("foo[bar]"));
+    }
+
+    public function testFlattenParams()
+    {
+        $params = [
+            'a' => 3,
+            'b' => '+foo?',
+            'c' => 'bar&baz',
+            'd' => ['a' => 'a', 'b' => 'b'],
+            'e' => [0, 1],
+            'f' => [
+                ['foo' => '1', 'ghi' => '2'],
+                ['foo' => '3', 'bar' => '4'],
+            ],
         ];
 
-        $enc = Util\Util::urlEncode($a);
-        $this->assertSame('my=value&that%5Byour%5D=example&bar=1', $enc);
-
-        $a = ['that' => ['your' => 'example', 'foo' => null]];
-        $enc = Util\Util::urlEncode($a);
-        $this->assertSame('that%5Byour%5D=example', $enc);
-
-        $a = ['that' => 'example', 'foo' => ['bar', 'baz']];
-        $enc = Util\Util::urlEncode($a);
-        $this->assertSame('that=example&foo%5B%5D=bar&foo%5B%5D=baz', $enc);
-
-        $a = [
-            'my' => 'value',
-            'that' => ['your' => ['cheese', 'whiz', null]],
-            'bar' => 1,
-            'baz' => null
-        ];
-
-        $enc = Util\Util::urlEncode($a);
-        $expected = 'my=value&that%5Byour%5D%5B%5D=cheese'
-              . '&that%5Byour%5D%5B%5D=whiz&bar=1';
-        $this->assertSame($expected, $enc);
-
-        // Ignores an empty array
-        $enc = Util\Util::urlEncode(['foo' => [], 'bar' => 'baz']);
-        $expected = 'bar=baz';
-        $this->assertSame($expected, $enc);
-
-        $a = ['foo' => [['bar' => 'baz'], ['bar' => 'bin']]];
-        $enc = Util\Util::urlEncode($a);
-        $this->assertSame('foo%5B0%5D%5Bbar%5D=baz&foo%5B1%5D%5Bbar%5D=bin', $enc);
+        $this->assertSame(
+            [
+                ['a', 3],
+                ['b', '+foo?'],
+                ['c', 'bar&baz'],
+                ['d[a]', 'a'],
+                ['d[b]', 'b'],
+                ['e[0]', 0],
+                ['e[1]', 1],
+                ['f[0][foo]', '1'],
+                ['f[0][ghi]', '2'],
+                ['f[1][foo]', '3'],
+                ['f[1][bar]', '4'],
+            ],
+            Util\Util::flattenParams($params)
+        );
     }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Okay, this goes a bit beyond just changing the encoding of arrays to use integer-indexing. I updated all the encoding logic to be ~identical to stripe-ruby's.
