### PR TITLE
Fix phpdoc of nested resources

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -140,7 +140,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account on which to create the external account.
+     * @param string|null $id The ID of the account on which to create the external account.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -152,7 +152,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the external account belongs.
+     * @param string|null $id The ID of the account to which the external account belongs.
      * @param array|null $externalAccountId The ID of the external account to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
@@ -165,7 +165,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the external account belongs.
+     * @param string|null $id The ID of the account to which the external account belongs.
      * @param array|null $externalAccountId The ID of the external account to update.
      * @param array|null $params
      * @param array|string|null $opts
@@ -178,7 +178,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the external account belongs.
+     * @param string|null $id The ID of the account to which the external account belongs.
      * @param array|null $externalAccountId The ID of the external account to delete.
      * @param array|null $params
      * @param array|string|null $opts
@@ -191,7 +191,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account on which to retrieve the external accounts.
+     * @param string|null $id The ID of the account on which to retrieve the external accounts.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -203,7 +203,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account on which to create the login link.
+     * @param string|null $id The ID of the account on which to create the login link.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -215,7 +215,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account on which to create the person.
+     * @param string|null $id The ID of the account on which to create the person.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -227,7 +227,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the person belongs.
+     * @param string|null $id The ID of the account to which the person belongs.
      * @param array|null $personId The ID of the person to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
@@ -240,7 +240,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the person belongs.
+     * @param string|null $id The ID of the account to which the person belongs.
      * @param array|null $personId The ID of the person to update.
      * @param array|null $params
      * @param array|string|null $opts
@@ -253,7 +253,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account to which the person belongs.
+     * @param string|null $id The ID of the account to which the person belongs.
      * @param array|null $personId The ID of the person to delete.
      * @param array|null $params
      * @param array|string|null $opts
@@ -266,7 +266,7 @@ class Account extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the account on which to retrieve the persons.
+     * @param string|null $id The ID of the account on which to retrieve the persons.
      * @param array|null $params
      * @param array|string|null $opts
      *

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -47,7 +47,7 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the application fee on which to create the refund.
+     * @param string|null $id The ID of the application fee on which to create the refund.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -59,7 +59,7 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the application fee to which the refund belongs.
+     * @param string|null $id The ID of the application fee to which the refund belongs.
      * @param array|null $refundId The ID of the refund to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
@@ -72,7 +72,7 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the application fee to which the refund belongs.
+     * @param string|null $id The ID of the application fee to which the refund belongs.
      * @param array|null $refundId The ID of the refund to update.
      * @param array|null $params
      * @param array|string|null $opts
@@ -85,7 +85,7 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the application fee on which to retrieve the refunds.
+     * @param string|null $id The ID of the application fee on which to retrieve the refunds.
      * @param array|null $params
      * @param array|string|null $opts
      *

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -141,7 +141,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the customer on which to create the source.
+     * @param string|null $id The ID of the customer on which to create the source.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -153,7 +153,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the customer to which the source belongs.
+     * @param string|null $id The ID of the customer to which the source belongs.
      * @param array|null $sourceId The ID of the source to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
@@ -166,7 +166,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the customer to which the source belongs.
+     * @param string|null $id The ID of the customer to which the source belongs.
      * @param array|null $sourceId The ID of the source to update.
      * @param array|null $params
      * @param array|string|null $opts
@@ -179,7 +179,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the customer to which the source belongs.
+     * @param string|null $id The ID of the customer to which the source belongs.
      * @param array|null $sourceId The ID of the source to delete.
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -61,7 +61,7 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the transfer on which to create the reversal.
+     * @param string|null $id The ID of the transfer on which to create the reversal.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -73,7 +73,7 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the transfer to which the reversal belongs.
+     * @param string|null $id The ID of the transfer to which the reversal belongs.
      * @param array|null $reversalId The ID of the reversal to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
@@ -86,7 +86,7 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the transfer to which the reversal belongs.
+     * @param string|null $id The ID of the transfer to which the reversal belongs.
      * @param array|null $reversalId The ID of the reversal to update.
      * @param array|null $params
      * @param array|string|null $opts
@@ -99,7 +99,7 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param array|null $id The ID of the transfer on which to retrieve the reversals.
+     * @param string|null $id The ID of the transfer on which to retrieve the reversals.
      * @param array|null $params
      * @param array|string|null $opts
      *


### PR DESCRIPTION
Hi there,

Phpdoc references to the `$id` as an array and it is a `string`. And also the `{_create,_retrieve,_update,_delete}NestedResource` methods expect a string.