### PR TITLE
Make stripemock host configurable

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->origAccountId = Stripe::getAccountId();
 
         // Set up host and credentials for stripe-mock
-        Stripe::$apiBase = MOCK_DOMAIN . ":" . MOCK_PORT;
+        Stripe::$apiBase = MOCK_URL;
         Stripe::setApiKey("sk_test_123");
         Stripe::setClientId("ca_123");
         Stripe::setApiVersion(null);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->origAccountId = Stripe::getAccountId();
 
         // Set up host and credentials for stripe-mock
-        Stripe::$apiBase = "http://localhost:" . MOCK_PORT;
+        Stripe::$apiBase = MOCK_DOMAIN . ":" . MOCK_PORT;
         Stripe::setApiKey("sk_test_123");
         Stripe::setClientId("ca_123");
         Stripe::setApiVersion(null);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@
 define("MOCK_MINIMUM_VERSION", "0.40.0");
 define("MOCK_HOST", getenv("STRIPE_MOCK_HOST") ?: "localhost");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
-define("MOCK_URL", "http://" . MOCK_HOST . ":" . MOCK_PORT . "/");
+define("MOCK_URL", "http://" . MOCK_HOST . ":" . MOCK_PORT);
 
 // Send a request to stripe-mock
 $ch = curl_init(MOCK_URL);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,19 +1,19 @@
 <?php
 
 define("MOCK_MINIMUM_VERSION", "0.40.0");
-define("MOCK_DOMAIN", getenv("STRIPE_MOCK_DOMAIN") ?: 'localhost');
+define("MOCK_HOST", getenv("STRIPE_MOCK_HOST") ?: "localhost");
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
+define("MOCK_URL", "http://" . MOCK_HOST . ":" . MOCK_PORT . "/");
 
 // Send a request to stripe-mock
-$mock_url = MOCK_DOMAIN . ":" . MOCK_PORT . "/";
-$ch = curl_init($mock_url);
+$ch = curl_init(MOCK_URL);
 curl_setopt($ch, CURLOPT_HEADER, 1);
 curl_setopt($ch, CURLOPT_NOBODY, 1);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 $resp = curl_exec($ch);
 
 if (curl_errno($ch)) {
-    echo "Couldn't reach stripe-mock at `" . $mock_url . "`. Is " .
+    echo "Couldn't reach stripe-mock at `" . MOCK_HOST . ":" . MOCK_PORT . "`. Is " .
          "it running? Please see README for setup instructions.\n";
     exit(1);
 }
@@ -30,7 +30,7 @@ foreach ($headers as $header) {
 
 if ($version === null) {
     echo "Could not retrieve Stripe-Mock-Version header. Are you sure " .
-         "that the server at `" . $mock_url . "` is a stripe-mock " .
+         "that the server at `" . MOCK_HOST . ":" . MOCK_PORT . "` is a stripe-mock " .
          "instance?";
     exit(1);
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,17 +1,19 @@
 <?php
 
 define("MOCK_MINIMUM_VERSION", "0.40.0");
+define("MOCK_DOMAIN", getenv("STRIPE_MOCK_DOMAIN") ?: 'localhost');
 define("MOCK_PORT", getenv("STRIPE_MOCK_PORT") ?: 12111);
 
 // Send a request to stripe-mock
-$ch = curl_init("http://localhost:" . MOCK_PORT . "/");
+$mock_url = MOCK_DOMAIN . ":" . MOCK_PORT . "/";
+$ch = curl_init($mock_url);
 curl_setopt($ch, CURLOPT_HEADER, 1);
 curl_setopt($ch, CURLOPT_NOBODY, 1);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 $resp = curl_exec($ch);
 
 if (curl_errno($ch)) {
-    echo "Couldn't reach stripe-mock at `localhost:" . MOCK_PORT . "`. Is " .
+    echo "Couldn't reach stripe-mock at `" . $mock_url . "`. Is " .
          "it running? Please see README for setup instructions.\n";
     exit(1);
 }
@@ -28,7 +30,7 @@ foreach ($headers as $header) {
 
 if ($version === null) {
     echo "Could not retrieve Stripe-Mock-Version header. Are you sure " .
-         "that the server at `localhost:" . MOCK_PORT . "` is a stripe-mock " .
+         "that the server at `" . $mock_url . "` is a stripe-mock " .
          "instance?";
     exit(1);
 }


### PR DESCRIPTION
Hi,
This PR is adding `MOCK_DOMAIN` to the available environment variables.

The reason is because my setup is using docker and I run `stripemock` as a separate container hence I can't reach it via localhost from the PHP container.

I hope I didn't overlook anything, I'm not really a seasoned PHP developer.

Thanks !