### PR TITLE
Use absolute value when checking timestamp tolerance

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -24,6 +24,8 @@ abstract class Webhook
      */
     public static function constructEvent($payload, $sigHeader, $secret, $tolerance = self::DEFAULT_TOLERANCE)
     {
+        WebhookSignature::verifyHeader($payload, $sigHeader, $secret, $tolerance);
+
         $data = json_decode($payload, true);
         $jsonError = json_last_error();
         if ($data === null && $jsonError !== JSON_ERROR_NONE) {
@@ -32,8 +34,6 @@ abstract class Webhook
             throw new \UnexpectedValueException($msg);
         }
         $event = Event::constructFrom($data);
-
-        WebhookSignature::verifyHeader($payload, $sigHeader, $secret, $tolerance);
 
         return $event;
     }

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -60,7 +60,7 @@ abstract class WebhookSignature
         }
 
         // Check if timestamp is within tolerance
-        if (($tolerance > 0) && ((time() - $timestamp) > $tolerance)) {
+        if (($tolerance > 0) && (abs(time() - $timestamp) > $tolerance)) {
             throw new Error\SignatureVerification(
                 "Timestamp outside the tolerance zone",
                 $header,

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -84,9 +84,19 @@ class WebhookTest extends TestCase
      * @expectedException \Stripe\Error\SignatureVerification
      * @expectedExceptionMessage Timestamp outside the tolerance zone
      */
-    public function testTimestampOutsideTolerance()
+    public function testTimestampTooOld()
     {
         $sigHeader = $this->generateHeader(["timestamp" => time() - 15]);
+        WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10);
+    }
+
+    /**
+     * @expectedException \Stripe\Error\SignatureVerification
+     * @expectedExceptionMessage Timestamp outside the tolerance zone
+     */
+    public function testTimestampTooRecent()
+    {
+        $sigHeader = $this->generateHeader(["timestamp" => time() + 15]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10);
     }
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Use absolute value when checking timestamp tolerance, since the local clock may be running either early or late compared to Stripe's clock.

Fixes #657.

Also, I've moved the signature check to happen before the event deserialization -- not much point deserializing the event if we're going to throw an exception afterwards.