### PR TITLE
Don't ignore null values in parameters

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -79,6 +79,8 @@ class ApiRequestor
     {
         if ($d instanceof ApiResource) {
             return Util\Util::utf8($d->id);
+        } elseif ($d === null) {
+            return '';
         } elseif ($d === true) {
             return 'true';
         } elseif ($d === false) {

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -34,6 +34,11 @@ class ApiRequestorTest extends TestCase
         $v = false;
         $enc = $method->invoke(null, $v);
         $this->assertSame('false', $enc);
+
+        // Encodes null
+        $v = null;
+        $enc = $method->invoke(null, $v);
+        $this->assertSame('', $enc);
     }
 
     public function testHttpClientInjection()


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

No longer ignore null values in parameter arrays, instead encode them as empty strings so that they're sent to the API.

I'm fairly sure this should be safe. Parameters can come from two different sources:
1. provided directly by the user (in which case it's safe to assume that any `null` value has been explicitly inserted by the user and they want it to be sent in the request)
2. computed automatically in `->save()` calls. In this case there shouldn't be any `null` values, because when we serialize update parameters we're already inserting empty strings as the parameter value for fields that been `null`ed: https://github.com/stripe/stripe-php/blob/96c59742329c4a9b3f531e91d64e432c82654b91/lib/StripeObject.php#L362-L363

This is difficult to test end-to-end because of the current HTTP client infrastructure in stripe-php, but I've verified this works:

```php
$customer = \Stripe\Customer::update('cus_123', ['metadata' => ['foo' => null]]);
```

Fixes #761.
