### PR TITLE
Make CaseInsensitiveArray countable and traversable

### DIFF
--- a/lib/Util/CaseInsensitiveArray.php
+++ b/lib/Util/CaseInsensitiveArray.php
@@ -2,8 +2,6 @@
 
 namespace Stripe\Util;
 
-use ArrayAccess;
-
 /**
  * CaseInsensitiveArray is an array-like class that ignores case for keys.
  *
@@ -14,13 +12,23 @@ use ArrayAccess;
  * In the context of stripe-php, this is useful because the API will return headers with different
  * case depending on whether HTTP/2 is used or not (with HTTP/2, headers are always in lowercase).
  */
-class CaseInsensitiveArray implements ArrayAccess
+class CaseInsensitiveArray implements \ArrayAccess, \Countable, \IteratorAggregate
 {
-    private $container = array();
+    private $container = [];
 
-    public function __construct($initial_array = array())
+    public function __construct($initial_array = [])
     {
-        $this->container = array_map("strtolower", $initial_array);
+        $this->container = array_change_key_case($initial_array, CASE_LOWER);
+    }
+
+    public function count()
+    {
+        return count($this->container);
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->container);
     }
 
     public function offsetSet($offset, $value)

--- a/tests/Stripe/Util/CaseInsensitiveArrayTest.php
+++ b/tests/Stripe/Util/CaseInsensitiveArrayTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Stripe\Util;
+
+class CaseInsensitiveArrayTest extends \Stripe\TestCase
+{
+    public function testArrayAccess()
+    {
+        $arr = new CaseInsensitiveArray(["One" => "1", "TWO" => "2"]);
+
+        $arr["thrEE"] = "3";
+
+        $this->assertSame("1", $arr["one"]);
+        $this->assertSame("1", $arr["One"]);
+        $this->assertSame("1", $arr["ONE"]);
+
+        $this->assertSame("2", $arr["two"]);
+        $this->assertSame("2", $arr["twO"]);
+        $this->assertSame("2", $arr["TWO"]);
+
+        $this->assertSame("3", $arr["three"]);
+        $this->assertSame("3", $arr["ThReE"]);
+        $this->assertSame("3", $arr["THREE"]);
+    }
+
+    public function testCount()
+    {
+        $arr = new CaseInsensitiveArray(["One" => "1", "TWO" => "2"]);
+
+        $this->assertSame(2, count($arr));
+    }
+
+    public function testIterable()
+    {
+        $arr = new CaseInsensitiveArray(["One" => "1", "TWO" => "2"]);
+
+        $seen = [];
+
+        foreach ($arr as $k => $v) {
+            $seen[$k] = $v;
+        }
+
+        $this->assertSame("1", $seen["one"]);
+        $this->assertSame("2", $seen["two"]);
+    }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Make `CaseInsensitiveArray` countable and traversable.

I also fixed a bug where the keys of the initial array passed to the constructor were not correctly converted to lowercase.

Fixes #735.
