### PR TITLE
Remove CURLFile check

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -333,12 +333,11 @@ class ApiRequestor
         }
 
         $hasFile = false;
-        $hasCurlFile = class_exists('\CURLFile', false);
         foreach ($params as $k => $v) {
             if (is_resource($v)) {
                 $hasFile = true;
-                $params[$k] = self::_processResourceParam($v, $hasCurlFile);
-            } elseif ($hasCurlFile && $v instanceof \CURLFile) {
+                $params[$k] = self::_processResourceParam($v);
+            } elseif ($v instanceof \CURLFile) {
                 $hasFile = true;
             }
         }
@@ -368,12 +367,11 @@ class ApiRequestor
 
     /**
      * @param resource $resource
-     * @param bool     $hasCurlFile
      *
      * @return \CURLFile|string
      * @throws Error\Api
      */
-    private function _processResourceParam($resource, $hasCurlFile)
+    private function _processResourceParam($resource)
     {
         if (get_resource_type($resource) !== 'stream') {
             throw new Error\Api(
@@ -388,12 +386,8 @@ class ApiRequestor
             );
         }
 
-        if ($hasCurlFile) {
-            // We don't have the filename or mimetype, but the API doesn't care
-            return new \CURLFile($metaData['uri']);
-        } else {
-            return '@'.$metaData['uri'];
-        }
+        // We don't have the filename or mimetype, but the API doesn't care
+        return new \CURLFile($metaData['uri']);
     }
 
     /**

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -10,7 +10,7 @@ interface ClientInterface
      * @param array $headers Headers to be used in the request (full strings, not KV pairs)
      * @param array $params KV pairs for parameters. Can be nested for arrays and hashes
      * @param boolean $hasFile Whether or not $params references a file (via an @ prefix or
-     *                         CurlFile)
+     *                         CURLFile)
      *
      * @throws \Stripe\Error\Api
      * @throws \Stripe\Error\ApiConnection

--- a/tests/Stripe/FileCreationTest.php
+++ b/tests/Stripe/FileCreationTest.php
@@ -44,13 +44,8 @@ class FileCreationTest extends TestCase
         $this->assertInstanceOf("Stripe\\File", $resource);
     }
 
-    public function testIsCreatableWithCurlFile()
+    public function testIsCreatableWithCURLFile()
     {
-        if (!class_exists('\CurlFile', false)) {
-            // Older PHP versions don't support this
-            return;
-        }
-
         $this->expectsRequest(
             'post',
             '/v1/files',
@@ -59,7 +54,7 @@ class FileCreationTest extends TestCase
             true,
             Stripe::$apiUploadBase
         );
-        $curlFile = new \CurlFile(dirname(__FILE__) . '/../data/test.png');
+        $curlFile = new \CURLFile(dirname(__FILE__) . '/../data/test.png');
         $resource = File::create([
             "purpose" => "dispute_evidence",
             "file" => $curlFile,

--- a/tests/Stripe/FileUploadCreationTest.php
+++ b/tests/Stripe/FileUploadCreationTest.php
@@ -46,11 +46,6 @@ class FileUploadCreationTest extends TestCase
 
     public function testIsCreatableWithCurlFile()
     {
-        if (!class_exists('\CurlFile', false)) {
-            // Older PHP versions don't support this
-            return;
-        }
-
         $this->expectsRequest(
             'post',
             '/v1/files',


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

The [`CURLFile`](https://secure.php.net/manual/en/class.curlfile.php) class is available as of PHP 5.5, so we can remove the check.