### PR TITLE
Remove HHVM from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - hhvm
 
 env:
   global:


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 

Remove HHVM from Travis CI.

HHVM 4.0 no longer supports PHP, and in particular is no longer compatible with Composer. See release notes at https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html.

I've tried pinning HHVM to the last 3.x version, but it didn't work (Travis failed to install the package).

I think removing it is the right move for now to avoid red CI builds. We can revisit once we make a decision regarding whether we want to officially support HHVM or not. 