### PR TITLE
Clean up Collection

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -31,21 +31,23 @@ class Collection extends StripeObject implements \IteratorAggregate
     /**
      * Returns the filters.
      *
-     * @param array $filters The filters.
+     * @return array The filters.
      */
-    public function getFilters($filters)
+    public function getFilters()
     {
         return $this->filters;
     }
 
     /**
-     * Sets the filters.
+     * Sets the filters, removing paging options.
      *
-     * @return array The filters.
+     * @param array $filters The filters.
      */
     public function setFilters($filters)
     {
         $this->filters = $filters;
+        unset($this->filters['starting_after']);
+        unset($this->filters['ending_before']);
     }
 
     public function offsetGet($k)
@@ -120,7 +122,6 @@ class Collection extends StripeObject implements \IteratorAggregate
     public function autoPagingIterator()
     {
         $page = $this;
-        $params = $this->_requestParams;
 
         while (true) {
             foreach ($page as $item) {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

A few clean ups for the `Collection` class:
- remove unnecessary `$params` assignment (leftover from  #715)
- fix PHPDoc blocks fro `getFilters()` / `setFilters()`
- remove paging options in `setFilters()` (consistent with stripe-ruby: https://github.com/stripe/stripe-ruby/blob/44766516d973f92f1a3f654c38cfb3dd9946db4b/lib/stripe/api_operations/list.rb#L17-L18)

Fixes #727.
