### PR TITLE
Drop support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can sign up for a Stripe account at https://stripe.com.
 
 ## Requirements
 
-PHP 5.5.0 and later.
+PHP 5.6.0 and later.
 
 ## Composer
 
@@ -60,9 +60,9 @@ Please see https://stripe.com/docs/api for up-to-date documentation.
 
 ## Legacy Version Support
 
-### PHP 5.4
+### PHP 5.4 & 5.5
 
-If you are using PHP 5.4, you can download v6.21.1 ([zip](https://github.com/stripe/stripe-php/archive/v6.21.1.zip), [tar.gz](https://github.com/stripe/stripe-php/archive/v5.9.2.tar.gz)) from our [releases page](https://github.com/stripe/stripe-php/releases). This version will continue to work with new versions of the Stripe API for all common uses.
+If you are using PHP 5.4 or 5.5, you can download v6.21.1 ([zip](https://github.com/stripe/stripe-php/archive/v6.21.1.zip), [tar.gz](https://github.com/stripe/stripe-php/archive/v5.9.2.tar.gz)) from our [releases page](https://github.com/stripe/stripe-php/releases). This version will continue to work with new versions of the Stripe API for all common uses.
 
 ### PHP 5.3
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=5.6.0",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

After reviewing usage metrics and considering the fact that PHP 5.5 security support ended over 2 years ago, I think we should also drop support for 5.5.
