### PR TITLE
Bump dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0",
-    "php-coveralls/php-coveralls": "1.*",
-    "squizlabs/php_codesniffer": "~2.0"
+    "phpunit/phpunit": "^5.7",
+    "php-coveralls/php-coveralls": "^2.1",
+    "squizlabs/php_codesniffer": "^3.3"
   },
   "autoload": {
     "psr-4": { "Stripe\\" : "lib/" }

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -60,7 +60,7 @@ class CurlClientTest extends TestCase
 
     private function createFakeRandomGenerator($returnValue = 1.0)
     {
-        $fakeRandomGenerator = $this->getMock('Stripe\Util\RandomGenetator', ['randFloat']);
+        $fakeRandomGenerator = $this->createMock('Stripe\Util\RandomGenerator', ['randFloat']);
         $fakeRandomGenerator->method('randFloat')->willReturn($returnValue);
         return $fakeRandomGenerator;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         Stripe::setAccountId(null);
 
         // Set up the HTTP client mocker
-        $this->clientMock = $this->getMock('\Stripe\HttpClient\ClientInterface');
+        $this->clientMock = $this->createMock('\Stripe\HttpClient\ClientInterface');
 
         // By default, use the real HTTP client
         ApiRequestor::setHttpClient(HttpClient\CurlClient::instance());


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Dropping support for PHP 5.4 and 5.5 allows us to bump some of our development dependencies to recent versions.
