### PR TITLE
Add constants for payment intent statuses

### DIFF
--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -51,6 +51,19 @@ class PaymentIntent extends ApiResource
     use ApiOperations\Update;
 
     /**
+     * These constants are possible representations of the status field.
+     *
+     * @link https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
+     */
+    const STATUS_CANCELED                = 'canceled';
+    const STATUS_PROCESSING              = 'processing';
+    const STATUS_REQUIRES_ACTION         = 'requires_action';
+    const STATUS_REQUIRES_CAPTURE        = 'requires_capture';
+    const STATUS_REQUIRES_CONFIRMATION   = 'requires_confirmation';
+    const STATUS_REQUIRES_PAYMENT_METHOD = 'requires_payment_method';
+    const STATUS_SUCCEEDED               = 'succeeded';
+
+    /**
      * @param array|null $params
      * @param array|string|null $options
      *


### PR DESCRIPTION
Just noticed constants for payment intents status were also missing. I left out the ones that were deprecated in version [2019-02-11](https://stripe.com/docs/upgrades#2019-02-11) as I assume they are no longer needed