### PR TITLE
ach_credit_transfer property

### DIFF
--- a/lib/Source.php
+++ b/lib/Source.php
@@ -8,22 +8,36 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property mixed $ach_credit_transfer
+ * @property mixed $ach_debit
+ * @property mixed $alipay
  * @property int $amount
+ * @property mixed $bancontact
+ * @property mixed $card
+ * @property mixed $card_present
  * @property string $client_secret
  * @property mixed $code_verification
  * @property int $created
  * @property string $currency
+ * @property mixed $eps
  * @property string $flow
+ * @property mixed $giropay
+ * @property mixed $ideal
  * @property bool $livemode
  * @property StripeObject $metadata
+ * @property mixed $multibanco
  * @property mixed $owner
+ * @property mixed $p24
  * @property mixed $receiver
  * @property mixed $redirect
+ * @property mixed $sepa_debit
+ * @property mixed $sofort
  * @property string $statement_descriptor
  * @property string $status
+ * @property mixed $three_d_secure
  * @property string $type
  * @property string $usage
- *
+ * @property mixed $wechat
+
  * @package Stripe
  */
 class Source extends ApiResource


### PR DESCRIPTION
Hello

On my pull request from yesterday I noticed I had erroneously included the `ach_credit_transfer` property on the `Source` class as it was the example used in the docs, however, this particular property is dynamic and only present if the `type` of the object is `ach_credit_transfer`.

If we are to include `ach_credit_transfer`, we should include all the possible enumerations of `type`. I can do that as well. What do you think?

I apologise for overlooking this.

https://stripe.com/docs/api/sources/object
