### PR TITLE
add  property and setter

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -9,6 +9,8 @@ namespace Stripe;
  */
 class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
 {
+    protected static $_permanentAttributes = null;
+
     protected $_opts;
     protected $_originalValues;
     protected $_values;
@@ -23,13 +25,23 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      */
     public static function getPermanentAttributes()
     {
-        static $permanentAttributes = null;
-        if ($permanentAttributes === null) {
-            $permanentAttributes = new Util\Set([
+        if (self::$_permanentAttributes === null) {
+            self::$_permanentAttributes = new Util\Set([
                 'id',
             ]);
         }
-        return $permanentAttributes;
+        return self::$_permanentAttributes;
+    }
+
+    /**
+     * Set specific permanent attributes. Could be used for unit test when
+     * it needs to have a specific id on Stripe Object to test the code behavior
+     *
+     * @param array $permanentAttributes
+     */
+    public static function setPermanentAttributes(array $permanentAttributes)
+    {
+        self::$_permanentAttributes = new Util\Set($permanentAttributes);
     }
 
     /**


### PR DESCRIPTION
Issue:

For unittests, we need to set and get an id on Stripe Object. But the id is protected.

Test example:
```php
$source = new Stripe\Source();
$source->id = 'src_test';
$this->stripeClientMock->expects($this->at(1))->method('attachSource')->withArgs('cus_test', 'src_test')->willReturn(true);
// some other mocks (customer, DB ...)
$stripeSource = (new SourceManager())->updateSource('cus_test', 'src_test');
$this->assertEquals($stripeSource->id, 'src_test');

```

This update will not modify the previus behavior of the SDK