### PR TITLE
Prevent variable from being parsed

### DIFF
--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -82,7 +82,7 @@ class CustomerBalanceTransaction extends ApiResource
     public static function update($_id, $_params = null, $_options = null)
     {
         $msg = "Customer Balance Transactions cannot be accessed without a customer ID. " .
-               "Update a balance transaction using Customer::updateBalanceTransaction('cus_123', 'cbtxn_123', $params) instead.";
+               "Update a balance transaction using Customer::updateBalanceTransaction('cus_123', 'cbtxn_123', \$params) instead.";
         throw new Error\InvalidRequest($msg, null);
     }
 }


### PR DESCRIPTION
The error message in `\Stripe\CustomerBalanceTransaction::update` contains a variable that will be parsed since the string is enclosed in double quotes and the `$` is not escaped