### PR TITLE
Add missing constants for Customer's `TaxId`

### DIFF
--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -28,11 +28,13 @@ class TaxId extends ApiResource
      * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-type
      */
     const TYPE_AU_ABN  = 'au_abn';
+    const TYPE_CH_VAT  = 'ch_vat';
     const TYPE_EU_VAT  = 'eu_vat';
     const TYPE_IN_GST  = 'in_gst';
     const TYPE_NO_VAT  = 'no_vat';
     const TYPE_NZ_GST  = 'nz_gst';
     const TYPE_UNKNOWN = 'unknown';
+    const TYPE_ZA_VAT  = 'za_vat';
 
     /**
      * Possible string representations of the verification status.


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

Fixes https://github.com/stripe/stripe-php/issues/769