### PR TITLE
Add support for Subscription Schedules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.42.0
+    - STRIPE_MOCK_VERSION=0.44.0
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/init.php
+++ b/init.php
@@ -115,6 +115,8 @@ require(dirname(__FILE__) . '/lib/Source.php');
 require(dirname(__FILE__) . '/lib/SourceTransaction.php');
 require(dirname(__FILE__) . '/lib/Subscription.php');
 require(dirname(__FILE__) . '/lib/SubscriptionItem.php');
+require(dirname(__FILE__) . '/lib/SubscriptionSchedule.php');
+require(dirname(__FILE__) . '/lib/SubscriptionScheduleRevision.php');
 require(dirname(__FILE__) . '/lib/Terminal/ConnectionToken.php');
 require(dirname(__FILE__) . '/lib/Terminal/Location.php');
 require(dirname(__FILE__) . '/lib/Terminal/Reader.php');

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -7,7 +7,6 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string[] $allowed_source_types
  * @property int $amount
  * @property int $amount_capturable
  * @property int $amount_received
@@ -26,8 +25,9 @@ namespace Stripe;
  * @property mixed $last_payment_error
  * @property bool $livemode
  * @property StripeObject $metadata
- * @property mixed $next_source_action
+ * @property mixed $next_action
  * @property string $on_behalf_of
+ * @property string[] $payment_method_types
  * @property string $receipt_email
  * @property string $return_url
  * @property string $review

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class Subscription
+ *
+ * @property string $id
+ * @property string $object
+ * @property string $billing
+ * @property mixed $billing_thresholds
+ * @property int $canceled_at
+ * @property int $completed_at
+ * @property int $created
+ * @property mixed $current_phase
+ * @property string $customer
+ * @property mixed $invoice_settings
+ * @property boolean $livemode
+ * @property StripeObject $metadata
+ * @property mixed $phases
+ * @property int $released_at
+ * @property string $released_subscription
+ * @property string $renewal_behavior
+ * @property mixed $renewal_interval
+ * @property string $revision
+ * @property string $status
+ * @property string $subscription
+ *
+ * @package Stripe
+ */
+class SubscriptionSchedule extends ApiResource
+{
+
+    const OBJECT_NAME = "subscription_schedule";
+
+    use ApiOperations\All;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\Update;
+    use ApiOperations\NestedResource;
+
+    const PATH_REVISIONS = '/revisions';
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return SubscriptionSchedule The canceled subscription schedule.
+     */
+    public function cancel($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/cancel';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return SubscriptionSchedule The released subscription schedule.
+     */
+    public function release($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/release';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return Collection The list of subscription schedule revisions.
+     */
+    public function revisions($params = null, $options = null)
+    {
+        $url = $this->instanceUrl() . '/revisions';
+        list($response, $opts) = $this->_request('get', $url, $params, $options);
+        $obj = Util\Util::convertToStripeObject($response, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    /**
+     * @param array|null $id The ID of the subscription schedule to which the person belongs.
+     * @param array|null $personId The ID of the person to retrieve.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return Revision
+     */
+    public static function retrieveRevision($id, $personId, $params = null, $opts = null)
+    {
+        return self::_retrieveNestedResource($id, static::PATH_REVISIONS, $personId, $params, $opts);
+    }
+
+    /**
+     * @param array|null $id The ID of the subscription schedule on which to retrieve the persons.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return Revision
+     */
+    public static function allRevisions($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_REVISIONS, $params, $opts);
+    }
+}

--- a/lib/SubscriptionScheduleRevision.php
+++ b/lib/SubscriptionScheduleRevision.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class Subscription
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $created
+ * @property mixed $invoice_settings
+ * @property boolean $livemode
+ * @property mixed $phases
+ * @property string $previous_revision
+ * @property string $renewal_behavior
+ * @property mixed $renewal_interval
+ * @property string $chedule
+ *
+ * @package Stripe
+ */
+class SubscriptionScheduleRevision extends ApiResource
+{
+
+    const OBJECT_NAME = "subscription_schedule_revision";
+
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
+    /**
+     * @return string The API URL for this Subscription Schedule Revision.
+     */
+    public function instanceUrl()
+    {
+        $id = $this['id'];
+        $schedule = $this['schedule'];
+        if (!$id) {
+            throw new Error\InvalidRequest(
+                "Could not determine which URL to request: " .
+                "class instance has invalid ID: $id",
+                null
+            );
+        }
+        $id = Util\Util::utf8($id);
+        $schedule = Util\Util::utf8($schedule);
+
+        $base = SubscriptionSchedule::classUrl();
+        $scheduleExtn = urlencode($schedule);
+        $extn = urlencode($id);
+        return "$base/$scheduleExtn/revisions/$extn";
+    }
+
+    /**
+     * @param array|string $_id
+     * @param array|string|null $_opts
+     *
+     * @throws \Stripe\Error\InvalidRequest
+     */
+    public static function retrieve($_id, $_opts = null)
+    {
+        $msg = "Subscription Schedule Revisions cannot be accessed without a Subscription Schedule ID. " .
+               "Retrieve one using \$schedule->retrieveRevision('revision_id') instead.";
+        throw new Error\InvalidRequest($msg, null);
+    }
+
+    /**
+     * @param array|string $_id
+     * @param array|string|null $_opts
+     *
+     * @throws \Stripe\Error\InvalidRequest
+     */
+    public static function all($params = null, $opts = null)
+    {
+        $msg = "Subscription Schedule Revisions cannot be listed without a Subscription Schedule ID. " .
+               "List those using \$schedule->allRevisions('revision_id') instead.";
+        throw new Error\InvalidRequest($msg, null);
+    }
+}

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -128,6 +128,8 @@ abstract class Util
             \Stripe\SourceTransaction::OBJECT_NAME => 'Stripe\\SourceTransaction',
             \Stripe\Subscription::OBJECT_NAME => 'Stripe\\Subscription',
             \Stripe\SubscriptionItem::OBJECT_NAME => 'Stripe\\SubscriptionItem',
+            \Stripe\SubscriptionSchedule::OBJECT_NAME => 'Stripe\\SubscriptionSchedule',
+            \Stripe\SubscriptionScheduleRevision::OBJECT_NAME => 'Stripe\\SubscriptionScheduleRevision',
             \Stripe\ThreeDSecure::OBJECT_NAME => 'Stripe\\ThreeDSecure',
             \Stripe\Terminal\ConnectionToken::OBJECT_NAME => 'Stripe\\Terminal\\ConnectionToken',
             \Stripe\Terminal\Location::OBJECT_NAME => 'Stripe\\Terminal\\Location',

--- a/tests/Stripe/Checkout/SessionTest.php
+++ b/tests/Stripe/Checkout/SessionTest.php
@@ -11,7 +11,6 @@ class SessionTest extends \Stripe\TestCase
             '/v1/checkout/sessions'
         );
         $resource = Session::create([
-            'allowed_source_types' => ['card'],
             'cancel_url' => 'https://stripe.com/cancel',
             'client_reference_id' => '1234',
             'line_items' => [
@@ -29,6 +28,7 @@ class SessionTest extends \Stripe\TestCase
             'payment_intent_data' => [
                 'receipt_email' => 'test@stripe.com',
             ],
+            'payment_method_types' => ['card'],
             'success_url' => 'https://stripe.com/success'
         ]);
         $this->assertInstanceOf('Stripe\\Checkout\\Session', $resource);

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -34,9 +34,9 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents'
         );
         $resource = PaymentIntent::create([
-            "allowed_source_types" => ["card"],
             "amount" => 100,
             "currency" => "usd",
+            'payment_method_types' => ['card'],
         ]);
         $this->assertInstanceOf("Stripe\\PaymentIntent", $resource);
     }

--- a/tests/Stripe/SubscriptionScheduleRevisionTest.php
+++ b/tests/Stripe/SubscriptionScheduleRevisionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Stripe;
+
+class SubscriptionScheduleRevisionTest extends TestCase
+{
+    const TEST_SCHEDULE_ID = 'sub_sched_123';
+    const TEST_RESOURCE_ID = 'sub_sched_rev_123';
+
+    public function testHasCorrectUrl()
+    {
+        $resource = \Stripe\SubscriptionSchedule::retrieveRevision(self::TEST_SCHEDULE_ID, self::TEST_RESOURCE_ID);
+        $this->assertSame(
+            "/v1/subscription_schedules/" . self::TEST_SCHEDULE_ID . "/revisions/" . self::TEST_RESOURCE_ID,
+            $resource->instanceUrl()
+        );
+    }
+
+    /**
+     * @expectedException \Stripe\Error\InvalidRequest
+     */
+    public function testIsNotDirectlyRetrievable()
+    {
+        SubscriptionScheduleRevision::retrieve(self::TEST_RESOURCE_ID);
+    }
+
+    /**
+     * @expectedException \Stripe\Error\InvalidRequest
+     */
+    public function testIsNotDirectlyAll()
+    {
+        SubscriptionScheduleRevision::all();
+    }
+}

--- a/tests/Stripe/SubscriptionScheduleTest.php
+++ b/tests/Stripe/SubscriptionScheduleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Stripe;
+
+class SubscriptionScheduleTest extends TestCase
+{
+    const TEST_RESOURCE_ID = 'sub_sched_123';
+    const TEST_REVISION_ID = 'sub_sched_rev_123';
+
+    public function testIsListable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules'
+        );
+        $resources = SubscriptionSchedule::all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resources->data[0]);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID
+        );
+        $resource = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testIsCreatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules'
+        );
+        $resource = SubscriptionSchedule::create([
+            "phases" => [
+                [
+                    "plans" => [
+                        [ "plan" => "plan_123", "quantity" => 2],
+                    ],
+                ],
+            ],
+        ]);
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testIsSaveable()
+    {
+        $resource = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
+        $resource->metadata["key"] = "value";
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . $resource->id
+        );
+        $resource->save();
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testIsUpdatable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID
+        );
+        $resource = SubscriptionSchedule::update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testIsCancelable()
+    {
+        $resource = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . $resource->id . '/cancel',
+            []
+        );
+        $resource->cancel([]);
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testIsReleaseable()
+    {
+        $resource = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . $resource->id . '/release',
+            []
+        );
+        $resource->release([]);
+        $this->assertInstanceOf("Stripe\\SubscriptionSchedule", $resource);
+    }
+
+    public function testRevisions()
+    {
+        $schedule = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules/' . $schedule->id . '/revisions'
+        );
+        $revisions = $schedule->revisions();
+        $this->assertTrue(is_array($revisions->data));
+        $this->assertInstanceOf("Stripe\\SubscriptionScheduleRevision", $revisions->data[0]);
+    }
+
+    public function testCanRetrieveRevision()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID . '/revisions/' . self::TEST_REVISION_ID
+        );
+        $resource = SubscriptionSchedule::retrieveRevision(self::TEST_RESOURCE_ID, self::TEST_REVISION_ID);
+        $this->assertInstanceOf("Stripe\\SubscriptionScheduleRevision", $resource);
+    }
+
+    public function testCanListRevisions()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID . '/revisions'
+        );
+        $resources = SubscriptionSchedule::allRevisions(self::TEST_RESOURCE_ID);
+        $this->assertTrue(is_array($resources->data));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once(__DIR__ . '/StripeMock.php');
 
-define("MOCK_MINIMUM_VERSION", "0.42.0");
+define("MOCK_MINIMUM_VERSION", "0.44.0");
 
 if (\Stripe\StripeMock::start()) {
     register_shutdown_function('\Stripe\StripeMock::stop');


### PR DESCRIPTION
This adds two new resources: Subscription Schedule and Subscription Schedule Revision. The latter is nested under the former.

This should be ready even though we won't merge until all libraries are ready and stripe-mock supports those new endpoints publicly.

r? @ob-stripe 
cc @stripe/api-libraries @alexander-stripe 