### PR TITLE
Fix PHPDocs in SubscriptionSchedule and SubscriptionScheduleRevision

### DIFF
--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -3,7 +3,7 @@
 namespace Stripe;
 
 /**
- * Class Subscription
+ * Class SubscriptionSchedule
  *
  * @property string $id
  * @property string $object

--- a/lib/SubscriptionScheduleRevision.php
+++ b/lib/SubscriptionScheduleRevision.php
@@ -3,7 +3,7 @@
 namespace Stripe;
 
 /**
- * Class Subscription
+ * Class SubscriptionScheduleRevision
  *
  * @property string $id
  * @property string $object
@@ -14,7 +14,7 @@ namespace Stripe;
  * @property string $previous_revision
  * @property string $renewal_behavior
  * @property mixed $renewal_interval
- * @property string $chedule
+ * @property string $schedule
  *
  * @package Stripe
  */


### PR DESCRIPTION
The PHPDocs in `SubscriptionSchedule` and `SubscriptionScheduleRevision` were incorrectly setting their classes to `Subscription`. There was also a typo in the property `chedule` inside of `SubscriptionScheduleRevision`, which would've caused some issues when integrating with the API