### PR TITLE
Update .travis.yml for PHP 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,47 @@
 sudo: false
 
+dist: bionic
+
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+matrix:
+  include:
+    - php: 5.4
+      env: AUTOLOAD=1
+      dist: trusty
+    - php: 5.4
+      env: AUTOLOAD=0
+      dist: trusty
+    - php: 5.5
+      env: AUTOLOAD=1
+      dist: trusty
+    - php: 5.5
+      env: AUTOLOAD=0
+      dist: trusty
+    - php: 5.6
+      env: AUTOLOAD=1
+      dist: xenial
+    - php: 5.6
+      env: AUTOLOAD=0
+      dist: xenial
+    - php: 7.0
+      env: AUTOLOAD=1
+      dist: xenial
+    - php: 7.0
+      env: AUTOLOAD=0
+      dist: xenial
+    - php: 7.1
+      env: AUTOLOAD=1
+    - php: 7.1
+      env: AUTOLOAD=0
+    - php: 7.2
+      env: AUTOLOAD=1
+    - php: 7.2
+      env: AUTOLOAD=0
 
 env:
   global:
     - STRIPE_MOCK_VERSION=0.60.0
-  matrix:
-    - AUTOLOAD=1
-    - AUTOLOAD=0
 
 cache:
   directories:


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Travis has changed the default Ubuntu version from Trusty (14.04) to Xenial (16.04), cf. https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment.

PHP 5.4 and 5.5 are not available on Xenial, so CI started failing for those versions.

In this PR, I:
- set the default Ubuntu version to Bionic (18.04), the most recent version available on Travis
- explicitly specify Trusty (14.04) for PHP 5.4 and 5.5
- explicitly specify Xenial (16.04) for PHP 5.6 and 7.0 (because those versions are not available on Bionic)

#552 has been stalled for a while, we should try to unblock it so we can at least clean up 5.4 and 5.5.
