### PR TITLE
New `StripeClient` class

### DIFF
--- a/init.php
+++ b/init.php
@@ -43,6 +43,10 @@ require(dirname(__FILE__) . '/lib/Exception/OAuth/UnknownOAuthErrorException.php
 require(dirname(__FILE__) . '/lib/Exception/OAuth/UnsupportedGrantTypeException.php');
 require(dirname(__FILE__) . '/lib/Exception/OAuth/UnsupportedResponseTypeException.php');
 
+// StripeClient
+require(dirname(__FILE__) . '/lib/StripeClientInterface.php');
+require(dirname(__FILE__) . '/lib/StripeClient.php');
+
 // API operations
 require(dirname(__FILE__) . '/lib/ApiOperations/All.php');
 require(dirname(__FILE__) . '/lib/ApiOperations/Create.php');

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Stripe;
+
+class StripeClient implements StripeClientInterface
+{
+    /**
+     * @var string Default base URL for Stripe's API.
+     */
+    const DEFAULT_API_BASE = 'https://api.stripe.com';
+
+    /**
+     * @var string Default base URL for Stripe's OAuth API.
+     */
+    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
+
+    /**
+     * @var string Default base URL for Stripe's Files API.
+     */
+    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
+
+    private $apiKey;
+    private $clientId;
+
+    private $apiBase;
+    private $connectBase;
+    private $filesBase;
+
+    /**
+     * Initializes a new instance of the {@link StripeClient} class.
+     *
+     * @param string|null $apiKey The API key used by the client to make requests.
+     * @param string|null $clientId The client ID used by the client in OAuth requests.
+     * @param string|null $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
+     * @param string|null $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
+     * @param string|null $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     */
+    public function __construct(
+        $apiKey,
+        $clientId = null,
+        $apiBase = null,
+        $connectBase = null,
+        $filesBase = null
+    ) {
+        if (!is_null($apiKey) && ($apiKey === '')) {
+            $msg = "API key cannot be the empty string.";
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+        if (!is_null($apiKey) && (preg_match('/\s/', $apiKey))) {
+            $msg = "API key cannot contain whitespace.";
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        $this->apiKey = $apiKey;
+        $this->clientId = $clientId;
+
+        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
+        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
+        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+    }
+
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return string|null The API key used by the client to send requests.
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return string|null The client ID used by the client in OAuth requests.
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string The base URL for Stripe's API.
+     */
+    public function getApiBase()
+    {
+        return $this->apiBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string The base URL for Stripe's OAuth API.
+     */
+    public function getConnectBase()
+    {
+        return $this->connectBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string The base URL for Stripe's Files API.
+     */
+    public function getFilesBase()
+    {
+        return $this->filesBase;
+    }
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method The HTTP method.
+     * @param string $path The path of the request.
+     * @param array $params The parameters of the request.
+     * @param array|\Stripe\RequestOptions $opts The special modifiers of the request.
+     * @return \Stripe\StripeObject The object returned by Stripe's API.
+     */
+    public function request($method, $path, $params, $opts)
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $baseUrl = $opts->apiBase ?: $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    private function apiKeyForRequest($opts)
+    {
+        $apiKey = $opts->apiKey ?: $this->getApiKey();
+
+        if (is_null($apiKey)) {
+            $msg = "No API key provided. Set your API key when constructing the "
+                . "StripeClient instance, or provide it on a per-request basis "
+                . "using the `api_key` key in the \$opts argument.";
+            throw new Exception\AuthenticationException($msg);
+        }
+
+        return $apiKey;
+    }
+}

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Interface for a Stripe client.
+ */
+interface StripeClientInterface
+{
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return string|null The API key used by the client to send requests.
+     */
+    public function getApiKey();
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return string|null The client ID used by the client in OAuth requests.
+     */
+    public function getClientId();
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string The base URL for Stripe's API.
+     */
+    public function getApiBase();
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string The base URL for Stripe's OAuth API.
+     */
+    public function getConnectBase();
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string The base URL for Stripe's Files API.
+     */
+    public function getFilesBase();
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method The HTTP method.
+     * @param string $path The path of the request.
+     * @param array $params The parameters of the request.
+     * @param array|\Stripe\RequestOptions $opts The special modifiers of the request.
+     * @return \Stripe\StripeObject The object returned by Stripe's API.
+     */
+    public function request($method, $path, $params, $opts);
+}

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Stripe;
+
+class StripeClientTest extends TestCase
+{
+    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    {
+        $client = new StripeClient(null);
+        $this->assertNotNull($client);
+        $this->assertNull($client->getApiKey());
+    }
+
+    /**
+     * @expectedException \Stripe\Exception\InvalidArgumentException
+     * @expectedExceptionMessage API key cannot be the empty string.
+     */
+    public function testCtorThrowsIfApiKeyIsEmpty()
+    {
+        $client = new StripeClient("");
+    }
+
+    /**
+     * @expectedException \Stripe\Exception\InvalidArgumentException
+     * @expectedExceptionMessage API key cannot contain whitespace.
+     */
+    public function testCtorThrowsIfApiKeyContainsWhitespace()
+    {
+        $client = new StripeClient("sk_test_123\n");
+    }
+
+    public function testRequestWithClientApiKey()
+    {
+        $client = new StripeClient("sk_test_client", null, MOCK_URL);
+        $charge = $client->request("get", "/v1/charges/ch_123", [], []);
+        $this->assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        $this->assertEquals("sk_test_client", $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestWithOptsApiKey()
+    {
+        $client = new StripeClient(null, null, MOCK_URL);
+        $charge = $client->request("get", "/v1/charges/ch_123", [], ["api_key" => "sk_test_opts"]);
+        $this->assertNotNull($charge);
+        $this->assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        $this->assertEquals("sk_test_opts", $optsReflector->getValue($charge)->apiKey);
+    }
+
+    /**
+     * @expectedException Stripe\Exception\AuthenticationException
+     * @expectedExceptionMessage No API key provided.
+     */
+    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
+    {
+        $client = new StripeClient(null, null, MOCK_URL);
+        $charge = $client->request("get", "/v1/charges/ch_123", [], []);
+        $this->assertNotNull($charge);
+        $this->assertEquals("ch_123", $charge->id);
+    }
+}


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

(Note: this PR targets the `integration-services` branch, not `master`.)

Adds a new `StripeClient` class, whose purpose is to hold configuration values:
- the API key
- the client ID (for OAuth requests)
- the base URLs for regular API requests, file API requests and OAuth requests

This client will be used by services to issue requests.

Also defines a `StripeClientInterface`, so users can easily write mock clients.
