### PR TITLE
Add docblock properties

### DIFF
--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -20,6 +20,7 @@ namespace Stripe;
  * @property bool $livemode
  * @property StripeObject $metadata
  * @property mixed $shipping
+ * @property string $source Used for save() only, not returned on resources.
  * @property Collection $sources
  * @property Collection $subscriptions
  * @property mixed $tax_info

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -13,6 +13,7 @@ namespace Stripe;
  * @property bool $cancel_at_period_end
  * @property int $canceled_at
  * @property int $created
+ * @property string $coupon Used for save() only, not returned on resources.
  * @property int $current_period_end
  * @property int $current_period_start
  * @property string $customer


### PR DESCRIPTION
Hi everyone,

this adds two properties that are only used when updating objects:
- Customer ([update docs](https://stripe.com/docs/api/customers/update#update_customer-source))
- Subscription ([update docs](https://stripe.com/docs/api/subscriptions/update#update_subscription-coupon))

Thanks!