### PR TITLE
Inform clients on retries

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -281,6 +281,7 @@ class CurlClient implements ClientInterface
             if ($this->shouldRetry($errno, $rcode, $rheaders, $numRetries)) {
                 $numRetries += 1;
                 $sleepSeconds = $this->sleepTime($numRetries, $rheaders);
+                Stripe::informOfRetry($numRetries);
                 usleep(intval($sleepSeconds * 1000000));
             } else {
                 break;

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -58,6 +58,9 @@ class Stripe
     // @var float Initial delay between retries, in seconds
     private static $initialNetworkRetryDelay = 0.5;
 
+    // @var callable|null A callback to inform when we attempt a retry.
+    public static $retryInformCallback;
+
     const VERSION = '7.3.1';
 
     /**
@@ -272,5 +275,33 @@ class Stripe
     public static function setEnableTelemetry($enableTelemetry)
     {
         self::$enableTelemetry = $enableTelemetry;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public static function getRetryInformCallback()
+    {
+        return self::$retryInformCallback;
+    }
+
+    /**
+     * @param callable $retryInformCallback
+     */
+    public static function setRetryInformCallback(callable $retryInformCallback)
+    {
+        self::$retryInformCallback = $retryInformCallback;
+    }
+
+    /**
+     * If a client registered a callback to inform them of retries, call to inform.
+     * @param int $retryAttempt
+     */
+    public static function informOfRetry($retryAttempt)
+    {
+        if (!is_callable(self::$retryInformCallback)) {
+            return;
+        }
+        call_user_func_array(self::$retryInformCallback, [$retryAttempt]);
     }
 }

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -27,4 +27,22 @@ class StripeTest extends TestCase
         Stripe::setCABundlePath('path/to/ca/bundle');
         $this->assertEquals('path/to/ca/bundle', Stripe::getCABundlePath());
     }
+
+    public function testInformCallBack()
+    {
+        $test = 0;
+
+        Stripe::setRetryInformCallback(function ($arg) use (&$test) {
+            $test = 3;
+        });
+
+        $this->assertTrue(is_callable(Stripe::getRetryInformCallback()));
+
+        $stripeReflection = new \ReflectionClass(Stripe::class);
+        $informMethod = $stripeReflection->getMethod('informOfRetry');
+        $informMethod->setAccessible(true);
+        $informMethod->invoke(null, 1);
+
+        $this->assertEquals(3, $test);
+    }
 }

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -38,10 +38,7 @@ class StripeTest extends TestCase
 
         $this->assertTrue(is_callable(Stripe::getRetryInformCallback()));
 
-        $stripeReflection = new \ReflectionClass(Stripe::class);
-        $informMethod = $stripeReflection->getMethod('informOfRetry');
-        $informMethod->setAccessible(true);
-        $informMethod->invoke(null, 1);
+        Stripe::informOfRetry(1);
 
         $this->assertEquals(3, $test);
     }


### PR DESCRIPTION
This adds a property to the Stripe class where consumers can opt into being informed when retry attempts are made, this is useful to have for monitoring. 
For example, finding patterns that can help determine why network issues occur every Friday for a specific time range.

relates to:
https://github.com/stripe/stripe-php/issues/760