### PR TITLE
Fix toArray() calls

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -243,7 +243,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         $this->_originalValues = self::deepCopy($values);
 
         if ($values instanceof StripeObject) {
-            $values = $values->toArray(true);
+            $values = $values->toArray();
         }
 
         // Wipe old state before setting new.  This is useful for e.g. updating a
@@ -401,7 +401,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
 
     public function jsonSerialize()
     {
-        return $this->toArray(true);
+        return $this->toArray();
     }
 
     /**
@@ -441,7 +441,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      */
     public function toJSON()
     {
-        return json_encode($this->toArray(true), JSON_PRETTY_PRINT);
+        return json_encode($this->toArray(), JSON_PRETTY_PRINT);
     }
 
     public function __toString()

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -31,7 +31,7 @@ class UtilTest extends TestCase
             ],
             null
         );
-        $this->assertTrue(array_key_exists("id", $customer->toArray(true)));
+        $this->assertTrue(array_key_exists("id", $customer->toArray()));
     }
 
     public function testUtf8()


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

In #704, I changed `toArray()` to no longer take any parameters, but I forgot to update a few callsites (and apparently PHP doesn't care that you're passing parameters to a function that doesn't take any).
