### PR TITLE
Supply constants for Source objects

### DIFF
--- a/lib/Source.php
+++ b/lib/Source.php
@@ -35,6 +35,32 @@ class Source extends ApiResource
     use ApiOperations\Update;
 
     /**
+     * Possible string representations of source flows.
+     * @link https://stripe.com/docs/api#source_object-flow
+     */
+    const FLOW_REDIRECT          = 'redirect';
+    const FLOW_RECEIVER          = 'receiver';
+    const FLOW_CODE_VERIFICATION = 'code_verification';
+    const FLOW_NONE              = 'none';
+
+    /**
+     * Possible string representations of source statuses.
+     * @link https://stripe.com/docs/api#source_object-status
+     */
+    const STATUS_CANCELED   = 'canceled';
+    const STATUS_CHARGEABLE = 'chargeable';
+    const STATUS_CONSUMED   = 'consumed';
+    const STATUS_FAILED     = 'failed';
+    const STATUS_PENDING    = 'pending';
+
+    /**
+     * Possible string representations of source usage.
+     * @link https://stripe.com/docs/api#source_object-usage
+     */
+    const USAGE_REUSABLE   = 'reusable';
+    const USAGE_SINGLE_USE = 'single_use';
+
+    /**
      * @param array|null $params
      * @param array|string|null $options
      *


### PR DESCRIPTION
I'd like to compare status and usage of a source I fetch from the api. I added flow as it might be handy for others. I didn't add type as it felt to fluid and less so something you depend flow upon, more something you might store as is.