### PR TITLE
Add schedule property to Subscription

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -27,6 +27,7 @@ namespace Stripe;
  * @property StripeObject $metadata
  * @property Plan $plan
  * @property int $quantity
+ * @property SubscriptionSchedule $schedule
  * @property int $start
  * @property string $status
  * @property float $tax_percent


### PR DESCRIPTION
The `schedule` property was missing in `Subscription`. Even though this may be `null`, I'm typing it as `SubscriptionSchedule` to follow the same approach as other nullable properties (i.e. `$discount`)