### PR TITLE
Don't overwrite CURLOPT_HTTP_VERSION option

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -228,8 +228,10 @@ class CurlClient implements ClientInterface
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
         }
 
-        // For HTTPS requests, enable HTTP/2, if supported
-        $opts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2TLS;
+        if (!isset($opts[CURLOPT_HTTP_VERSION])) {
+            // For HTTPS requests, enable HTTP/2, if supported
+            $opts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2TLS;
+        }
 
         list($rbody, $rcode) = $this->executeRequestWithRetries($opts, $absUrl);
 


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Don't force `CURLOPT_HTTP_VERSION` to `CURL_HTTP_VERSION_2TLS` if a value is already set. This allows users to set their own value for `CURLOPT_HTTP_VERSION` when using custom clients, e.g.:

```php
$client = new \Stripe\HttpClient\CurlClient([CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1]);
\Stripe\ApiRequestor::setHttpClient($client);
```
