### PR TITLE
add pending_setup_intent property in Subscription

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -28,6 +28,7 @@ namespace Stripe;
  * @property string $latest_invoice
  * @property boolean $livemode
  * @property StripeObject $metadata
+ * @property string|null $pending_setup_intent
  * @property Plan $plan
  * @property int $quantity
  * @property SubscriptionSchedule $schedule


### PR DESCRIPTION
It just seems like this property doesn't exist in the Subscription object. I just added it.

Source : https://stripe.com/docs/api/subscriptions/object#subscription_object-pending_setup_intent