### PR TITLE
[wip] Instantiated services

### DIFF
--- a/lib/Services/AbstractNestedService.php
+++ b/lib/Services/AbstractNestedService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Stripe\Services;
+
+abstract class AbstractNestedService extends AbstractService
+{
+    protected function allNestedObjects($parentId, $params, $opts)
+    {
+        return $this->request('get', $this->baseNestedPath($parentId), $params, $opts);
+    }
+
+    protected function createNestedObject($parentId, $params, $opts)
+    {
+        return $this->request('post', $this->baseNestedPath($parentId), $params, $opts);
+    }
+
+    protected function deleteNestedObject($parentId, $id, $params, $opts)
+    {
+        return $this->request('delete', $this->nestedInstancePath($parentId, $id), $params, $opts);
+    }
+
+    protected function retrieveNestedObject($parentId, $id, $params, $opts)
+    {
+        return $this->request('get', $this->nestedInstancePath($parentId, $id), $params, $opts);
+    }
+
+    protected function updateNestedObject($parentId, $id, $params, $opts)
+    {
+        return $this->request('post', $this->nestedInstancePath($parentId, $id), $params, $opts);
+    }
+
+    protected function baseNestedPath($parentId)
+    {
+        return str_replace('{PARENT}', urlencode($parentId), $this->basePath());
+    }
+
+    protected function nestedInstancePath($parentId, $id)
+    {
+        return $this->baseNestedPath($parentId) . '/' . urlencode($id);
+    }
+}

--- a/lib/Services/AbstractService.php
+++ b/lib/Services/AbstractService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Stripe\Services;
+
+abstract class AbstractService
+{
+    /**
+     * @var \Stripe\StripeClientInterface
+     */
+    protected $client = null;
+
+    /**
+     * Initializes a new instance of the AbstractService class.
+     *
+     * @param \Stripe\StripeClientInterface $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    abstract public function basePath();
+
+    protected function allObjects($params, $opts)
+    {
+        return $this->request('get', $this->basePath(), $params, $opts);
+    }
+
+    protected function createObject($params, $opts)
+    {
+        return $this->request('post', $this->basePath(), $params, $opts);
+    }
+
+    protected function deleteObject($id, $params, $opts)
+    {
+        return $this->request('delete', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function retrieveObject($id, $params, $opts)
+    {
+        return $this->request('get', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function updateObject($id, $params, $opts)
+    {
+        return $this->request('post', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function request($method, $path, $params, $opts)
+    {
+        return $this->client->request($method, $path, $params, $opts);
+    }
+
+    protected function instancePath($id)
+    {
+        return $this->basePath() . '/' . urlencode($id);
+    }
+}

--- a/lib/Services/CoreServices.php
+++ b/lib/Services/CoreServices.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stripe\Services;
+
+class CoreServices extends ServiceNamespace
+{
+    public function getServiceClass($name)
+    {
+        switch ($name) {
+            case 'coupons':
+                return CouponService::class;
+            case 'files':
+                return FileService::class;
+            case 'issuing':
+                return Issuing\IssuingServices::class;
+            case 'paymentSources':
+                return PaymentSourceService::class;
+        }
+
+        return null;
+    }
+}

--- a/lib/Services/CouponService.php
+++ b/lib/Services/CouponService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Services;
+
+class CouponService extends AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/coupons';
+    }
+
+    /**
+     * List all coupons.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a coupon.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Delete a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function delete($id, $params = [], $opts = [])
+    {
+        return $this->deleteObject($id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Services/FileService.php
+++ b/lib/Services/FileService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Stripe\Services;
+
+class FileService extends AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/files';
+    }
+
+    /**
+     * List all files.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\File
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a file.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\File
+     */
+    public function create($params = [], $opts = [])
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        if (is_null($opts->apiBase)) {
+            $opts->apiBase = $this->client->getFilesBase();
+        }
+        // Manually flatten params, otherwise curl's multipart encoder will
+        // choke on nested arrays.
+        $flatParams = array_column(\Stripe\Util\Util::flattenParams($params), 1, 0);
+        return $this->createObject($flatParams, $opts);
+    }
+
+    /**
+     * Retrieve a file.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\File
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+}

--- a/lib/Services/Issuing/CardService.php
+++ b/lib/Services/Issuing/CardService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Services\Issuing;
+
+class CardService extends \Stripe\Services\AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/issuing/cards';
+    }
+
+    /**
+     * List all cards.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Issuing\Card
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a card.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Issuing\Card
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Retrieve a card's details.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Issuing\CardDetails
+     */
+    public function details($id, $params = [], $opts = [])
+    {
+        return $this->request('get', $this->instancePath($id) . '/details', $params, $opts);
+    }
+
+    /**
+     * Retrieve a card.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Issuing\Card
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a card.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Issuing\Card
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Services/Issuing/IssuingServices.php
+++ b/lib/Services/Issuing/IssuingServices.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stripe\Services\Issuing;
+
+class IssuingServices extends \Stripe\Services\ServiceNamespace
+{
+    public function getServiceClass($name)
+    {
+        switch ($name) {
+            case 'cards':
+                return CardService::class;
+        }
+
+        return null;
+    }
+}

--- a/lib/Services/PaymentSourceService.php
+++ b/lib/Services/PaymentSourceService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Services;
+
+class PaymentSourceService extends AbstractNestedService
+{
+    public function basePath()
+    {
+        return '/v1/customers/{PARENT}/sources';
+    }
+
+    /**
+     * List all payment sources.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\PaymentMethod|\Stripe\Source
+     */
+    public function all($parentId, $params = [], $opts = [])
+    {
+        return $this->allNestedObjects($parentId, $params, $opts);
+    }
+
+    /**
+     * Create a payment source.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\PaymentMethod|\Stripe\Source
+     */
+    public function create($parentId, $params = [], $opts = [])
+    {
+        return $this->createNestedObject($parentId, $params, $opts);
+    }
+
+    /**
+     * Delete a payment source.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\PaymentMethod|\Stripe\Source
+     */
+    public function delete($parentId, $id, $params = [], $opts = [])
+    {
+        return $this->deleteNestedObject($parentId, $id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a payment source.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\PaymentMethod|\Stripe\Source
+     */
+    public function retrieve($parentId, $id, $params = [], $opts = [])
+    {
+        return $this->retrieveNestedObject($parentId, $id, $params, $opts);
+    }
+
+    /**
+     * Update a payment source.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\PaymentMethod|\Stripe\Source
+     */
+    public function update($parentId, $id, $params = [], $opts = [])
+    {
+        return $this->updateNestedObject($parentId, $id, $params, $opts);
+    }
+}

--- a/lib/Services/ServiceNamespace.php
+++ b/lib/Services/ServiceNamespace.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Stripe\Services;
+
+abstract class ServiceNamespace
+{
+    private $client;
+    private $services;
+
+    public function __construct($client)
+    {
+        $this->client = $client;
+        $this->services = [];
+    }
+
+    abstract public function getServiceClass($name);
+
+    public function __get($name)
+    {
+        $serviceClass = $this->getServiceClass($name);
+        if (!is_null($serviceClass)) {
+            return $this->getCachedService($name, $serviceClass);
+        }
+
+        // TODO: throw exception?
+        return null;
+    }
+
+    private function getCachedService($name, $class)
+    {
+        if (!array_key_exists($name, $this->services)) {
+            $this->services[$name] = new $class($this->client);
+        }
+        return $this->services[$name];
+    }
+}

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Stripe;
+
+class StripeClient implements StripeClientInterface
+{
+    const DEFAULT_API_BASE = 'https://api.stripe.com';
+    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
+    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
+
+    private $apiKey;
+    private $clientId;
+
+    private $apiBase;
+    private $connectBase;
+    private $filesBase;
+
+    private $coreServices;
+
+    public function __construct(
+        $apiKey,
+        $clientId = null,
+        $apiBase = null,
+        $connectBase = null,
+        $filesBase = null
+    ) {
+        $this->apiKey = $apiKey;
+        $this->clientId = $clientId;
+
+        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
+        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
+        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+
+        $this->coreServices = new \Stripe\Services\CoreServices($this);
+    }
+
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    public function getApiBase()
+    {
+        return $this->apiBase;
+    }
+
+    public function getConnectBase()
+    {
+        return $this->connectBase;
+    }
+
+    public function getFilesBase()
+    {
+        return $this->filesBase;
+    }
+
+    public function request($method, $path, $params, $opts)
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $baseUrl = isset($opts->apiBase) ? $opts->apiBase : $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($opts->apiKey ?: $this->getApiKey(), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    public function __get($name)
+    {
+        return $this->coreServices->__get($name);
+    }
+}

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stripe;
+
+interface StripeClientInterface
+{
+    public function getApiKey();
+
+    public function getClientId();
+
+    public function getApiBase();
+
+    public function getConnectBase();
+
+    public function getFilesBase();
+
+    public function request($method, $path, $params, $opts);
+}

--- a/tests/Stripe/Services/CouponServiceTest.php
+++ b/tests/Stripe/Services/CouponServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stripe\Services;
+
+class CouponServiceTest extends ServiceTestCase
+{
+    const TEST_RESOURCE_ID = '25OFF';
+
+    protected function getServiceClass()
+    {
+        return CouponService::class;
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/coupons'
+        );
+        $resources = $this->service->all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/coupons'
+        );
+        $resource = $this->service->create([
+            "percent_off" => 25,
+            "duration" => "repeating",
+            "duration_in_months" => 3,
+            "id" => self::TEST_RESOURCE_ID,
+        ]);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            'delete',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource->delete();
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+}

--- a/tests/Stripe/Services/FileServiceTest.php
+++ b/tests/Stripe/Services/FileServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Stripe\Services;
+
+class FileServiceTest extends ServiceTestCase
+{
+    const TEST_RESOURCE_ID = 'file_123';
+
+    protected function getServiceClass()
+    {
+        return FileService::class;
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/files'
+        );
+        $resources = $this->service->all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf(\Stripe\File::class, $resources->data[0]);
+    }
+
+    public function testCreateWithFileHandle()
+    {
+        $stripeClient = new \Stripe\StripeClient("sk_test_123", null, null, null, MOCK_URL);
+        $service = new FileService($stripeClient);
+
+        $this->expectsRequest(
+            'post',
+            '/v1/files',
+            null,
+            ['Content-Type: multipart/form-data'],
+            true,
+            MOCK_URL
+        );
+        $fp = fopen(dirname(__FILE__) . '/../../data/test.png', 'r');
+        $resource = $service->create([
+            "purpose" => "dispute_evidence",
+            "file" => $fp,
+            "file_link_data" => ["create" => true]
+        ]);
+        $this->assertInstanceOf(\Stripe\File::class, $resource);
+    }
+
+    public function testIsCreatableWithCURLFile()
+    {
+        $stripeClient = new \Stripe\StripeClient("sk_test_123", null, null, null, MOCK_URL);
+        $service = new FileService($stripeClient);
+
+        $this->expectsRequest(
+            'post',
+            '/v1/files',
+            null,
+            ['Content-Type: multipart/form-data'],
+            true,
+            MOCK_URL
+        );
+        $curlFile = new \CURLFile(dirname(__FILE__) . '/../../data/test.png');
+        $resource = $service->create([
+            "purpose" => "dispute_evidence",
+            "file" => $curlFile,
+            "file_link_data" => ["create" => true]
+        ]);
+        $this->assertInstanceOf(\Stripe\File::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/files/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\File::class, $resource);
+    }
+}

--- a/tests/Stripe/Services/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Services/Issuing/CardServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Stripe\Services\Issuing;
+
+class CardServiceTest extends \Stripe\Services\ServiceTestCase
+{
+    const TEST_RESOURCE_ID = 'ic_123';
+
+    protected function getServiceClass()
+    {
+        return CardService::class;
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards'
+        );
+        $resources = $this->service->all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cards'
+        );
+        $resource = $this->service->create([
+            "authorization_controls" => ["max_amount" => 123],
+            "currency" => "usd",
+            "type" => "virtual",
+        ]);
+        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+
+    public function testDetails()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID . '/details'
+        );
+        $resource = $this->service->details(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\Issuing\CardDetails::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+}

--- a/tests/Stripe/Services/PaymentSourceServiceTest.php
+++ b/tests/Stripe/Services/PaymentSourceServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Stripe\Services;
+
+class PaymentSourceServiceTest extends ServiceTestCase
+{
+    const TEST_PARENT_RESOURCE_ID = 'cus_123';
+    const TEST_RESOURCE_ID = 'card_123';
+
+    protected function getServiceClass()
+    {
+        return PaymentSourceService::class;
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_PARENT_RESOURCE_ID . '/sources'
+        );
+        $resources = $this->service->all(self::TEST_PARENT_RESOURCE_ID);
+        $this->assertTrue(is_array($resources->data));
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_PARENT_RESOURCE_ID . '/sources'
+        );
+        $resource = $this->service->create(
+            self::TEST_PARENT_RESOURCE_ID,
+            [
+                "source" => "tok_123",
+            ]
+        );
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_PARENT_RESOURCE_ID . '/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_PARENT_RESOURCE_ID, self::TEST_RESOURCE_ID);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_PARENT_RESOURCE_ID . '/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_PARENT_RESOURCE_ID, self::TEST_RESOURCE_ID);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_PARENT_RESOURCE_ID . '/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(
+            self::TEST_PARENT_RESOURCE_ID,
+            self::TEST_RESOURCE_ID,
+            [
+                "metadata" => ["key" => "value"],
+            ]
+        );
+    }
+}

--- a/tests/Stripe/Services/ServiceTestCase.php
+++ b/tests/Stripe/Services/ServiceTestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Stripe\Services;
+
+abstract class ServiceTestCase extends \Stripe\TestCase
+{
+    protected $stripeClient = null;
+
+    protected $service = null;
+
+    /**
+     * @before
+     */
+    protected function setUpStripeClientAndService()
+    {
+        $this->stripeClient = new \Stripe\StripeClient(
+            "sk_test_123",
+            "ca_123",
+            MOCK_URL,
+            null,
+            null
+        );
+        $serviceClass = $this->getServiceClass();
+        $this->service = new $serviceClass($this->stripeClient);
+    }
+
+    abstract protected function getServiceClass();
+}

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stripe;
+
+class StripeClientTest extends TestCase
+{
+    public function testGetServices()
+    {
+        $client = new StripeClient("sk_test_123");
+
+        $this->assertInstanceOf(\Stripe\Services\CouponService::class, $client->coupons);
+        $this->assertInstanceOf(\Stripe\Services\FileService::class, $client->files);
+        $this->assertInstanceOf(\Stripe\Services\Issuing\CardService::class, $client->issuing->cards);
+        $this->assertInstanceOf(\Stripe\Services\PaymentSourceService::class, $client->paymentSources);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,3 +54,5 @@ if ($version != "master" && version_compare($version, MOCK_MINIMUM_VERSION) == -
 }
 
 require_once __DIR__ . '/TestCase.php';
+
+require_once __DIR__ . '/Stripe/Services/ServiceTestCase.php';


### PR DESCRIPTION
cc @remi-stripe 

Pretty experimental yet, but it works. I will polish this up and split it into smaller PRs.

Sample syntax:

```php
require_once('vendor/autoload.php');

// Instantiate client
$stripe = new \Stripe\StripeClient("sk_test_123");

// Retrieve method
$coupon = $stripe->coupons->retrieve("mycoupon");

// Create method, namespaced resource
$issuingCard = $stripe->issuing->cards->create(["authorization_controls" => ["max_amount" => 123]]);

// Custom method, namespaced resource
$details = $stripe->issuing->cards->details("ic_123");

// Update method, nested polymorphic resource
$updatedPaymentSource = $stripe->paymentSources->update("cus_123", " card_123", ["metadata" => ["key" => "value"]]);
```
