### PR TITLE
Properly serialize `individual` on Account objects

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -289,6 +289,12 @@ class Account extends ApiResource
                 $update['legal_entity'] = $entityUpdate;
             }
         }
+        if (isset($this->_values['individual'])) {
+            $individual = $this['individual'];
+            if (($individual instanceof Person) && !isset($update['individual'])) {
+                $update['individual'] = $individual->serializeParameters($force);
+            }
+        }
         return $update;
     }
 

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -456,4 +456,59 @@ class AccountTest extends TestCase
         ];
         $this->assertSame($expected, $obj->serializeParameters());
     }
+
+    public function testSerializeNewIndividual()
+    {
+        $obj = Util\Util::convertToStripeObject([
+            'object' => 'account',
+        ], null);
+        $obj->individual = ['first_name' => 'Jane'];
+
+        $expected = ['individual' => ['first_name' => 'Jane']];
+        $this->assertSame($expected, $obj->serializeParameters());
+    }
+
+    public function testSerializePartiallyChangedIndividual()
+    {
+        $obj = Util\Util::convertToStripeObject([
+            'object' => 'account',
+            'individual' => Util\Util::convertToStripeObject([
+                'object' => 'person',
+                'first_name' => 'Jenny',
+            ], null),
+        ], null);
+        $obj->individual = ['first_name' => 'Jane'];
+
+        $expected = ['individual' => ['first_name' => 'Jane']];
+        $this->assertSame($expected, $obj->serializeParameters());
+    }
+
+    public function testSerializeUnchangedIndividual()
+    {
+        $obj = Util\Util::convertToStripeObject([
+            'object' => 'account',
+            'individual' => Util\Util::convertToStripeObject([
+                'object' => 'person',
+                'first_name' => 'Jenny',
+            ], null),
+        ], null);
+
+        $expected = ['individual' => []];
+        $this->assertSame($expected, $obj->serializeParameters());
+    }
+
+    public function testSerializeUnsetIndividual()
+    {
+        $obj = Util\Util::convertToStripeObject([
+            'object' => 'account',
+            'individual' => Util\Util::convertToStripeObject([
+                'object' => 'person',
+                'first_name' => 'Jenny',
+            ], null),
+        ], null);
+        $obj->individual = null;
+
+        $expected = ['individual' => ''];
+        $this->assertSame($expected, $obj->serializeParameters());
+    }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Properly serialize `individual` on Account objects.
