### PR TITLE
Fix typo in payment_method.attached event constant

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -107,7 +107,7 @@ class Event extends ApiResource
     const PAYMENT_INTENT_CREATED                    = 'payment_intent.created';
     const PAYMENT_INTENT_PAYMENT_FAILED             = 'payment_intent.payment_failed';
     const PAYMENT_INTENT_SUCCEEDED                  = 'payment_intent.succeeded';
-    const PAYMENT_METHOD_ATTACHED                   = 'payment_method.detached';
+    const PAYMENT_METHOD_ATTACHED                   = 'payment_method.attached';
     const PAYMENT_METHOD_CARD_AUTOMATICALLY_UPDATED = 'payment_method.card_automatically_updated';
     const PAYMENT_METHOD_DETACHED                   = 'payment_method.detached';
     const PAYMENT_METHOD_UPDATED                    = 'payment_method.updated';


### PR DESCRIPTION
Fixing a typo in the constant definition for the [payment_method.attached](https://stripe.com/docs/api/events/types#event_types-payment_method.attached) event