### PR TITLE
Couple of fixes for PHP 7.4

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -368,7 +368,7 @@ class ApiRequestor
             $hasFile
         );
 
-        if (array_key_exists('request-id', $rheaders)) {
+        if (isset($rheaders['request-id'])) {
             self::$requestTelemetry = new RequestTelemetry(
                 $rheaders['request-id'],
                 Util\Util::currentTimeMillis() - $requestStartMs

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -35,7 +35,7 @@ class EphemeralKey extends ApiResource
      */
     public static function create($params = null, $opts = null)
     {
-        if (!$opts['stripe_version']) {
+        if (!$opts || !isset($opts['stripe_version'])) {
             throw new Exception\InvalidArgumentException('stripe_version must be specified to create an ephemeral key');
         }
         return self::_create($params, $opts);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes a couple of warnings for PHP 7.4.

The PHP 7.4 builds are still red, but that's because php-cs-fixer doesn't support 7.4 yet. The test suite is passing without warnings.

Fixes #723.
