### PR TITLE
Fixed phpdoc/constants for Customer, Invoice and TaxID

### DIFF
--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -8,6 +8,7 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $account_balance
+ * @property mixed $address
  * @property string $created
  * @property string $currency
  * @property string $default_source
@@ -19,11 +20,13 @@ namespace Stripe;
  * @property mixed $invoice_settings
  * @property bool $livemode
  * @property StripeObject $metadata
+ * @property string $name
+ * @property string $phone
+ * @property string[] preferred_locales
  * @property mixed $shipping
  * @property Collection $sources
  * @property Collection $subscriptions
- * @property mixed $tax_info
- * @property mixed $tax_info_verification
+ * @property Collection $tax_ids
  *
  * @package Stripe
  */

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -7,6 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
+ * @property string $account_country
+ * @property string $account_name
  * @property int $amount_due
  * @property int $amount_paid
  * @property int $amount_remaining
@@ -19,8 +21,15 @@ namespace Stripe;
  * @property string $charge
  * @property int $created
  * @property string $currency
- * @property mixed $custom_fields
+ * @property array $custom_fields
  * @property string $customer
+ * @property mixed $customer_address
+ * @property string $customer_email
+ * @property string $customer_name
+ * @property string $customer_phone
+ * @property mixed $customer_shipping
+ * @property array $customer_tax_ids
+ * @property string $default_payment_method
  * @property string $default_source
  * @property string $description
  * @property Discount $discount
@@ -35,8 +44,11 @@ namespace Stripe;
  * @property int $next_payment_attempt
  * @property string $number
  * @property bool $paid
+ * @property string $payment_intent
  * @property int $period_end
  * @property int $period_start
+ * @property int $post_payment_credit_notes_amount
+ * @property int $pre_payment_credit_notes_amount
  * @property string $receipt_number
  * @property int $starting_balance
  * @property string $statement_descriptor

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -14,7 +14,7 @@ namespace Stripe;
  * @property string $customer
  * @property bool $deleted
  * @property bool $livemode
- * @property type $type
+ * @property string $type
  * @property string $value
  * @property mixed $verification
  */
@@ -33,6 +33,15 @@ class TaxId extends ApiResource
     const TYPE_EU_VAT  = 'eu_vat';
     const TYPE_NZ_GST  = 'nz_gst';
     const TYPE_UNKNOWN = 'unknown';
+
+    /**
+     * Possible string representations of the verification status.
+     * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-verification
+     */
+    const VERIFICATION_STATUS_PENDING     = 'pending';
+    const VERIFICATION_STATUS_UNAVAILABLE = 'unavailable';
+    const VERIFICATION_STATUS_UNVERIFIED  = 'unverified';
+    const VERIFICATION_STATUS_VERIFIED    = 'verified';
 
     /**
      * @return string The API URL for this tax id.


### PR DESCRIPTION
In relation to customer tax ID logic, there have been a few changes to the customer object.

Updates reflected in this PR.

I removed the deprecated properties. Not sure if you want them to remain. I figure it's good practice to remove them as this draws attention to them having been deprecated without breaking anything.