### PR TITLE
Call `toArray()` on objects only

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -417,7 +417,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 return null;
             }
 
-            return method_exists($value, 'toArray') ? $value->toArray() : $value;
+            return is_object($value) && method_exists($value, 'toArray') ? $value->toArray() : $value;
         };
 
         return array_reduce(array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {


### PR DESCRIPTION
`method_exists($value, 'toArray')` has 2 arguments, the first one is an object instance or a class name, see https://www.php.net/manual/en/function.method-exists.php

It's possible that developers can store full qualified classname to SrtripeObject meta and thus this line https://github.com/stripe/stripe-php/blob/91e2b80c55428df2c45fcde7b5bc908f8f49fd25/lib/StripeObject.php#L420 will throw a fatal error `Call to a member function toArray() on string`: https://3v4l.org/2Gh07