### PR TITLE
Added phpdocs for tax_rates, fixed Coupon and Subscription

### DIFF
--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -16,7 +16,7 @@ namespace Stripe;
  * @property int $max_redemptions
  * @property StripeObject $metadata
  * @property string $name
- * @property int $percent_off
+ * @property float $percent_off
  * @property int $redeem_by
  * @property int $times_redeemed
  * @property bool $valid

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -31,6 +31,7 @@ namespace Stripe;
  * @property array $customer_tax_ids
  * @property string $default_payment_method
  * @property string $default_source
+ * @property array $default_tax_rates
  * @property string $description
  * @property Discount $discount
  * @property int $due_date
@@ -58,9 +59,9 @@ namespace Stripe;
  * @property int $subscription_proration_date
  * @property int $subtotal
  * @property int $tax
- * @property float $tax_percent
  * @property mixed $threshold_reason
  * @property int $total
+ * @property array $total_tax_amounts
  * @property int $webhooks_delivered_at
  *
  * @package Stripe

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -22,6 +22,7 @@ namespace Stripe;
  * @property int $quantity
  * @property string $subscription
  * @property string $subscription_item
+ * @property array $tax_rates
  * @property int $unit_amount
  *
  * @package Stripe

--- a/lib/InvoiceLineItem.php
+++ b/lib/InvoiceLineItem.php
@@ -20,6 +20,8 @@ namespace Stripe;
  * @property int $quantity
  * @property string $subscription
  * @property string $subscription_item
+ * @property array $tax_amounts
+ * @property array $tax_rates
  * @property string $type
  *
  * @package Stripe

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -18,7 +18,9 @@ namespace Stripe;
  * @property int $current_period_start
  * @property string $customer
  * @property int $days_until_due
+ * @property string $default_payment_method
  * @property string $default_source
+ * @property array $default_tax_rates
  * @property Discount $discount
  * @property int $ended_at
  * @property Collection $items

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -13,6 +13,7 @@ namespace Stripe;
  * @property Plan $plan
  * @property int $quantity
  * @property string $subscription
+ * @property array $tax_rates
  *
  * @package Stripe
  */


### PR DESCRIPTION
Hey

I don't know if I missed these yesterday or if they were just added, but I've added `tax_rates` properties in all places I could find them.

Also found an int/float error on `Coupon` and missing `default_payment_method` on Subscription.

I've removed `tax_percent` from `Invoice` as it seems it's deprecated. Not explicitly though.