### PR TITLE
Add support for retrieving a Checkout Session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.44.0
+    - STRIPE_MOCK_VERSION=0.49.0
   matrix:
     - AUTOLOAD=1
     - AUTOLOAD=0

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -7,7 +7,16 @@ namespace Stripe\Checkout;
  *
  * @property string $id
  * @property string $object
+ * @property string $cancel_url
+ * @property string $client_reference_id
+ * @property string $customer
+ * @property string $customer_email
+ * @property mixed $display_items
  * @property bool $livemode
+ * @property string $payment_intent
+ * @property string[] $payment_method_types
+ * @property string $subscription
+ * @property string $success_url
  *
  * @package Stripe
  */
@@ -17,4 +26,5 @@ class Session extends \Stripe\ApiResource
     const OBJECT_NAME = "checkout.session";
 
     use \Stripe\ApiOperations\Create;
+    use \Stripe\ApiOperations\Retrieve;
 }

--- a/tests/Stripe/Checkout/SessionTest.php
+++ b/tests/Stripe/Checkout/SessionTest.php
@@ -4,6 +4,8 @@ namespace Stripe\Checkout;
 
 class SessionTest extends \Stripe\TestCase
 {
+    const TEST_RESOURCE_ID = 'cs_123';
+
     public function testIsCreatable()
     {
         $this->expectsRequest(
@@ -32,5 +34,15 @@ class SessionTest extends \Stripe\TestCase
             'success_url' => 'https://stripe.com/success'
         ]);
         $this->assertInstanceOf('Stripe\\Checkout\\Session', $resource);
+    }
+
+    public function testIsRetrievable()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/checkout/sessions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = Session::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Checkout\\Session", $resource);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once(__DIR__ . '/StripeMock.php');
 
-define("MOCK_MINIMUM_VERSION", "0.44.0");
+define("MOCK_MINIMUM_VERSION", "0.49.0");
 
 if (\Stripe\StripeMock::start()) {
     register_shutdown_function('\Stripe\StripeMock::stop');


### PR DESCRIPTION
This adds support for retrieving a Checkout Session via the API and also changes the shape of the resource to have more details.

cc @stripe/api-libraries 