### PR TITLE
Drop support for PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can sign up for a Stripe account at https://stripe.com.
 
 ## Requirements
 
-PHP 5.4.0 and later.
+PHP 5.5.0 and later.
 
 ## Composer
 
@@ -59,6 +59,10 @@ echo $charge;
 Please see https://stripe.com/docs/api for up-to-date documentation.
 
 ## Legacy Version Support
+
+### PHP 5.4
+
+If you are using PHP 5.4, you can download v6.21.1 ([zip](https://github.com/stripe/stripe-php/archive/v6.21.1.zip), [tar.gz](https://github.com/stripe/stripe-php/archive/v5.9.2.tar.gz)) from our [releases page](https://github.com/stripe/stripe-php/releases). This version will continue to work with new versions of the Stripe API for all common uses.
 
 ### PHP 5.3
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.5.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Drop support for PHP 5.4. This will allow us to ship #550 as well as other improvements.

Note that this PR targets `integration-v7`, not `master`.

