### PR TITLE
Fix constant for payment_intent.payment_failed

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -100,7 +100,7 @@ class Event extends ApiResource
     const ORDER_RETURN_CREATED                     = 'order_return.created';
     const PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED = 'payment_intent.amount_capturable_updated';
     const PAYMENT_INTENT_CREATED                   = 'payment_intent.created';
-    const PAYMENT_INTENT_FAILED                    = 'payment_intent.failed';
+    const PAYMENT_INTENT_PAYMENT_FAILED            = 'payment_intent.payment_failed';
     const PAYMENT_INTENT_SUCCEEDED                 = 'payment_intent.succeeded';
     const PAYOUT_CANCELED                          = 'payout.canceled';
     const PAYOUT_CREATED                           = 'payout.created';


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Fixes the constant for `payment_intent.payment_failed`. Technically a breaking change because I also renamed the constant, but given that the existing constant has the wrong value, I don't think anyone is using it.

Fixes #609.
