### PR TITLE
Correctly handle case where a metadata key is called 'metadata'

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -280,7 +280,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             // This is necessary in case metadata is empty, as PHP arrays do
             // not differentiate between lists and hashes, and we consider
             // empty arrays to be lists.
-            if ($k === "metadata") {
+            if (($k === "metadata") && (is_array($v))) {
                 $this->_values[$k] = StripeObject::constructFrom($v, $opts);
             } else {
                 $this->_values[$k] = Util\Util::convertToStripeObject($v, $opts);

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -473,4 +473,23 @@ EOS;
         $obj = StripeObject::constructFrom(['deleted' => true]);
         $this->assertTrue($obj->isDeleted());
     }
+
+    public function testDeserializeEmptyMetadata()
+    {
+        $obj = StripeObject::constructFrom([
+            'metadata' => [],
+        ]);
+
+        $this->assertInstanceOf("Stripe\\StripeObject", $obj->metadata);
+    }
+
+    public function testDeserializeMetadataWithKeyNamedMetadata()
+    {
+        $obj = StripeObject::constructFrom([
+            'metadata' => ['metadata' => 'value'],
+        ]);
+
+        $this->assertInstanceOf("Stripe\\StripeObject", $obj->metadata);
+        $this->assertEquals("value", $obj->metadata->metadata);
+    }
 }


### PR DESCRIPTION
r? @remi-stripe
cc @stripe/api-libraries

Fixes #589.