### PR TITLE
Store HTTP response headers in case-insensitive array

### DIFF
--- a/init.php
+++ b/init.php
@@ -5,6 +5,7 @@ require(dirname(__FILE__) . '/lib/Stripe.php');
 
 // Utilities
 require(dirname(__FILE__) . '/lib/Util/AutoPagingIterator.php');
+require(dirname(__FILE__) . '/lib/Util/CaseInsensitiveArray.php');
 require(dirname(__FILE__) . '/lib/Util/LoggerInterface.php');
 require(dirname(__FILE__) . '/lib/Util/DefaultLogger.php');
 require(dirname(__FILE__) . '/lib/Util/RandomGenerator.php');

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -162,7 +162,7 @@ class CurlClient implements ClientInterface
         }
 
         // Create a callback to capture HTTP headers for the response
-        $rheaders = [];
+        $rheaders = new Util\CaseInsensitiveArray();
         $headerCallback = function ($curl, $header_line) use (&$rheaders) {
             // Ignore the HTTP request line (HTTP/1.1 200 OK)
             if (strpos($header_line, ":") === false) {

--- a/lib/Util/CaseInsensitiveArray.php
+++ b/lib/Util/CaseInsensitiveArray.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Stripe\Util;
+
+use ArrayAccess;
+
+/**
+ * CaseInsensitiveArray is an array-like class that ignores case for keys.
+ *
+ * It is used to store HTTP headers. Per RFC 2616, section 4.2:
+ * Each header field consists of a name followed by a colon (":") and the field value. Field names
+ * are case-insensitive.
+ *
+ * In the context of stripe-php, this is useful because the API will return headers with different
+ * case depending on whether HTTP/2 is used or not (with HTTP/2, headers are always in lowercase).
+ */
+class CaseInsensitiveArray implements ArrayAccess
+{
+    private $container = array();
+
+    public function __construct($initial_array = array())
+    {
+        $this->container = array_map("strtolower", $initial_array);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $offset = static::maybeLowercase($offset);
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    public function offsetExists($offset)
+    {
+        $offset = static::maybeLowercase($offset);
+        return isset($this->container[$offset]);
+    }
+
+    public function offsetUnset($offset)
+    {
+        $offset = static::maybeLowercase($offset);
+        unset($this->container[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        $offset = static::maybeLowercase($offset);
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
+    }
+
+    private static function maybeLowercase($v)
+    {
+        if (is_string($v)) {
+            return strtolower($v);
+        } else {
+            return $v;
+        }
+    }
+}

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -225,4 +225,13 @@ class CurlClientTest extends TestCase
         $this->assertEquals($baseValue * 4, $this->sleepTimeMethod->invoke($curlClient, 3));
         $this->assertEquals($baseValue * 8, $this->sleepTimeMethod->invoke($curlClient, 4));
     }
+
+    public function testResponseHeadersCaseInsensitive()
+    {
+        $charge = Charge::all();
+
+        $headers = $charge->getLastResponse()->headers;
+        $this->assertNotNull($headers['request-id']);
+        $this->assertEquals($headers['request-id'], $headers['Request-Id']);
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Store HTTP response headers in case-insensitive array. HTTP headers are supposed to be case-insensitive, but since we stored them in a regular PHP array, they were actually case-sensitive.

This is particularly problematic since the API will return headers with different cases depending on whether HTTP/2 is used or not (since HTTP/2 requires that all headers be in lowercase).

Fixes #529.
