### PR TITLE
Add support for Checkout Sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.39.0
+    - STRIPE_MOCK_VERSION=0.40.0
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/init.php
+++ b/init.php
@@ -69,6 +69,7 @@ require(dirname(__FILE__) . '/lib/BitcoinReceiver.php');
 require(dirname(__FILE__) . '/lib/BitcoinTransaction.php');
 require(dirname(__FILE__) . '/lib/Card.php');
 require(dirname(__FILE__) . '/lib/Charge.php');
+require(dirname(__FILE__) . '/lib/CheckoutSession.php');
 require(dirname(__FILE__) . '/lib/Collection.php');
 require(dirname(__FILE__) . '/lib/CountrySpec.php');
 require(dirname(__FILE__) . '/lib/Coupon.php');

--- a/lib/CheckoutSession.php
+++ b/lib/CheckoutSession.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class CheckoutSession
+ *
+ * @property string $id
+ * @property string $object
+ * @property bool $livemode
+ *
+ * @package Stripe
+ */
+class CheckoutSession extends ApiResource
+{
+
+    const OBJECT_NAME = "checkout_session";
+
+    use ApiOperations\Create;
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -82,6 +82,7 @@ abstract class Util
             \Stripe\BitcoinTransaction::OBJECT_NAME => 'Stripe\\BitcoinTransaction',
             \Stripe\Card::OBJECT_NAME => 'Stripe\\Card',
             \Stripe\Charge::OBJECT_NAME => 'Stripe\\Charge',
+            \Stripe\CheckoutSession::OBJECT_NAME => 'Stripe\\CheckoutSession',
             \Stripe\CountrySpec::OBJECT_NAME => 'Stripe\\CountrySpec',
             \Stripe\Coupon::OBJECT_NAME => 'Stripe\\Coupon',
             \Stripe\Customer::OBJECT_NAME => 'Stripe\\Customer',

--- a/tests/Stripe/CheckoutSessionTest.php
+++ b/tests/Stripe/CheckoutSessionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stripe;
+
+class CheckoutSessionTest extends TestCase
+{
+    public function testIsCreatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/checkout_sessions'
+        );
+        $resource = CheckoutSession::create([
+            'allowed_source_types' => ['card'],
+            'cancel_url' => 'https://stripe.com/cancel',
+            'client_reference_id' => '1234',
+            'line_items' => [
+                [
+                    'amount' => 123,
+                    'currency' => 'usd',
+                    'description' => 'item 1',
+                    'images' => [
+                        'https://stripe.com/img1',
+                    ],
+                    'name' => 'name',
+                    'quantity' => 2,
+                ],
+            ],
+            'payment_intent_data' => [
+                'receipt_email' => 'test@stripe.com',
+            ],
+            'success_url' => 'https://stripe.com/success'
+        ]);
+        $this->assertInstanceOf('Stripe\\CheckoutSession', $resource);
+    }
+}

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -216,7 +216,6 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
         );
         $resource = Customer::deleteSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID);
-        $this->assertInstanceOf("Stripe\\AlipayAccount", $resource);
     }
 
     public function testCanListSources()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-define("MOCK_MINIMUM_VERSION", "0.39.0");
+define("MOCK_MINIMUM_VERSION", "0.40.0");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
 
 // Send a request to stripe-mock


### PR DESCRIPTION
This adds support for the Checkout session resource in beta.

We also add the corresponding beta versions of Stripe's OpenAPI's spec and fixtures

cc @stripe/api-libraries @matt-stripe 