### PR TITLE
Handle case when adding a new additional owner to the array

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -230,7 +230,9 @@ class Account extends ApiResource
             $update = ($v instanceof StripeObject) ? $v->serializeParameters() : $v;
 
             if ($update !== []) {
-                if (!$originalValue || ($update != $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
+                if (!$originalValue ||
+                    !array_key_exists($i, $originalValue) ||
+                    ($update != $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
                     $updateArr[$i] = $update;
                 }
             }

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -202,6 +202,29 @@ class AccountTest extends TestCase
         $this->assertSame($expected, $obj->serializeParameters());
     }
 
+    public function testSerializeAddAdditionalOwners()
+    {
+        $obj = Util\Util::convertToStripeObject([
+            'object' => 'account',
+            'legal_entity' => [
+                'additional_owners' => [
+                    StripeObject::constructFrom(['first_name' => 'Joe']),
+                    StripeObject::constructFrom(['first_name' => 'Jane']),
+                ],
+            ],
+        ], null);
+        $obj->legal_entity->additional_owners[2] = ['first_name' => 'Andrew'];
+
+        $expected = [
+            'legal_entity' => [
+                'additional_owners' => [
+                    2 => ['first_name' => 'Andrew'],
+                ],
+            ],
+        ];
+        $this->assertSame($expected, $obj->serializeParameters());
+    }
+
     public function testSerializePartiallyChangedAdditionalOwners()
     {
         $obj = Util\Util::convertToStripeObject([


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @karlr-stripe 

Fixes #521.

I've verified that without the fix, the new test does trigger the issue reported by @karlr-stripe in #521:
```
There was 1 error:

1) Stripe\AccountTest::testSerializeAddAdditionalOwners
Undefined offset: 2

/Users/ob/workspace/php/stripe-php/lib/Account.php:235
/Users/ob/workspace/php/stripe-php/lib/Account.php:208
/Users/ob/workspace/php/stripe-php/tests/Stripe/AccountTest.php:225
```
