### PR TITLE
Added missing setup intent constants to events

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -133,6 +133,9 @@ class Event extends ApiResource
     const REPORTING_REPORT_TYPE_UPDATED             = 'reporting.report_type.updated';
     const REVIEW_CLOSED                             = 'review.closed';
     const REVIEW_OPENED                             = 'review.opened';
+    const SETUP_INTENT_CREATED                      = 'setup_intent.created';
+    const SETUP_INTENT_SETUP_FAILED                 = 'setup_intent.setup_failed';
+    const SETUP_INTENT_SUCCEEDED                    = 'setup_intent.succeeded';
     const SIGMA_SCHEDULED_QUERY_RUN_CREATED         = 'sigma.scheduled_query_run.created';
     const SKU_CREATED                               = 'sku.created';
     const SKU_DELETED                               = 'sku.deleted';


### PR DESCRIPTION
Hey guys

Please merge in these event constants :)

Edit: It would be really nice if you could release this on 6.x, as I don't have the time to migrate to 7.x right now but I still would like the constants if possible.