### PR TITLE
Update return type to `static` to improve static analysis

### DIFF
--- a/lib/ApiOperations/Retrieve.php
+++ b/lib/ApiOperations/Retrieve.php
@@ -15,7 +15,7 @@ trait Retrieve
      *     or an options array containing an `id` key.
      * @param array|string|null $opts
      *
-     * @return \Stripe\StripeObject
+     * @return static
      */
     public static function retrieve($id, $opts = null)
     {


### PR DESCRIPTION
While there is no official PHPDoc standard ... Pretty much all static analyzers (phpstan, etc.) and leading IDEs (e.g. PHPStorm) all support the `@return static`. Making this change will improve static analysis and prevent unnecessary docblock declarations.