### PR TITLE
[WIP] Static request methods

### DIFF
--- a/lib/ApiOperations/Delete.php
+++ b/lib/ApiOperations/Delete.php
@@ -10,12 +10,30 @@ namespace Stripe\ApiOperations;
 trait Delete
 {
     /**
+     * @param string $id The ID of the resource to update.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @return \Stripe\ApiResource The updated resource.
+     */
+    public static function _static_delete($id, $params = null, $opts = null)
+    {
+        self::_validateParams($params);
+        $url = static::resourceUrl($id);
+
+        list($response, $opts) = static::_staticRequest('delete', $url, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    /**
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @return \Stripe\ApiResource The deleted resource.
      */
-    public function delete($params = null, $opts = null)
+    public function _instance_delete($params = null, $opts = null)
     {
         self::_validateParams($params);
 

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -109,4 +109,22 @@ abstract class ApiResource extends StripeObject
     {
         return static::resourceUrl($this['id']);
     }
+
+    public function __call($name, $arguments)
+    {
+        $method_name = '_instance_' . $name;
+        if (method_exists($this, $method_name)) {
+            return call_user_func_array([$this, $method_name], $arguments);
+        }
+        trigger_error("Call to undefined method " . get_called_class() . "::" . $name . "()", E_USER_ERROR);
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        $method_name = '_static_' . $name;
+        if (method_exists(get_called_class(), $method_name)) {
+            return call_user_func_array([get_called_class(), $method_name], $arguments);
+        }
+        trigger_error("Call to undefined method " . get_called_class() . "::" . $name . "()", E_USER_ERROR);
+    }
 }

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -125,7 +125,22 @@ class Charge extends ApiResource
      *
      * @return Charge The captured charge.
      */
-    public function capture($params = null, $options = null)
+    public static function _static_capture($id, $params = null, $options = null)
+    {
+        $url = static::resourceUrl($id) . '/capture';
+        list($response, $opts) = static::_staticRequest('post', $url, $params, $options);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
+     * @return Charge The captured charge.
+     */
+    public function _instance_capture($params = null, $options = null)
     {
         $url = $this->instanceUrl() . '/capture';
         list($response, $opts) = $this->_request('post', $url, $params, $options);

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -44,7 +44,7 @@ class Subscription extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Create;
     use ApiOperations\Delete {
-        delete as protected _delete;
+        _instance_delete as protected _delete;
     }
     use ApiOperations\Retrieve;
     use ApiOperations\Update;

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -89,6 +89,16 @@ class ChargeTest extends TestCase
         $this->assertSame($resource, $charge);
     }
 
+    public function testCanCaptureStatic()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/charges/' . self::TEST_RESOURCE_ID . '/capture'
+        );
+        $resource = Charge::capture(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Charge", $resource);
+    }
+
     public function testCanUpdateDispute()
     {
         $charge = Charge::retrieve(self::TEST_RESOURCE_ID);

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -73,6 +73,16 @@ class CustomerTest extends TestCase
         $this->assertInstanceOf("Stripe\\Customer", $resource);
     }
 
+    public function testIsDeletableStatic()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = Customer::delete(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf("Stripe\\Customer", $resource);
+    }
+
     public function testCanAddInvoiceItem()
     {
         $customer = Customer::retrieve(self::TEST_RESOURCE_ID);


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 

This is a terrible, terrible hack that uses the [`__call()` and `__callStatic()` magic methods](https://secure.php.net/manual/en/language.oop5.overloading.php#object.call).

Pros:
- it does the job

Cons:
- no PHPDoc on either the static or the instance method, since the "real" method name must not exist in order for this trick to work
- slightly different behavior when calling a method that doesn't exist (I'm manually triggering a similar error, but it's not quite the same: `E_USER_ERROR` instead of `E_ERROR`, no stacktrace, maybe other differences)?
- probably other things
