### PR TITLE
Ensure correct type for `default_source`

### DIFF
--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -11,7 +11,7 @@ namespace Stripe;
  * @property mixed $address
  * @property string $created
  * @property string $currency
- * @property string $default_source
+ * @property string|null $default_source
  * @property bool $delinquent
  * @property string $description
  * @property Discount $discount


### PR DESCRIPTION
The `default_source` for a customer is optional and returns `null` when not set.

/cc @ob-stripe 