### PR TITLE
Add support for iterating directly over Collection

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -12,7 +12,7 @@ namespace Stripe;
  *
  * @package Stripe
  */
-class Collection extends StripeObject
+class Collection extends StripeObject implements \IteratorAggregate
 {
 
     const OBJECT_NAME = "list";
@@ -66,6 +66,15 @@ class Collection extends StripeObject
         );
         $this->_requestParams = $params;
         return Util\Util::convertToStripeObject($response, $opts);
+    }
+
+    /**
+     * @return \ArrayIterator An iterator that can be used to iterate
+     *    across objects in the current page.
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
     }
 
     /**

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -71,6 +71,26 @@ class CollectionTest extends TestCase
         ]);
     }
 
+    public function testCanIterate()
+    {
+        $seen = [];
+        foreach ($this->fixture as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertSame([1], $seen);
+    }
+
+    public function testSupportsIteratorToArray()
+    {
+        $seen = [];
+        foreach (iterator_to_array($this->fixture) as $item) {
+            array_push($seen, $item['id']);
+        }
+
+        $this->assertSame([1], $seen);
+    }
+
     public function testProvidesAutoPagingIterator()
     {
         $this->stubRequest(
@@ -95,7 +115,7 @@ class CollectionTest extends TestCase
         $this->assertSame([1, 2, 3], $seen);
     }
 
-    public function testSupportsIteratorToArray()
+    public function testAutoPagingIteratorSupportsIteratorToArray()
     {
         $this->stubRequest(
             'GET',


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries @stemis 

Adds support for iterating directly over `Collection` instances.

Fixes #575.
