### PR TITLE
Redact API key in RequestOpts debug info

### DIFF
--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -25,6 +25,15 @@ class RequestOptions
         $this->apiBase = $base;
     }
 
+    public function __debugInfo()
+    {
+        return [
+            'apiKey' => $this->redactedApiKey(),
+            'headers' => $this->headers,
+            'apiBase' => $this->apiBase,
+        ];
+    }
+
     /**
      * Unpacks an options array and merges it into the existing RequestOptions
      * object.
@@ -104,5 +113,16 @@ class RequestOptions
            . 'per-request options, which must be an array. (HINT: you can set '
            . 'a global apiKey by "Stripe::setApiKey(<apiKey>)")';
         throw new Exception\InvalidArgumentException($message);
+    }
+
+    private function redactedApiKey()
+    {
+        $pieces = explode('_', $this->apiKey, 3);
+        $last = array_pop($pieces);
+        $redactedLast = strlen($last) > 4
+            ? (str_repeat('*', strlen($last) - 4) . substr($last, -4))
+            : $last;
+        array_push($pieces, $redactedLast);
+        return implode('_', $pieces);
     }
 }

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -78,4 +78,19 @@ class RequestOptionsTest extends TestCase
         $opts->discardNonPersistentHeaders();
         $this->assertSame(['Stripe-Account' => 'foo'], $opts->headers);
     }
+
+    public function testDebugInfo()
+    {
+        $opts = Util\RequestOptions::parse(['api_key' => 'sk_test_1234567890abcdefghijklmn']);
+        $debugInfo = print_r($opts, true);
+        $this->assertContains("[apiKey] => sk_test_********************klmn", $debugInfo);
+
+        $opts = Util\RequestOptions::parse(['api_key' => 'sk_1234567890abcdefghijklmn']);
+        $debugInfo = print_r($opts, true);
+        $this->assertContains("[apiKey] => sk_********************klmn", $debugInfo);
+
+        $opts = Util\RequestOptions::parse(['api_key' => '1234567890abcdefghijklmn']);
+        $debugInfo = print_r($opts, true);
+        $this->assertContains("[apiKey] => ********************klmn", $debugInfo);
+    }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Redacts the API key in `RequestOpts` debug info (when using `var_dump` or `print_r`).