### PR TITLE
Enable persistent connections

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -40,6 +40,10 @@ class CurlClient implements ClientInterface
 
     protected $userAgentInfo;
 
+    protected $enablePersistentConnections = true;
+
+    protected $curlHandle = null;
+
     /**
      * CurlClient constructor.
      *
@@ -60,6 +64,11 @@ class CurlClient implements ClientInterface
         $this->initUserAgentInfo();
     }
 
+    public function __destruct()
+    {
+        $this->closeCurlHandle();
+    }
+
     public function initUserAgentInfo()
     {
         $curlVersion = curl_version();
@@ -77,6 +86,22 @@ class CurlClient implements ClientInterface
     public function getUserAgentInfo()
     {
         return $this->userAgentInfo;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getEnablePersistentConnections()
+    {
+        return $this->enablePersistentConnections;
+    }
+
+    /**
+     * @param boolean $enable
+     */
+    public function setEnablePersistentConnections($enable)
+    {
+        $this->enablePersistentConnections = $enable;
     }
 
     // USER DEFINED TIMEOUTS
@@ -216,17 +241,19 @@ class CurlClient implements ClientInterface
             $rcode = 0;
             $errno = 0;
 
-            $curl = curl_init();
-            curl_setopt_array($curl, $opts);
-            $rbody = curl_exec($curl);
+            $this->resetCurlHandle();
+            curl_setopt_array($this->curlHandle, $opts);
+            $rbody = curl_exec($this->curlHandle);
 
             if ($rbody === false) {
-                $errno = curl_errno($curl);
-                $message = curl_error($curl);
+                $errno = curl_errno($this->curlHandle);
+                $message = curl_error($this->curlHandle);
             } else {
-                $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+                $rcode = curl_getinfo($this->curlHandle, CURLINFO_HTTP_CODE);
             }
-            curl_close($curl);
+            if (!$this->getEnablePersistentConnections()) {
+                $this->closeCurlHandle();
+            }
 
             if ($this->shouldRetry($errno, $rcode, $numRetries)) {
                 $numRetries += 1;
@@ -337,5 +364,38 @@ class CurlClient implements ClientInterface
         $sleepSeconds = max(Stripe::getInitialNetworkRetryDelay(), $sleepSeconds);
 
         return $sleepSeconds;
+    }
+
+    /**
+     * Initializes the curl handle. If already initialized, the handle is closed first.
+     */
+    private function initCurlHandle()
+    {
+        $this->closeCurlHandle();
+        $this->curlHandle = curl_init();
+    }
+
+    /**
+     * Closes the curl handle if initialized. Do nothing if already closed.
+     */
+    private function closeCurlHandle()
+    {
+        if (!is_null($this->curlHandle)) {
+            curl_close($this->curlHandle);
+            $this->curlHandle = null;
+        }
+    }
+
+    /**
+     * Resets the curl handle. If the handle is not already initialized, or if persistent
+     * connections are disabled, the handle is reinitialized instead.
+     */
+    private function resetCurlHandle()
+    {
+        if (!is_null($this->curlHandle) && $this->getEnablePersistentConnections()) {
+            curl_reset($this->curlHandle);
+        } else {
+            $this->initCurlHandle();
+        }
     }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Instead of creating and closing a new curl handle for each request, create a curl handle once and reuse it for all requests. This should offer a significant performance improvement, since curl will reuse the connection.

Unfortunately, it's difficult to write automated tests for this given the current shape of `CurlClient` (not really possible to test private static methods). I've ran some manual tests though, and things look pretty good.

This should also be thread-safe. From https://secure.php.net/manual/en/intro.pthreads.php:
> Static Members: When a new context is created ( Thread or Worker ), they are generally copied, but resources and objects with internal state are nullified (for safety reasons).

Because `CurlClient` is instantiated as a singleton via `CurlClient::instance()`, each thread gets its own client instance (and thus its own curl handle). I've verified that running multiple threads in parallel doesn't cause issues when persistent connections are enabled.
