### PR TITLE
Move Balance History endpoint to /v1/balance_transactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ matrix:
 
 env:
   global:
-    - STRIPE_MOCK_VERSION=0.60.0
-
+    - STRIPE_MOCK_VERSION=0.63.0
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -63,13 +63,4 @@ class BalanceTransaction extends ApiResource
     const TYPE_TRANSFER_CANCEL               = 'transfer_cancel';
     const TYPE_TRANSFER_FAILURE              = 'transfer_failure';
     const TYPE_TRANSFER_REFUND               = 'transfer_refund';
-
-    /**
-     * @return string The class URL for this resource. It needs to be special
-     *    cased because it doesn't fit into the standard resource pattern.
-     */
-    public static function classUrl()
-    {
-        return "/v1/balance/history";
-    }
 }

--- a/tests/Stripe/BalanceTransactionTest.php
+++ b/tests/Stripe/BalanceTransactionTest.php
@@ -10,7 +10,7 @@ class BalanceTransactionTest extends TestCase
     {
         $this->expectsRequest(
             'get',
-            '/v1/balance/history'
+            '/v1/balance_transactions'
         );
         $resources = BalanceTransaction::all();
         $this->assertTrue(is_array($resources->data));
@@ -21,7 +21,7 @@ class BalanceTransactionTest extends TestCase
     {
         $this->expectsRequest(
             'get',
-            '/v1/balance/history/' . self::TEST_RESOURCE_ID
+            '/v1/balance_transactions/' . self::TEST_RESOURCE_ID
         );
         $resource = BalanceTransaction::retrieve(self::TEST_RESOURCE_ID);
         $this->assertInstanceOf("Stripe\\BalanceTransaction", $resource);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once(__DIR__ . '/StripeMock.php');
 
-define("MOCK_MINIMUM_VERSION", "0.60.0");
+define("MOCK_MINIMUM_VERSION", "0.63.0");
 
 if (\Stripe\StripeMock::start()) {
     register_shutdown_function('\Stripe\StripeMock::stop');


### PR DESCRIPTION
This changes the endpoint from `/v1/balance/history` to `/v1/balance_transactions`.

r? @ob-stripe 
cc @stripe/api-libraries 