### PR TITLE
Rename fake magic methods and rewrite array conversion

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -243,7 +243,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         $this->_originalValues = self::deepCopy($values);
 
         if ($values instanceof StripeObject) {
-            $values = $values->__toArray(true);
+            $values = $values->toArray(true);
         }
 
         // Wipe old state before setting new.  This is useful for e.g. updating a
@@ -401,27 +401,53 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
 
     public function jsonSerialize()
     {
-        return $this->__toArray(true);
+        return $this->toArray(true);
     }
 
-    public function __toJSON()
+    /**
+     * Returns an associative array with the key and values composing the
+     * Stripe object.
+     *
+     * @return array The associative array.
+     */
+    public function toArray()
     {
-        return json_encode($this->__toArray(true), JSON_PRETTY_PRINT);
+        $maybeToArray = function ($value) {
+            if (is_null($value)) {
+                return null;
+            }
+
+            return method_exists($value, 'toArray') ? $value->toArray() : $value;
+        };
+
+        return array_reduce(array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {
+            if ($k[0] == '_') {
+                return $acc;
+            }
+            $v = $this->_values[$k];
+            if (Util\Util::isList($v)) {
+                $acc[$k] = array_map($maybeToArray, $v);
+            } else {
+                $acc[$k] = $maybeToArray($v);
+            }
+            return $acc;
+        }, []);
+    }
+
+    /**
+     * Returns a pretty JSON representation of the Stripe object.
+     *
+     * @return string The JSON representation of the Stripe object.
+     */
+    public function toJSON()
+    {
+        return json_encode($this->toArray(true), JSON_PRETTY_PRINT);
     }
 
     public function __toString()
     {
         $class = get_class($this);
-        return $class . ' JSON: ' . $this->__toJSON();
-    }
-
-    public function __toArray($recursive = false)
-    {
-        if ($recursive) {
-            return Util\Util::convertStripeObjectToArray($this->_values);
-        } else {
-            return $this->_values;
-        }
+        return $class . ' JSON: ' . $this->toJSON();
     }
 
     /**

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -32,31 +32,6 @@ abstract class Util
     }
 
     /**
-     * Recursively converts the PHP Stripe object to an array.
-     *
-     * @param array $values The PHP Stripe object to convert.
-     * @return array
-     */
-    public static function convertStripeObjectToArray($values)
-    {
-        $results = [];
-        foreach ($values as $k => $v) {
-            // FIXME: this is an encapsulation violation
-            if ($k[0] == '_') {
-                continue;
-            }
-            if ($v instanceof StripeObject) {
-                $results[$k] = $v->__toArray(true);
-            } elseif (is_array($v)) {
-                $results[$k] = self::convertStripeObjectToArray($v);
-            } else {
-                $results[$k] = $v;
-            }
-        }
-        return $results;
-    }
-
-    /**
      * Converts a response from the Stripe API to the corresponding PHP object.
      *
      * @param array $resp The response from the Stripe API.

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -82,31 +82,41 @@ class StripeObjectTest extends TestCase
 
     public function testToArray()
     {
-        $s = new StripeObject();
-        $s->foo = 'a';
+        $array = [
+            'foo' => 'a',
+            'list' => [1, 2, 3],
+            'null' => null,
+        ];
+        $s = StripeObject::constructFrom($array);
 
-        $converted = $s->__toArray();
+        $converted = $s->toArray();
 
         $this->assertInternalType('array', $converted);
-        $this->assertArrayHasKey('foo', $converted);
-        $this->assertEquals('a', $converted['foo']);
+        $this->assertEquals($array, $converted);
     }
 
-    public function testRecursiveToArray()
+    public function testToArrayRecursive()
     {
-        $s = new StripeObject();
-        $z = new StripeObject();
+        // deep nested associative array (when contained in an indexed array)
+        // or StripeObject
+        $nestedArray = ['id' => 7, 'foo' => 'bar'];
+        $nested = StripeObject::constructFrom($nestedArray);
 
-        $s->child = $z;
-        $z->foo = 'a';
+        $obj = StripeObject::constructFrom([
+            'id' => 1,
+            // simple associative array that contains a StripeObject to help us
+            // test deep recursion
+            'nested' => ['object' => 'list', 'data' => $nested],
+            'list' => [$nested],
+        ]);
 
-        $converted = $s->__toArray(true);
+        $expected = [
+            'id' => 1,
+            'nested' => ['object' => 'list', 'data' => $nestedArray],
+            'list' => [$nestedArray],
+        ];
 
-        $this->assertInternalType('array', $converted);
-        $this->assertArrayHasKey('child', $converted);
-        $this->assertInternalType('array', $converted['child']);
-        $this->assertArrayHasKey('foo', $converted['child']);
-        $this->assertEquals('a', $converted['child']['foo']);
+        $this->assertEquals($expected, $obj->toArray());
     }
 
     public function testNonexistentProperty()
@@ -134,7 +144,7 @@ class StripeObjectTest extends TestCase
         $s = new StripeObject();
         $s->foo = 'a';
 
-        $string = $s->__toString();
+        $string = (string)$s;
         $expected = <<<EOS
 Stripe\StripeObject JSON: {
     "foo": "a"

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -31,7 +31,7 @@ class UtilTest extends TestCase
             ],
             null
         );
-        $this->assertTrue(array_key_exists("id", $customer->__toArray(true)));
+        $this->assertTrue(array_key_exists("id", $customer->toArray(true)));
     }
 
     public function testUtf8()


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

- Rename the "fake" magic methods `__toArray` and `__toJSON` to `toArray` and `toJSON`. They weren't actually magic methods so the double underscores were misleading and causing warnings (cf. #587).
- Rewrite `toArray` to no longer rely on `Util::convertStripeObjectToArray`. The implementation is a bit hard to read but it's basically an exact port of the [stripe-ruby logic](https://github.com/stripe/stripe-ruby/blob/82b5e510b9d4af74ad2c611c81e7d93c594dbfce/lib/stripe/stripe_object.rb#L181-L196).
    - Also, `toArray` no longer accepts a `$recursive` argument and always converts recursively.
- Remove `Util::convertStripeObjectToArray`. The method was misleading because it pretended to accept a `StripeObject` when really it expected the `$_values` property of a `StripeObject`. This lead to user confusion (cf. #702).

Fixes #587, fixes #702.
