### PR TITLE
Fix PHPDoc return types for `allSomething()` methods

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -183,7 +183,7 @@ class Account extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return BankAccount|Card
+     * @return Collection The list of external accounts (BankAccount or Card).
      */
     public static function allExternalAccounts($id, $params = null, $opts = null)
     {
@@ -258,7 +258,7 @@ class Account extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return Person
+     * @return Collection The list of persons.
      */
     public static function allPersons($id, $params = null, $opts = null)
     {

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -89,7 +89,7 @@ class ApplicationFee extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return ApplicationFeeRefund
+     * @return Collection The list of refunds.
      */
     public static function allRefunds($id, $params = null, $opts = null)
     {

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -196,7 +196,7 @@ class Customer extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return ApiResource
+     * @return Collection The list of sources.
      */
     public static function allSources($id, $params = null, $opts = null)
     {

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -102,7 +102,7 @@ class SubscriptionSchedule extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return Revision
+     * @return Collection The list of revisions.
      */
     public static function allRevisions($id, $params = null, $opts = null)
     {

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -112,7 +112,7 @@ class Transfer extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return TransferReversal
+     * @return Collection The list of reversals.
      */
     public static function allReversals($id, $params = null, $opts = null)
     {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fix the return type in PHPDoc for `allSomething()` methods (i.e. nested resources).

Replaces #618.