### PR TITLE
Loose package weight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes
+
+# A list of files and folders those will be excluded from release archive
+/.coveralls.yml export-ignore
+/examples export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/phpunit.xml export-ignore
+/phpunit.no_autoload.xml export-ignore
+/tests export-ignore
+/.travis.yml export-ignore
+/.vscode export-ignore


### PR DESCRIPTION
Hi,

Let's not publish all those file.
`.gitattributes` can be used to exclude files from final archive that is downloaded by composer.


Read more
- https://madewithlove.be/gitattributes/
- https://alexbilbie.com/2012/11/exclude-objects-with-gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
