### PR TITLE
Collection improvements / fixes

### DIFF
--- a/lib/ApiOperations/All.php
+++ b/lib/ApiOperations/All.php
@@ -28,7 +28,7 @@ trait All
             );
         }
         $obj->setLastResponse($response);
-        $obj->setRequestParams($params);
+        $obj->setFilters($params);
         return $obj;
     }
 }

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -16,6 +16,15 @@ class CollectionTest extends TestCase
         ]);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /You tried to access the \d index/
+     */
+    public function testOffsetGetNumericIndex()
+    {
+        $this->fixture[0];
+    }
+
     public function testCanList()
     {
         $this->stubRequest(
@@ -166,5 +175,66 @@ class CollectionTest extends TestCase
             'stripe_account' => 'acct_foo',
             'idempotency_key' => 'qwertyuiop',
         ]);
+    }
+
+    public function testEmptyCollection()
+    {
+        $emptyCollection = Collection::emptyCollection();
+        $this->assertEquals([], $emptyCollection->data);
+    }
+
+    public function testIsEmpty()
+    {
+        $empty = Collection::constructFrom(['data' => []]);
+        $this->assertTrue($empty->isEmpty());
+
+        $notEmpty = Collection::constructFrom(['data' => [['id' => 1]]]);
+        $this->assertFalse($notEmpty->isEmpty());
+    }
+
+    public function testNextPage()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'starting_after' => 1,
+            ],
+            null,
+            false,
+            [
+                'object' => 'list',
+                'data' => [['id' => 2], ['id' => 3]],
+                'has_more' => false,
+            ]
+        );
+
+        $nextPage = $this->fixture->nextPage();
+        $ids = [];
+        foreach ($nextPage->data as $element) {
+            array_push($ids, $element['id']);
+        }
+        $this->assertEquals([2, 3], $ids);
+    }
+
+    public function testPreviousPage()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'ending_before' => 1,
+            ],
+            null,
+            false,
+            [
+                'object' => 'list',
+                'data' => [],
+                'has_more' => false,
+            ]
+        );
+
+        $previousPage = $this->fixture->previousPage();
+        $this->assertEquals([], $previousPage->data);
     }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

A bunch of improvements and fixes to the `Collection` model:
- renamed `requestParams` to `filters`, which conveys the intent better and is consistent with stripe-ruby (this is a breaking change, though I don't think many users use this)
- override `offsetGet` (magic method invoked when accessing elements via `[]`) to output a helpful error message when using numeric indices (this is consistent with stripe-ruby)
- add `emptyCollection()` static constructor, and `nextPage()` and `previousPage()` helper methods. Simplify `autoPagingIterator()` by using `nextPage()` (again, this is consistent with stripe-ruby)
- fix the `all`/`create`/`retrieve` method. Previously they updated the filters on the instance, which was incorrect. Now `all` correctly sets the filters on the _returned_ object (not the object on which the method is called), and `create` and `retrieve` don't set the filters.
    - There's a bit of duplicated code between the trait methods for `all`/`create`/`retrieve` and the methods in `Collection`, but unfortunately PHP does not have anything like Ruby's `include` vs. `extend` to add trait methods as static methods or instance methods.
- added a bunch of tests for the new stuff

