### PR TITLE
Add FileUpload.php file to fix autoloading

### DIFF
--- a/init.php
+++ b/init.php
@@ -78,6 +78,7 @@ require(dirname(__FILE__) . '/lib/Event.php');
 require(dirname(__FILE__) . '/lib/ExchangeRate.php');
 require(dirname(__FILE__) . '/lib/File.php');
 require(dirname(__FILE__) . '/lib/FileLink.php');
+require(dirname(__FILE__) . '/lib/FileUpload.php');
 require(dirname(__FILE__) . '/lib/Invoice.php');
 require(dirname(__FILE__) . '/lib/InvoiceItem.php');
 require(dirname(__FILE__) . '/lib/InvoiceLineItem.php');

--- a/lib/File.php
+++ b/lib/File.php
@@ -53,6 +53,3 @@ class File extends ApiResource
         return static::_create($params, $opts);
     }
 }
-
-// For backwards compatibility, the `File` class is aliased to `FileUpload`.
-class_alias('Stripe\\File', 'Stripe\\FileUpload');

--- a/lib/FileUpload.php
+++ b/lib/FileUpload.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Stripe;
+
+// For backwards compatibility, the `File` class is aliased to `FileUpload`.
+class_alias('Stripe\\File', 'Stripe\\FileUpload');


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Adds a `FileUpload.php` file so that PSR-4 autoloading for the `\Stripe\FileUpload` class works correctly.

Fixes the issue reported by @ruudk in https://github.com/stripe/stripe-php/pull/520#issuecomment-428934556.

I can't think of a way to write automated tests for this, but I've verified manually that it works:

- before the fix:
```
php > require("vendor/autoload.php");
php > echo class_exists('Stripe\FileUpload');
php > echo class_exists('Stripe\File');
1
php > echo class_exists('Stripe\FileUpload');
1
```

- after the fix:
```
php > require("vendor/autoload.php");
php > echo class_exists('Stripe\FileUpload');
1
```
