### PR TITLE
Add support for Radar List and ListItem resources

### DIFF
--- a/init.php
+++ b/init.php
@@ -98,6 +98,8 @@ require(dirname(__FILE__) . '/lib/Payout.php');
 require(dirname(__FILE__) . '/lib/Person.php');
 require(dirname(__FILE__) . '/lib/Plan.php');
 require(dirname(__FILE__) . '/lib/Product.php');
+require(dirname(__FILE__) . '/lib/Radar/List.php');
+require(dirname(__FILE__) . '/lib/Radar/ListItem.php');
 require(dirname(__FILE__) . '/lib/Recipient.php');
 require(dirname(__FILE__) . '/lib/RecipientTransfer.php');
 require(dirname(__FILE__) . '/lib/Refund.php');

--- a/lib/Radar/List.php
+++ b/lib/Radar/List.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Stripe\Radar;
+
+/**
+ * Class List
+ *
+ * @property string $id
+ * @property string $object
+ * @property string $alias
+ * @property int $created
+ * @property string $created_by
+ * @property string $item_type
+ * @property Collection $list_items
+ * @property bool $livemode
+ * @property StripeObject $metadata
+ * @property mixed $name
+ * @property int $updated
+ * @property string $updated_by
+ *
+ * @package Stripe\Radar
+ */
+class List extends \Stripe\ApiResource
+{
+    const OBJECT_NAME = "radar.list";
+
+    use \Stripe\ApiOperations\All;
+    use \Stripe\ApiOperations\Create;
+    use \Stripe\ApiOperations\Delete;
+    use \Stripe\ApiOperations\Retrieve;
+    use \Stripe\ApiOperations\Update;
+}

--- a/lib/Radar/ListItem.php
+++ b/lib/Radar/ListItem.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stripe\Radar;
+
+/**
+ * Class ListItem
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $created
+ * @property string $created_by
+ * @property string $list
+ * @property bool $livemode
+ * @property string $value
+ *
+ * @package Stripe\Radar
+ */
+class ListItem extends \Stripe\ApiResource
+{
+    const OBJECT_NAME = "radar.list_item";
+
+    use \Stripe\ApiOperations\All;
+    use \Stripe\ApiOperations\Create;
+    use \Stripe\ApiOperations\Delete;
+    use \Stripe\ApiOperations\Retrieve;
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -112,6 +112,8 @@ abstract class Util
             \Stripe\Person::OBJECT_NAME => 'Stripe\\Person',
             \Stripe\Plan::OBJECT_NAME => 'Stripe\\Plan',
             \Stripe\Product::OBJECT_NAME => 'Stripe\\Product',
+            \Stripe\Radar\List::OBJECT_NAME => 'Stripe\\Radar\\List',
+            \Stripe\Radar\ListItem::OBJECT_NAME => 'Stripe\\Radar\\ListItem',
             \Stripe\Recipient::OBJECT_NAME => 'Stripe\\Recipient',
             \Stripe\RecipientTransfer::OBJECT_NAME => 'Stripe\\RecipientTransfer',
             \Stripe\Refund::OBJECT_NAME => 'Stripe\\Refund',

--- a/tests/Stripe/Radar/ListItemTest.php
+++ b/tests/Stripe/Radar/ListItemTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Stripe\Radar;
+
+class ListItemTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = 'rsli_123';
+
+    public function testIsListItemable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/list_items'
+        );
+        $resources = ListItem::all([
+            "list" => "rsl_123",
+        ]);
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Radar\\ListItem", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/list_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = ListItem::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Radar\\ListItem", $resource);
+    }
+
+    public function testIsCreatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/list_items'
+        );
+        $resource = ListItem::create([
+            "list" => "rsl_123",
+            "value" => "value",
+        ]);
+        $this->assertInstanceOf("Stripe\\Radar\\ListItem", $resource);
+    }
+
+    public function testIsDeletable()
+    {
+        $resource = ListItem::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'delete',
+            '/v1/radar/list_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource->delete();
+        $this->assertInstanceOf("Stripe\\Radar\\ListItem", $resource);
+    }
+}

--- a/tests/Stripe/Radar/ListTest.php
+++ b/tests/Stripe/Radar/ListTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Stripe\Radar;
+
+class ListTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = 'rsl_123';
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/lists'
+        );
+        $resources = List::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource = List::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resource);
+    }
+
+    public function testIsCreatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/lists'
+        );
+        $resource = List::create([
+            "alias" => "alias",
+            "name" => "name",
+        ]);
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resource);
+    }
+
+    public function testIsSaveable()
+    {
+        $resource = List::retrieve(self::TEST_RESOURCE_ID);
+        $resource->metadata["key"] = "value";
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource->save();
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resource);
+    }
+
+    public function testIsUpdatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource = List::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resource);
+    }
+
+    public function testIsDeletable()
+    {
+        $resource = List::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'delete',
+            '/v1/radar/lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource->delete();
+        $this->assertInstanceOf("Stripe\\Radar\\List", $resource);
+    }
+}


### PR DESCRIPTION
cc @stripe/api-libraries 

cc @ob-stripe as `List` is forbidden as a class name in PHP so `List` as an object in Radar was likely a bad idea :p