### PR TITLE
Fix encoding of nested parameters in multipart requests

### DIFF
--- a/lib/File.php
+++ b/lib/File.php
@@ -50,6 +50,13 @@ class File extends ApiResource
         if (is_null($opts->apiBase)) {
             $opts->apiBase = Stripe::$apiUploadBase;
         }
-        return static::_create($params, $opts);
+        // Manually flatten params, otherwise curl's multipart encoder will
+        // choke on nested arrays.
+        // TODO: use array_column() once we drop support for PHP 5.4
+        $flatParams = [];
+        foreach (\Stripe\Util\Util::flattenParams($params) as $pair) {
+            $flatParams[$pair[0]] = $pair[1];
+        }
+        return static::_create($flatParams, $opts);
     }
 }

--- a/tests/Stripe/FileCreationTest.php
+++ b/tests/Stripe/FileCreationTest.php
@@ -40,6 +40,7 @@ class FileCreationTest extends TestCase
         $resource = File::create([
             "purpose" => "dispute_evidence",
             "file" => $fp,
+            "file_link_data" => ["create" => true]
         ]);
         $this->assertInstanceOf("Stripe\\File", $resource);
     }
@@ -63,6 +64,7 @@ class FileCreationTest extends TestCase
         $resource = File::create([
             "purpose" => "dispute_evidence",
             "file" => $curlFile,
+            "file_link_data" => ["create" => true]
         ]);
         $this->assertInstanceOf("Stripe\\File", $resource);
     }

--- a/tests/Stripe/FileUploadCreationTest.php
+++ b/tests/Stripe/FileUploadCreationTest.php
@@ -40,6 +40,7 @@ class FileUploadCreationTest extends TestCase
         $resource = FileUpload::create([
             "purpose" => "dispute_evidence",
             "file" => $fp,
+            "file_link_data" => ["create" => true]
         ]);
         $this->assertInstanceOf("Stripe\\FileUpload", $resource);
     }
@@ -63,6 +64,7 @@ class FileUploadCreationTest extends TestCase
         $resource = FileUpload::create([
             "purpose" => "dispute_evidence",
             "file" => $curlFile,
+            "file_link_data" => ["create" => true]
         ]);
         $this->assertInstanceOf("Stripe\\FileUpload", $resource);
     }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

For multipart requests, we don't encode the parameters ourselves and instead pass them directly to curl: https://github.com/stripe/stripe-php/blob/d14f02d603c47824d7acaf88491195e3f199408d/lib/HttpClient/CurlClient.php#L194

However, curl doesn't know how to encode arrays and encodes them as `Array` regardless of their contents. For instance this request:
```php
$file = \Stripe\File::create([
  "file" => new \CurlFile("/Users/ob/test.txt"),
  "purpose" => "identity_document",
  "file_link_data" => ["create" => true],
]);
```
would be encoded as:
```
--------------------------9f9f472a73222896
Content-Disposition: form-data; name="file"; filename="/Users/ob/test.txt"
Content-Type: application/octet-stream

hello

--------------------------9f9f472a73222896
Content-Disposition: form-data; name="purpose"

identity_document
--------------------------9f9f472a73222896
Content-Disposition: form-data; name="file_link_data"

Array
--------------------------9f9f472a73222896--
```
which of course causes the request to fail.

This PR fixes this by manually flattening the parameters before passing them to curl. It's unfortunately difficult to write tests for this because we can't mock curl, but I've verified that requests are encoded correctly even with deeply nested parameters. E.g. with this patch, the following request:
```php
$file = \Stripe\File::create([
  "file" => new \CurlFile("/Users/ob/test.txt"),
  "purpose" => "identity_document",
  "file_link_data" => [
    "create" => true,
    "expires_at" => 1234567890,
    "metadata" => [
      "key1" => "value1",
      "key2" => "value2",
    ],
  ],
]);
```
is encoded as:
```
--------------------------344ee1cb94395191
Content-Disposition: form-data; name="file"; filename="/Users/ob/test.txt"
Content-Type: application/octet-stream

hello

--------------------------344ee1cb94395191
Content-Disposition: form-data; name="purpose"

identity_document
--------------------------344ee1cb94395191
Content-Disposition: form-data; name="file_link_data[create]"

true
--------------------------344ee1cb94395191
Content-Disposition: form-data; name="file_link_data[expires_at]"

1234567890
--------------------------344ee1cb94395191
Content-Disposition: form-data; name="file_link_data[metadata][key1]"

value1
--------------------------344ee1cb94395191
Content-Disposition: form-data; name="file_link_data[metadata][key2]"

value2
--------------------------344ee1cb94395191--
```
