### PR TITLE
Add support for Review resource.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.37.0
+    - STRIPE_MOCK_VERSION=0.38.0
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/init.php
+++ b/init.php
@@ -106,6 +106,7 @@ require(dirname(__FILE__) . '/lib/RecipientTransfer.php');
 require(dirname(__FILE__) . '/lib/Refund.php');
 require(dirname(__FILE__) . '/lib/Reporting/ReportRun.php');
 require(dirname(__FILE__) . '/lib/Reporting/ReportType.php');
+require(dirname(__FILE__) . '/lib/Review.php');
 require(dirname(__FILE__) . '/lib/SKU.php');
 require(dirname(__FILE__) . '/lib/Sigma/ScheduledQueryRun.php');
 require(dirname(__FILE__) . '/lib/Source.php');

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class Review
+ *
+ * @property string $id
+ * @property string $object
+ * @property string $charge
+ * @property int $created
+ * @property bool $livemode
+ * @property bool $open
+ * @property sring $payment_intent
+ * @property string $reason
+ *
+ * @package Stripe
+ */
+class Review extends \Stripe\ApiResource
+{
+    const OBJECT_NAME = "review";
+
+    use \Stripe\ApiOperations\All;
+    use \Stripe\ApiOperations\Retrieve;
+
+    /**
+     * @param array|string|null $options
+     *
+     * @return Review The approved review.
+     */
+    public function approve($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/approve';
+        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -119,6 +119,7 @@ abstract class Util
             \Stripe\Refund::OBJECT_NAME => 'Stripe\\Refund',
             \Stripe\Reporting\ReportRun::OBJECT_NAME => 'Stripe\\Reporting\\ReportRun',
             \Stripe\Reporting\ReportType::OBJECT_NAME => 'Stripe\\Reporting\\ReportType',
+            \Stripe\Review::OBJECT_NAME => 'Stripe\\Review',
             \Stripe\SKU::OBJECT_NAME => 'Stripe\\SKU',
             \Stripe\Sigma\ScheduledQueryRun::OBJECT_NAME => 'Stripe\\Sigma\\ScheduledQueryRun',
             \Stripe\Source::OBJECT_NAME => 'Stripe\\Source',

--- a/tests/Stripe/ReviewTest.php
+++ b/tests/Stripe/ReviewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Stripe;
+
+class ReviewTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = 'prv_123';
+
+    public function testIsApprovable()
+    {
+        $resource = Review::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'post',
+            '/v1/reviews/' . self::TEST_RESOURCE_ID . '/approve'
+        );
+        $resource->approve();
+        $this->assertInstanceOf("Stripe\\Review", $resource);
+    }
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reviews'
+        );
+        $resources = Review::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\Review", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reviews/' . self::TEST_RESOURCE_ID
+        );
+        $resource = Review::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Review", $resource);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-define("MOCK_MINIMUM_VERSION", "0.37.0");
+define("MOCK_MINIMUM_VERSION", "0.38.0");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
 
 // Send a request to stripe-mock


### PR DESCRIPTION
cc @stripe/api-libraries 

This is tagged as WIP as we're missing a release of stripe-mock and the route in the spec is currently incorrect (/v1/reviews)