### PR TITLE
Client and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ $customers = $stripe->customers->all([],[
     'stripe_account' => 'acct_...'
 ]);
 
-$stripe->customers->retrieve('cus_123456789', [
+$stripe->customers->retrieve('cus_123456789', [], [
     'api_key' => 'sk_test_...',
     'stripe_account' => 'acct_...'
 ]);

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ If you use Composer, these dependencies should be handled automatically. If you 
 Simple usage looks like:
 
 ```php
-\Stripe\Stripe::setApiKey('sk_test_BQokikJOvBiI2HlWgH4olfQ2');
-$customer = \Stripe\Customer::create([
+$stripe = new \Stripe\StripeClient('sk_test_BQokikJOvBiI2HlWgH4olfQ2');
+$customer = $stripe->customers->create([
     'description' => 'example customer',
     'email' => 'email@example.com',
     'payment_method' => 'pm_card_visa',
@@ -125,7 +125,7 @@ end up there instead of `error_log`:
 You can access the data from the last API response on any object via `getLastResponse()`.
 
 ```php
-$customer = \Stripe\Customer::create([
+$customer = $stripe->customers->create([
     'description' => 'example customer',
 ]);
 echo $customer->getLastResponse()->headers['Request-Id'];
@@ -149,12 +149,12 @@ one that uses [Stripe Connect][connect], it's also possible to set a
 per-request key and/or account:
 
 ```php
-$customers = \Stripe\Customer::all([],[
+$customers = $stripe->customers->all([],[
     'api_key' => 'sk_test_...',
     'stripe_account' => 'acct_...'
 ]);
 
-\Stripe\Customer::retrieve("cus_123456789", [
+$stripe->customers->retrieve('cus_123456789', [
     'api_key' => 'sk_test_...',
     'stripe_account' => 'acct_...'
 ]);

--- a/init.php
+++ b/init.php
@@ -160,6 +160,7 @@ require __DIR__ . '/lib/Service/ApplePayDomainService.php';
 require __DIR__ . '/lib/Service/ApplicationFeeService.php';
 require __DIR__ . '/lib/Service/BalanceService.php';
 require __DIR__ . '/lib/Service/BalanceTransactionService.php';
+require __DIR__ . '/lib/Service/BillingPortal/SessionService.php';
 require __DIR__ . '/lib/Service/ChargeService.php';
 require __DIR__ . '/lib/Service/Checkout/SessionService.php';
 require __DIR__ . '/lib/Service/CountrySpecService.php';
@@ -186,6 +187,7 @@ require __DIR__ . '/lib/Service/PaymentIntentService.php';
 require __DIR__ . '/lib/Service/PaymentMethodService.php';
 require __DIR__ . '/lib/Service/PayoutService.php';
 require __DIR__ . '/lib/Service/PlanService.php';
+require __DIR__ . '/lib/Service/PriceService.php';
 require __DIR__ . '/lib/Service/ProductService.php';
 require __DIR__ . '/lib/Service/Radar/EarlyFraudWarningService.php';
 require __DIR__ . '/lib/Service/Radar/ValueListService.php';
@@ -212,6 +214,7 @@ require __DIR__ . '/lib/Service/WebhookEndpointService.php';
 
 // Service factories
 require __DIR__ . '/lib/Service/CoreServiceFactory.php';
+require __DIR__ . '/lib/Service/BillingPortal/BillingPortalServiceFactory.php';
 require __DIR__ . '/lib/Service/Checkout/CheckoutServiceFactory.php';
 require __DIR__ . '/lib/Service/Issuing/IssuingServiceFactory.php';
 require __DIR__ . '/lib/Service/Radar/RadarServiceFactory.php';

--- a/init.php
+++ b/init.php
@@ -162,4 +162,5 @@ require __DIR__ . '/lib/WebhookSignature.php';
 require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/CouponService.php';
 require __DIR__ . '/lib/Service/FileService.php';
+require __DIR__ . '/lib/Service/Issuing/CardService.php';
 require __DIR__ . '/lib/Service/PaymentIntentService.php';

--- a/init.php
+++ b/init.php
@@ -157,3 +157,8 @@ require __DIR__ . '/lib/OAuthErrorObject.php';
 // Webhooks
 require __DIR__ . '/lib/Webhook.php';
 require __DIR__ . '/lib/WebhookSignature.php';
+
+// Services
+require __DIR__ . '/lib/Service/AbstractService.php';
+require __DIR__ . '/lib/Service/CouponService.php';
+require __DIR__ . '/lib/Service/PaymentIntentService.php';

--- a/init.php
+++ b/init.php
@@ -161,6 +161,7 @@ require __DIR__ . '/lib/WebhookSignature.php';
 // Services
 require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/CouponService.php';
+require __DIR__ . '/lib/Service/CustomerService.php';
 require __DIR__ . '/lib/Service/FileService.php';
 require __DIR__ . '/lib/Service/Issuing/CardService.php';
 require __DIR__ . '/lib/Service/PaymentIntentService.php';

--- a/init.php
+++ b/init.php
@@ -64,6 +64,7 @@ require __DIR__ . '/lib/StripeObject.php';
 require __DIR__ . '/lib/ApiRequestor.php';
 require __DIR__ . '/lib/ApiResource.php';
 require __DIR__ . '/lib/SingletonApiResource.php';
+require __DIR__ . '/lib/Service/AbstractService.php';
 
 // Stripe API Resources
 require __DIR__ . '/lib/Account.php';
@@ -150,6 +151,63 @@ require __DIR__ . '/lib/UsageRecord.php';
 require __DIR__ . '/lib/UsageRecordSummary.php';
 require __DIR__ . '/lib/WebhookEndpoint.php';
 
+// Services
+require __DIR__ . '/lib/Service/AccountService.php';
+require __DIR__ . '/lib/Service/AccountLinkService.php';
+require __DIR__ . '/lib/Service/ApplePayDomainService.php';
+require __DIR__ . '/lib/Service/ApplicationFeeService.php';
+require __DIR__ . '/lib/Service/BalanceService.php';
+require __DIR__ . '/lib/Service/BalanceTransactionService.php';
+require __DIR__ . '/lib/Service/ChargeService.php';
+require __DIR__ . '/lib/Service/Checkout/SessionService.php';
+require __DIR__ . '/lib/Service/CountrySpecService.php';
+require __DIR__ . '/lib/Service/CouponService.php';
+require __DIR__ . '/lib/Service/CreditNoteService.php';
+require __DIR__ . '/lib/Service/CustomerService.php';
+require __DIR__ . '/lib/Service/DisputeService.php';
+require __DIR__ . '/lib/Service/EphemeralKeyService.php';
+require __DIR__ . '/lib/Service/EventService.php';
+require __DIR__ . '/lib/Service/ExchangeRateService.php';
+require __DIR__ . '/lib/Service/FileService.php';
+require __DIR__ . '/lib/Service/FileLinkService.php';
+require __DIR__ . '/lib/Service/InvoiceService.php';
+require __DIR__ . '/lib/Service/InvoiceItemService.php';
+require __DIR__ . '/lib/Service/Issuing/AuthorizationService.php';
+require __DIR__ . '/lib/Service/Issuing/CardService.php';
+require __DIR__ . '/lib/Service/Issuing/CardholderService.php';
+require __DIR__ . '/lib/Service/Issuing/DisputeService.php';
+require __DIR__ . '/lib/Service/Issuing/TransactionService.php';
+require __DIR__ . '/lib/Service/MandateService.php';
+require __DIR__ . '/lib/Service/OrderService.php';
+require __DIR__ . '/lib/Service/OrderReturnService.php';
+require __DIR__ . '/lib/Service/PaymentIntentService.php';
+require __DIR__ . '/lib/Service/PaymentMethodService.php';
+require __DIR__ . '/lib/Service/PayoutService.php';
+require __DIR__ . '/lib/Service/PlanService.php';
+require __DIR__ . '/lib/Service/ProductService.php';
+require __DIR__ . '/lib/Service/Radar/EarlyFraudWarningService.php';
+require __DIR__ . '/lib/Service/Radar/ValueListService.php';
+require __DIR__ . '/lib/Service/Radar/ValueListItemService.php';
+require __DIR__ . '/lib/Service/RefundService.php';
+require __DIR__ . '/lib/Service/Reporting/ReportRunService.php';
+require __DIR__ . '/lib/Service/Reporting/ReportTypeService.php';
+require __DIR__ . '/lib/Service/ReviewService.php';
+require __DIR__ . '/lib/Service/SetupIntentService.php';
+require __DIR__ . '/lib/Service/Sigma/ScheduledQueryRunService.php';
+require __DIR__ . '/lib/Service/SkuService.php';
+require __DIR__ . '/lib/Service/SourceService.php';
+require __DIR__ . '/lib/Service/SubscriptionService.php';
+require __DIR__ . '/lib/Service/SubscriptionItemService.php';
+require __DIR__ . '/lib/Service/SubscriptionScheduleService.php';
+require __DIR__ . '/lib/Service/TaxRateService.php';
+require __DIR__ . '/lib/Service/Terminal/ConnectionTokenService.php';
+require __DIR__ . '/lib/Service/Terminal/LocationService.php';
+require __DIR__ . '/lib/Service/Terminal/ReaderService.php';
+require __DIR__ . '/lib/Service/TokenService.php';
+require __DIR__ . '/lib/Service/TopupService.php';
+require __DIR__ . '/lib/Service/TransferService.php';
+require __DIR__ . '/lib/Service/WebhookEndpointService.php';
+
 // OAuth
 require __DIR__ . '/lib/OAuth.php';
 require __DIR__ . '/lib/OAuthErrorObject.php';
@@ -157,11 +215,3 @@ require __DIR__ . '/lib/OAuthErrorObject.php';
 // Webhooks
 require __DIR__ . '/lib/Webhook.php';
 require __DIR__ . '/lib/WebhookSignature.php';
-
-// Services
-require __DIR__ . '/lib/Service/AbstractService.php';
-require __DIR__ . '/lib/Service/CouponService.php';
-require __DIR__ . '/lib/Service/CustomerService.php';
-require __DIR__ . '/lib/Service/FileService.php';
-require __DIR__ . '/lib/Service/Issuing/CardService.php';
-require __DIR__ . '/lib/Service/PaymentIntentService.php';

--- a/init.php
+++ b/init.php
@@ -44,10 +44,6 @@ require __DIR__ . '/lib/Exception/OAuth/UnknownOAuthErrorException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedGrantTypeException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedResponseTypeException.php';
 
-// StripeClient
-require __DIR__ . '/lib/StripeClientInterface.php';
-require __DIR__ . '/lib/StripeClient.php';
-
 // API operations
 require __DIR__ . '/lib/ApiOperations/All.php';
 require __DIR__ . '/lib/ApiOperations/Create.php';
@@ -65,6 +61,12 @@ require __DIR__ . '/lib/ApiRequestor.php';
 require __DIR__ . '/lib/ApiResource.php';
 require __DIR__ . '/lib/SingletonApiResource.php';
 require __DIR__ . '/lib/Service/AbstractService.php';
+require __DIR__ . '/lib/Service/AbstractServiceFactory.php';
+
+// StripeClient
+require __DIR__ . '/lib/StripeClientInterface.php';
+require __DIR__ . '/lib/BaseStripeClient.php';
+require __DIR__ . '/lib/StripeClient.php';
 
 // Stripe API Resources
 require __DIR__ . '/lib/Account.php';
@@ -207,6 +209,15 @@ require __DIR__ . '/lib/Service/TokenService.php';
 require __DIR__ . '/lib/Service/TopupService.php';
 require __DIR__ . '/lib/Service/TransferService.php';
 require __DIR__ . '/lib/Service/WebhookEndpointService.php';
+
+// Service factories
+require __DIR__ . '/lib/Service/CoreServiceFactory.php';
+require __DIR__ . '/lib/Service/Checkout/CheckoutServiceFactory.php';
+require __DIR__ . '/lib/Service/Issuing/IssuingServiceFactory.php';
+require __DIR__ . '/lib/Service/Radar/RadarServiceFactory.php';
+require __DIR__ . '/lib/Service/Reporting/ReportingServiceFactory.php';
+require __DIR__ . '/lib/Service/Sigma/SigmaServiceFactory.php';
+require __DIR__ . '/lib/Service/Terminal/TerminalServiceFactory.php';
 
 // OAuth
 require __DIR__ . '/lib/OAuth.php';

--- a/init.php
+++ b/init.php
@@ -161,4 +161,5 @@ require __DIR__ . '/lib/WebhookSignature.php';
 // Services
 require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/CouponService.php';
+require __DIR__ . '/lib/Service/FileService.php';
 require __DIR__ . '/lib/Service/PaymentIntentService.php';

--- a/init.php
+++ b/init.php
@@ -44,6 +44,10 @@ require __DIR__ . '/lib/Exception/OAuth/UnknownOAuthErrorException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedGrantTypeException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedResponseTypeException.php';
 
+// StripeClient
+require __DIR__ . '/lib/StripeClientInterface.php';
+require __DIR__ . '/lib/StripeClient.php';
+
 // API operations
 require __DIR__ . '/lib/ApiOperations/All.php';
 require __DIR__ . '/lib/ApiOperations/Create.php';

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Stripe;
+
+class BaseStripeClient implements StripeClientInterface
+{
+    /** @var string default base URL for Stripe's API */
+    const DEFAULT_API_BASE = 'https://api.stripe.com';
+
+    /** @var string default base URL for Stripe's OAuth API */
+    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
+
+    /** @var string default base URL for Stripe's Files API */
+    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
+
+    /** @var null|string */
+    private $apiKey;
+
+    /** @var null|string */
+    private $clientId;
+
+    /** @var string */
+    private $apiBase;
+
+    /** @var string */
+    private $connectBase;
+
+    /** @var string */
+    private $filesBase;
+
+    /**
+     * Initializes a new instance of the {@link StripeClient} class.
+     *
+     * @param null|string $apiKey the API key used by the client to make requests
+     * @param null|string $clientId the client ID used by the client in OAuth requests
+     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
+     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
+     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     */
+    public function __construct(
+        $apiKey,
+        $clientId = null,
+        $apiBase = null,
+        $connectBase = null,
+        $filesBase = null
+    ) {
+        if (null !== $apiKey && ('' === $apiKey)) {
+            $msg = 'API key cannot be the empty string.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        if (null !== $apiKey && (\preg_match('/\s/', $apiKey))) {
+            $msg = 'API key cannot contain whitespace.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        $this->apiKey = $apiKey;
+        $this->clientId = $clientId;
+
+        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
+        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
+        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+    }
+
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return null|string the API key used by the client to send requests
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return null|string the client ID used by the client in OAuth requests
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string the base URL for Stripe's API
+     */
+    public function getApiBase()
+    {
+        return $this->apiBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string the base URL for Stripe's OAuth API
+     */
+    public function getConnectBase()
+    {
+        return $this->connectBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string the base URL for Stripe's Files API
+     */
+    public function getFilesBase()
+    {
+        return $this->filesBase;
+    }
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\StripeObject the object returned by Stripe's API
+     */
+    public function request($method, $path, $params, $opts)
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $baseUrl = $opts->apiBase ?: $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+
+        return $obj;
+    }
+
+    /**
+     * @param \Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\AuthenticationException
+     *
+     * @return string
+     */
+    private function apiKeyForRequest($opts)
+    {
+        $apiKey = $opts->apiKey ?: $this->getApiKey();
+
+        if (null === $apiKey) {
+            $msg = 'No API key provided. Set your API key when constructing the '
+                . 'StripeClient instance, or provide it on a per-request basis '
+                . 'using the `api_key` key in the $opts argument.';
+
+            throw new Exception\AuthenticationException($msg);
+        }
+
+        return $apiKey;
+    }
+}

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -126,7 +126,7 @@ class BaseStripeClient implements StripeClientInterface
      */
     public function request($method, $path, $params, $opts)
     {
-        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $opts = \Stripe\Util\RequestOptions::parse($opts, true);
         $baseUrl = $opts->apiBase ?: $this->getApiBase();
         $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
         list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -29,21 +29,42 @@ class BaseStripeClient implements StripeClientInterface
     private $filesBase;
 
     /**
-     * Initializes a new instance of the {@link StripeClient} class.
+     * Initializes a new instance of the {@link BaseStripeClient} class.
      *
-     * @param null|string $apiKey the API key used by the client to make requests
-     * @param null|string $clientId the client ID used by the client in OAuth requests
-     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
-     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
-     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     * The constructor takes a single argument. The argument can be a string, in which case it
+     * should be the API key. It can also be an array with various configuration settings.
+     *
+     * Configuration settings include the following options:
+     *
+     * - api_key (string): the Stripe API key, to be used in regular API requests.
+     * - client_id (string): the Stripe client ID, to be used in OAuth requests.
+     * - api_base (string): the base URL for regular API requests. Defaults to
+     *   {@link DEFAULT_API_BASE}. Changing this should rarely be necessary.
+     * - connect_base (string): the base URL for OAuth requests. Defaults to
+     *   {@link DEFAULT_CONNECT_BASE}. Changing this should rarely be necessary.
+     * - files_base (string): the base URL for file creation requests. Defaults to
+     *   {@link DEFAULT_FILES_BASE}. Changing this should rarely be necessary.
+     *
+     * @param array<string, mixed>|string $config the API key as a string, or an array containing
+     *   the client configuration settings
      */
-    public function __construct(
-        $apiKey,
-        $clientId = null,
-        $apiBase = null,
-        $connectBase = null,
-        $filesBase = null
-    ) {
+    public function __construct($config = [])
+    {
+        if (\is_string($config)) {
+            $config = ['api_key' => $config];
+        }
+
+        $defaults = [
+            'api_key' => null,
+            'client_id' => null,
+            'api_base' => self::DEFAULT_API_BASE,
+            'connect_base' => self::DEFAULT_CONNECT_BASE,
+            'files_base' => self::DEFAULT_FILES_BASE,
+        ];
+        $config = \array_merge($defaults, $config);
+
+        $apiKey = $config['api_key'];
+
         if (null !== $apiKey && ('' === $apiKey)) {
             $msg = 'API key cannot be the empty string.';
 
@@ -57,11 +78,10 @@ class BaseStripeClient implements StripeClientInterface
         }
 
         $this->apiKey = $apiKey;
-        $this->clientId = $clientId;
-
-        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
-        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
-        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+        $this->clientId = $config['client_id'];
+        $this->apiBase = $config['api_base'];
+        $this->connectBase = $config['connect_base'];
+        $this->filesBase = $config['files_base'];
     }
 
     /**

--- a/lib/Issuing/Transaction.php
+++ b/lib/Issuing/Transaction.php
@@ -26,7 +26,6 @@ namespace Stripe\Issuing;
  * @property string $merchant_currency The currency with which the merchant is taking payment.
  * @property \Stripe\StripeObject $merchant_data
  * @property \Stripe\StripeObject $metadata Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
- * @property null|\Stripe\StripeObject $purchase_details Additional purchase information that is optionally provided by the merchant.
  * @property string $type The nature of the transaction.
  */
 class Transaction extends \Stripe\ApiResource

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -6,8 +6,9 @@ namespace Stripe;
  * Products describe the specific goods or services you offer to your customers.
  * For example, you might offer a Standard and Premium version of your goods or
  * service; each version would be a separate Product. They can be used in
- * conjunction with <a href="https://stripe.com/docs/api#prices">Prices</a> to
- * configure pricing in Checkout and Subscriptions.
+ * conjunction with <a href="https://stripe.com/docs/api#skus">SKUs</a> and <a
+ * href="https://stripe.com/docs/api#plans">Plans</a> to configure pricing in
+ * Checkout and Subscriptions.
  *
  * Related guides: <a
  * href="https://stripe.com/docs/billing/subscriptions/set-up-subscription">Set up

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Abstract base class for all services.
+ */
+abstract class AbstractService
+{
+    /**
+     * @var \Stripe\StripeClientInterface
+     */
+    protected $client;
+
+    /**
+     * Initializes a new instance of the {@link AbstractService} class.
+     *
+     * @param \Stripe\StripeClientInterface $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Returns the base path for requests issued by this service. Must be
+     * implemented by all concrete subclasses.
+     *
+     * @return string the base path for requests issued by this service
+     */
+    abstract public function basePath();
+
+    /**
+     * Gets the client used by this service to send requests.
+     *
+     * @return \Stripe\StripeClientInterface
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    protected function allObjects($params, $opts)
+    {
+        return $this->request('get', $this->basePath(), $params, $opts);
+    }
+
+    protected function createObject($params, $opts)
+    {
+        return $this->request('post', $this->basePath(), $params, $opts);
+    }
+
+    protected function deleteObject($id, $params, $opts)
+    {
+        return $this->request('delete', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function retrieveObject($id, $params, $opts)
+    {
+        return $this->request('get', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function updateObject($id, $params, $opts)
+    {
+        return $this->request('post', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function request($method, $path, $params, $opts)
+    {
+        return $this->getClient()->request($method, $path, $params, $opts);
+    }
+
+    protected function instancePath($id)
+    {
+        if (null === $id || '' === \trim($id)) {
+            $msg = 'The resource ID cannot be null or whitespace.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        return $this->basePath() . '/' . \urlencode($id);
+    }
+}

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -23,14 +23,6 @@ abstract class AbstractService
     }
 
     /**
-     * Returns the base path for requests issued by this service. Must be
-     * implemented by all concrete subclasses.
-     *
-     * @return string the base path for requests issued by this service
-     */
-    abstract public function basePath();
-
-    /**
      * Gets the client used by this service to send requests.
      *
      * @return \Stripe\StripeClientInterface
@@ -40,85 +32,21 @@ abstract class AbstractService
         return $this->client;
     }
 
-    protected function allObjects($params, $opts)
-    {
-        return $this->request('get', $this->basePath(), $params, $opts);
-    }
-
-    protected function allNestedObjects($nestedPath, $parentId, $params, $opts)
-    {
-        return $this->request('get', $this->baseNestedPath($parentId, $nestedPath), $params, $opts);
-    }
-
-    protected function createObject($params, $opts)
-    {
-        return $this->request('post', $this->basePath(), $params, $opts);
-    }
-
-    protected function createNestedObject($nestedPath, $parentId, $params, $opts)
-    {
-        return $this->request('post', $this->baseNestedPath($parentId, $nestedPath), $params, $opts);
-    }
-
-    protected function deleteObject($id, $params, $opts)
-    {
-        return $this->request('delete', $this->instancePath($id), $params, $opts);
-    }
-
-    protected function deleteNestedObject($nestedPath, $parentId, $id, $params, $opts)
-    {
-        return $this->request('delete', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
-    }
-
-    protected function retrieveObject($id, $params, $opts)
-    {
-        return $this->request('get', $this->instancePath($id), $params, $opts);
-    }
-
-    protected function retrieveNestedObject($nestedPath, $parentId, $id, $params, $opts)
-    {
-        return $this->request('get', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
-    }
-
-    protected function updateObject($id, $params, $opts)
-    {
-        return $this->request('post', $this->instancePath($id), $params, $opts);
-    }
-
-    protected function updateNestedObject($nestedPath, $parentId, $id, $params, $opts)
-    {
-        return $this->request('post', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
-    }
-
     protected function request($method, $path, $params, $opts)
     {
         return $this->getClient()->request($method, $path, $params, $opts);
     }
 
-    protected function baseNestedPath($parentId, $nestedPath)
+    protected function buildPath($basePath, ...$ids)
     {
-        return $this->instancePath($parentId) . '/' . $nestedPath;
-    }
+        foreach ($ids as $id) {
+            if (null === $id || '' === \trim($id)) {
+                $msg = 'The resource ID cannot be null or whitespace.';
 
-    protected function instancePath($id)
-    {
-        if (null === $id || '' === \trim($id)) {
-            $msg = 'The resource ID cannot be null or whitespace.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
+                throw new \Stripe\Exception\InvalidArgumentException($msg);
+            }
         }
 
-        return $this->basePath() . '/' . \urlencode($id);
-    }
-
-    protected function instanceNestedPath($parentId, $nestedPath, $id)
-    {
-        if (null === $id || '' === \trim($id)) {
-            $msg = 'The resource ID cannot be null or whitespace.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
-        }
-
-        return $this->baseNestedPath($parentId, $nestedPath) . '/' . \urlencode($id);
+        return \sprintf($basePath, ...\array_map('\urlencode', $ids));
     }
 }

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -45,9 +45,19 @@ abstract class AbstractService
         return $this->request('get', $this->basePath(), $params, $opts);
     }
 
+    protected function allNestedObjects($nestedPath, $parentId, $params, $opts)
+    {
+        return $this->request('get', $this->baseNestedPath($parentId, $nestedPath), $params, $opts);
+    }
+
     protected function createObject($params, $opts)
     {
         return $this->request('post', $this->basePath(), $params, $opts);
+    }
+
+    protected function createNestedObject($nestedPath, $parentId, $params, $opts)
+    {
+        return $this->request('post', $this->baseNestedPath($parentId, $nestedPath), $params, $opts);
     }
 
     protected function deleteObject($id, $params, $opts)
@@ -55,9 +65,19 @@ abstract class AbstractService
         return $this->request('delete', $this->instancePath($id), $params, $opts);
     }
 
+    protected function deleteNestedObject($nestedPath, $parentId, $id, $params, $opts)
+    {
+        return $this->request('delete', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
+    }
+
     protected function retrieveObject($id, $params, $opts)
     {
         return $this->request('get', $this->instancePath($id), $params, $opts);
+    }
+
+    protected function retrieveNestedObject($nestedPath, $parentId, $id, $params, $opts)
+    {
+        return $this->request('get', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
     }
 
     protected function updateObject($id, $params, $opts)
@@ -65,9 +85,19 @@ abstract class AbstractService
         return $this->request('post', $this->instancePath($id), $params, $opts);
     }
 
+    protected function updateNestedObject($nestedPath, $parentId, $id, $params, $opts)
+    {
+        return $this->request('post', $this->instanceNestedPath($parentId, $nestedPath, $id), $params, $opts);
+    }
+
     protected function request($method, $path, $params, $opts)
     {
         return $this->getClient()->request($method, $path, $params, $opts);
+    }
+
+    protected function baseNestedPath($parentId, $nestedPath)
+    {
+        return $this->instancePath($parentId) . '/' . $nestedPath;
     }
 
     protected function instancePath($id)
@@ -79,5 +109,16 @@ abstract class AbstractService
         }
 
         return $this->basePath() . '/' . \urlencode($id);
+    }
+
+    protected function instanceNestedPath($parentId, $nestedPath, $id)
+    {
+        if (null === $id || '' === \trim($id)) {
+            $msg = 'The resource ID cannot be null or whitespace.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        return $this->baseNestedPath($parentId, $nestedPath) . '/' . \urlencode($id);
     }
 }

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -32,8 +32,19 @@ abstract class AbstractService
         return $this->client;
     }
 
+    /**
+     * Translate null values to empty strings. For service methods,
+     * we interpret null as a request to unset the field, which
+     * corresponds to sending an empty string for the field to the
+     * API.
+     *
+     * @param null|array $params
+     */
     private static function formatParams($params)
     {
+      if (null === $params) {
+        return $params;
+      }
       $formatted = [];
       foreach ($params as $k => $v) {
         if (null === $v) {

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -42,18 +42,19 @@ abstract class AbstractService
      */
     private static function formatParams($params)
     {
-      if (null === $params) {
-        return $params;
-      }
-      $formatted = [];
-      foreach ($params as $k => $v) {
-        if (null === $v) {
-          $formatted[$k] = "";
-        } else {
-          $formatted[$k] = $v;
+        if (null === $params) {
+            return $params;
         }
-      }
-      return $formatted;
+        $formatted = [];
+        foreach ($params as $k => $v) {
+            if (null === $v) {
+                $formatted[$k] = '';
+            } else {
+                $formatted[$k] = $v;
+            }
+        }
+
+        return $formatted;
     }
 
     protected function request($method, $path, $params, $opts)

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -32,9 +32,22 @@ abstract class AbstractService
         return $this->client;
     }
 
+    private static function formatParams($params)
+    {
+      $formatted = [];
+      foreach ($params as $k => $v) {
+        if (null === $v) {
+          $formatted[$k] = "";
+        } else {
+          $formatted[$k] = $v;
+        }
+      }
+      return $formatted;
+    }
+
     protected function request($method, $path, $params, $opts)
     {
-        return $this->getClient()->request($method, $path, $params, $opts);
+        return $this->getClient()->request($method, $path, static::formatParams($params), $opts);
     }
 
     protected function buildPath($basePath, ...$ids)

--- a/lib/Service/AbstractServiceFactory.php
+++ b/lib/Service/AbstractServiceFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Abstract base class for all service factories used to expose service
+ * instances through {@link \Stripe\StripeClient}.
+ *
+ * Service factories serve two purposes:
+ *
+ * 1. Expose properties for all services through the `__get()` magic method.
+ * 2. Lazily initialize each service instance the first time the property for
+ *    a given service is used.
+ */
+abstract class AbstractServiceFactory
+{
+    /** @var \Stripe\StripeClientInterface */
+    private $client;
+
+    /** @var array<string, AbstractService|AbstractServiceFactory> */
+    private $services;
+
+    /**
+     * @param \Stripe\StripeClientInterface $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+        $this->services = [];
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return null|string
+     */
+    abstract protected function getServiceClass($name);
+
+    /**
+     * @param string $name
+     *
+     * @return null|AbstractService|AbstractServiceFactory
+     */
+    public function __get($name)
+    {
+        $serviceClass = $this->getServiceClass($name);
+        if (null !== $serviceClass) {
+            if (!\array_key_exists($name, $this->services)) {
+                $this->services[$name] = new $serviceClass($this->client);
+            }
+
+            return $this->services[$name];
+        }
+
+        \trigger_error('Undefined property: ' . static::class . '::$' . $name);
+
+        return null;
+    }
+}

--- a/lib/Service/AccountLinkService.php
+++ b/lib/Service/AccountLinkService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service;
+
+class AccountLinkService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Creates an AccountLink object that returns a single-use Stripe URL that the user
+     * can redirect their user to in order to take them through the Connect Onboarding
+     * flow.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AccountLink
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/account_links', $params, $opts);
+    }
+}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace Stripe\Service;
+
+class AccountService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of accounts connected to your platform via <a
+     * href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/accounts', $params, $opts);
+    }
+
+    /**
+     * Returns a list of capabilities associated with the account. The capabilities are
+     * returned sorted by creation date, with the most recent capability appearing
+     * first.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allCapabilities($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/capabilities', $parentId), $params, $opts);
+    }
+
+    /**
+     * List external accounts for an account.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allExternalAccounts($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/external_accounts', $parentId), $params, $opts);
+    }
+
+    /**
+     * Returns a list of people associated with the account’s legal entity. The people
+     * are returned sorted by creation date, with the most recent people appearing
+     * first.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allPersons($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/persons', $parentId), $params, $opts);
+    }
+
+    /**
+     * With <a href="/docs/connect">Connect</a>, you can create Stripe accounts for
+     * your users. To do this, you’ll first need to <a
+     * href="https://dashboard.stripe.com/account/applications/settings">register your
+     * platform</a>.
+     *
+     * For Standard accounts, parameters other than <code>country</code>,
+     * <code>email</code>, and <code>type</code> are used to prefill the account
+     * application that we ask the account holder to complete.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Account
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/accounts', $params, $opts);
+    }
+
+    /**
+     * Create an external account for a given account.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card
+     */
+    public function createExternalAccount($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/external_accounts', $parentId), $params, $opts);
+    }
+
+    /**
+     * Creates a single-use login link for an Express account to access their Stripe
+     * dashboard.
+     *
+     * <strong>You may only create login links for <a
+     * href="/docs/connect/express-accounts">Express accounts</a> connected to your
+     * platform</strong>.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\LoginLink
+     */
+    public function createLoginLink($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/login_links', $parentId), $params, $opts);
+    }
+
+    /**
+     * Creates a new person.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Person
+     */
+    public function createPerson($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/persons', $parentId), $params, $opts);
+    }
+
+    /**
+     * With <a href="/docs/connect">Connect</a>, you can delete Custom or Express
+     * accounts you manage.
+     *
+     * Accounts created using test-mode keys can be deleted at any time. Accounts
+     * created using live-mode keys can only be deleted once all balances are zero.
+     *
+     * If you want to delete your own account, use the <a
+     * href="https://dashboard.stripe.com/account">account information tab in your
+     * account settings</a> instead.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Account
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/accounts/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Delete a specified external account for a given account.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card
+     */
+    public function deleteExternalAccount($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/accounts/%s/external_accounts/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Deletes an existing person’s relationship to the account’s legal entity. Any
+     * person with a relationship for an account can be deleted through the API, except
+     * if the person is the <code>account_opener</code>. If your integration is using
+     * the <code>executive</code> parameter, you cannot delete the only verified
+     * <code>executive</code> on file.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Person
+     */
+    public function deletePerson($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/accounts/%s/persons/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * With <a href="/docs/connect">Connect</a>, you may flag accounts as suspicious.
+     *
+     * Test-mode Custom and Express accounts can be rejected at any time. Accounts
+     * created using live-mode keys may only be rejected once all balances are zero.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Account
+     */
+    public function reject($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/reject', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves information about the specified Account Capability.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Capability
+     */
+    public function retrieveCapability($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/capabilities/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Retrieve a specified external account for a given account.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card
+     */
+    public function retrieveExternalAccount($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/external_accounts/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves an existing person.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Person
+     */
+    public function retrievePerson($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/accounts/%s/persons/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Updates a connected <a href="/docs/connect/accounts">Express or Custom
+     * account</a> by setting the values of the parameters passed. Any parameters not
+     * provided are left unchanged. Most parameters can be changed only for Custom
+     * accounts. (These are marked <strong>Custom Only</strong> below.) Parameters
+     * marked <strong>Custom and Express</strong> are supported by both account types.
+     *
+     * To update your own account, use the <a
+     * href="https://dashboard.stripe.com/account">Dashboard</a>. Refer to our <a
+     * href="/docs/connect/updating-accounts">Connect</a> documentation to learn more
+     * about updating accounts.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Account
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing Account Capability.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Capability
+     */
+    public function updateCapability($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/capabilities/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Updates the metadata, account holder name, and account holder type of a bank
+     * account belonging to a <a href="/docs/connect/custom-accounts">Custom
+     * account</a>, and optionally sets it as the default for its currency. Other bank
+     * account details are not editable by design.</p> <p>You can re-enable a disabled
+     * bank account by performing an update call without providing any arguments or
+     * changes.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card
+     */
+    public function updateExternalAccount($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/external_accounts/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing person.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Person
+     */
+    public function updatePerson($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/accounts/%s/persons/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an account.
+     *
+     * @param null|string $id
+     * @param null|array $params
+     * @param null|array|StripeUtilRequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Account
+     */
+    public function retrieve($id = null, $params = null, $opts = null)
+    {
+        if (null === $id) {
+            return $this->request('get', '/v1/account', $params, $opts);
+        }
+
+        return $this->request('get', $this->buildPath('/v1/accounts/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -175,9 +175,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Delete a specified external account for a given account.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -196,9 +196,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * <code>executive</code> on file.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -232,9 +232,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Retrieves information about the specified Account Capability.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -249,9 +249,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Retrieve a specified external account for a given account.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -266,9 +266,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Retrieves an existing person.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -308,9 +308,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Updates an existing Account Capability.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -330,9 +330,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * changes.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -347,9 +347,9 @@ class AccountService extends \Stripe\Service\AbstractService
      * Updates an existing person.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -78,10 +78,6 @@ class AccountService extends \Stripe\Service\AbstractService
      * href="https://dashboard.stripe.com/account/applications/settings">register your
      * platform</a>.
      *
-     * For Standard accounts, parameters other than <code>country</code>,
-     * <code>email</code>, and <code>type</code> are used to prefill the account
-     * application that we ask the account holder to complete.
-     *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
      *

--- a/lib/Service/ApplePayDomainService.php
+++ b/lib/Service/ApplePayDomainService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Stripe\Service;
+
+class ApplePayDomainService extends \Stripe\Service\AbstractService
+{
+    /**
+     * List apple pay domains.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/apple_pay/domains', $params, $opts);
+    }
+
+    /**
+     * Create an apple pay domain.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplePayDomain
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/apple_pay/domains', $params, $opts);
+    }
+
+    /**
+     * Delete an apple pay domain.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplePayDomain
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/apple_pay/domains/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieve an apple pay domain.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplePayDomain
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/apple_pay/domains/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/ApplicationFeeService.php
+++ b/lib/Service/ApplicationFeeService.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Stripe\Service;
+
+class ApplicationFeeService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of application fees you’ve previously collected. The application
+     * fees are returned in sorted order, with the most recent fees appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/application_fees', $params, $opts);
+    }
+
+    /**
+     * You can see a list of the refunds belonging to a specific application fee. Note
+     * that the 10 most recent refunds are always available by default on the
+     * application fee object. If you need more than those 10, you can use this API
+     * method and the <code>limit</code> and <code>starting_after</code> parameters to
+     * page through additional refunds.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allRefunds($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/application_fees/%s/refunds', $parentId), $params, $opts);
+    }
+
+    /**
+     * Refunds an application fee that has previously been collected but not yet
+     * refunded. Funds will be refunded to the Stripe account from which the fee was
+     * originally collected.
+     *
+     * You can optionally refund only part of an application fee. You can do so
+     * multiple times, until the entire fee has been refunded.
+     *
+     * Once entirely refunded, an application fee can’t be refunded again. This method
+     * will raise an error when called on an already-refunded application fee, or when
+     * trying to refund more money than is left on an application fee.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplicationFeeRefund
+     */
+    public function createRefund($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/application_fees/%s/refunds', $parentId), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an application fee that your account has collected. The
+     * same information is returned when refunding the application fee.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplicationFee
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/application_fees/%s', $id), $params, $opts);
+    }
+
+    /**
+     * By default, you can see the 10 most recent refunds stored directly on the
+     * application fee object, but you can also retrieve details about a specific
+     * refund stored on the application fee.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplicationFeeRefund
+     */
+    public function retrieveRefund($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/application_fees/%s/refunds/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified application fee refund by setting the values of the
+     * parameters passed. Any parameters not provided will be left unchanged.
+     *
+     * This request only accepts metadata as an argument.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ApplicationFeeRefund
+     */
+    public function updateRefund($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/application_fees/%s/refunds/%s', $parentId, $id), $params, $opts);
+    }
+}

--- a/lib/Service/ApplicationFeeService.php
+++ b/lib/Service/ApplicationFeeService.php
@@ -88,9 +88,9 @@ class ApplicationFeeService extends \Stripe\Service\AbstractService
      * refund stored on the application fee.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -108,9 +108,9 @@ class ApplicationFeeService extends \Stripe\Service\AbstractService
      * This request only accepts metadata as an argument.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *

--- a/lib/Service/BalanceService.php
+++ b/lib/Service/BalanceService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Stripe\Service;
+
+class BalanceService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Retrieves the current account balance, based on the authentication that was used
+     * to make the request.  For a sample request, see <a
+     * href="/docs/connect/account-balances#accounting-for-negative-balances">Accounting
+     * for negative balances</a>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Balance
+     */
+    public function retrieve($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/balance', $params, $opts);
+    }
+}

--- a/lib/Service/BalanceTransactionService.php
+++ b/lib/Service/BalanceTransactionService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Stripe\Service;
+
+class BalanceTransactionService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of transactions that have contributed to the Stripe account
+     * balance (e.g., charges, transfers, and so forth). The transactions are returned
+     * in sorted order, with the most recent transactions appearing first.
+     *
+     * Note that this endpoint was previously called “Balance history” and used the
+     * path <code>/v1/balance/history</code>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/balance_transactions', $params, $opts);
+    }
+
+    /**
+     * Retrieves the balance transaction with the given ID.
+     *
+     * Note that this endpoint previously used the path
+     * <code>/v1/balance/history/:id</code>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BalanceTransaction
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/balance_transactions/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/BillingPortal/BillingPortalServiceFactory.php
+++ b/lib/Service/BillingPortal/BillingPortalServiceFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\BillingPortal;
+
+/**
+ * Service factory class for API resources in the BillingPortal namespace.
+ *
+ * @property SessionService $sessions
+ */
+class BillingPortalServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'sessions' => SessionService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/BillingPortal/SessionService.php
+++ b/lib/Service/BillingPortal/SessionService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Stripe\Service\BillingPortal;
+
+class SessionService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Creates a session of the self-serve Portal.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\BillingPortal\Session
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/billing_portal/sessions', $params, $opts);
+    }
+}

--- a/lib/Service/ChargeService.php
+++ b/lib/Service/ChargeService.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Stripe\Service;
+
+class ChargeService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of charges you’ve previously created. The charges are returned in
+     * sorted order, with the most recent charges appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/charges', $params, $opts);
+    }
+
+    /**
+     * Capture the payment of an existing, uncaptured, charge. This is the second half
+     * of the two-step payment flow, where first you <a href="#create_charge">created a
+     * charge</a> with the capture option set to false.
+     *
+     * Uncaptured payments expire exactly seven days after they are created. If they
+     * are not captured by that point in time, they will be marked as refunded and will
+     * no longer be capturable.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Charge
+     */
+    public function capture($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/charges/%s/capture', $id), $params, $opts);
+    }
+
+    /**
+     * To charge a credit card or other payment source, you create a
+     * <code>Charge</code> object. If your API key is in test mode, the supplied
+     * payment source (e.g., card) won’t actually be charged, although everything else
+     * will occur as if in live mode. (Stripe assumes that the charge would have
+     * completed successfully).
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Charge
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/charges', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of a charge that has previously been created. Supply the
+     * unique charge ID that was returned from your previous request, and Stripe will
+     * return the corresponding charge information. The same information is returned
+     * when creating or refunding the charge.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Charge
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/charges/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified charge by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Charge
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/charges/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Checkout/CheckoutServiceFactory.php
+++ b/lib/Service/Checkout/CheckoutServiceFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\Checkout;
+
+/**
+ * Service factory class for API resources in the Checkout namespace.
+ *
+ * @property SessionService $sessions
+ */
+class CheckoutServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'sessions' => SessionService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Checkout/SessionService.php
+++ b/lib/Service/Checkout/SessionService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Stripe\Service\Checkout;
+
+class SessionService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Checkout Sessions.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/checkout/sessions', $params, $opts);
+    }
+
+    /**
+     * Creates a Session object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Checkout\Session
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/checkout/sessions', $params, $opts);
+    }
+
+    /**
+     * Retrieves a Session object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Checkout\Session
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/checkout/sessions/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Checkout/SessionService.php
+++ b/lib/Service/Checkout/SessionService.php
@@ -20,6 +20,25 @@ class SessionService extends \Stripe\Service\AbstractService
     }
 
     /**
+     * When retrieving a Checkout Session, there is an includable
+     * <strong>line_items</strong> property containing the first handful of those
+     * items. There is also a URL where you can retrieve the full (paginated) list of
+     * line items.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allLineItems($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/checkout/sessions/%s/line_items', $parentId), $params, $opts);
+    }
+
+    /**
      * Creates a Session object.
      *
      * @param null|array $params

--- a/lib/Service/CoreServiceFactory.php
+++ b/lib/Service/CoreServiceFactory.php
@@ -11,6 +11,7 @@ namespace Stripe\Service;
  * @property ApplicationFeeService $applicationFees
  * @property BalanceTransactionService $balanceTransactions
  * @property BalanceService $balances
+ * @property BillingPortal\BillingPortalServiceFactory $billingPortal
  * @property ChargeService $charges
  * @property Checkout\CheckoutServiceFactory $checkout
  * @property CountrySpecService $countrySpecs
@@ -33,6 +34,7 @@ namespace Stripe\Service;
  * @property PaymentMethodService $paymentMethods
  * @property PayoutService $payouts
  * @property PlanService $plans
+ * @property PriceService $prices
  * @property ProductService $products
  * @property Radar\RadarServiceFactory $radar
  * @property RefundService $refunds
@@ -64,6 +66,7 @@ class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
         'applicationFees' => ApplicationFeeService::class,
         'balanceTransactions' => BalanceTransactionService::class,
         'balances' => BalanceService::class,
+        'billingPortal' => BillingPortal\BillingPortalServiceFactory::class,
         'charges' => ChargeService::class,
         'checkout' => Checkout\CheckoutServiceFactory::class,
         'countrySpecs' => CountrySpecService::class,
@@ -86,6 +89,7 @@ class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
         'paymentMethods' => PaymentMethodService::class,
         'payouts' => PayoutService::class,
         'plans' => PlanService::class,
+        'prices' => PriceService::class,
         'products' => ProductService::class,
         'radar' => Radar\RadarServiceFactory::class,
         'refunds' => RefundService::class,

--- a/lib/Service/CoreServiceFactory.php
+++ b/lib/Service/CoreServiceFactory.php
@@ -9,8 +9,8 @@ namespace Stripe\Service;
  * @property AccountService $accounts
  * @property ApplePayDomainService $applePayDomains
  * @property ApplicationFeeService $applicationFees
- * @property BalanceTransactionService $balanceTransactions
  * @property BalanceService $balances
+ * @property BalanceTransactionService $balanceTransactions
  * @property BillingPortal\BillingPortalServiceFactory $billingPortal
  * @property ChargeService $charges
  * @property Checkout\CheckoutServiceFactory $checkout
@@ -45,8 +45,8 @@ namespace Stripe\Service;
  * @property SkuService $skus
  * @property SourceService $sources
  * @property SubscriptionItemService $subscriptionItems
- * @property SubscriptionScheduleService $subscriptionSchedules
  * @property SubscriptionService $subscriptions
+ * @property SubscriptionScheduleService $subscriptionSchedules
  * @property TaxRateService $taxRates
  * @property Terminal\TerminalServiceFactory $terminal
  * @property TokenService $tokens
@@ -64,8 +64,8 @@ class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
         'accounts' => AccountService::class,
         'applePayDomains' => ApplePayDomainService::class,
         'applicationFees' => ApplicationFeeService::class,
-        'balanceTransactions' => BalanceTransactionService::class,
         'balances' => BalanceService::class,
+        'balanceTransactions' => BalanceTransactionService::class,
         'billingPortal' => BillingPortal\BillingPortalServiceFactory::class,
         'charges' => ChargeService::class,
         'checkout' => Checkout\CheckoutServiceFactory::class,
@@ -100,8 +100,8 @@ class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
         'skus' => SkuService::class,
         'sources' => SourceService::class,
         'subscriptionItems' => SubscriptionItemService::class,
-        'subscriptionSchedules' => SubscriptionScheduleService::class,
         'subscriptions' => SubscriptionService::class,
+        'subscriptionSchedules' => SubscriptionScheduleService::class,
         'taxRates' => TaxRateService::class,
         'terminal' => Terminal\TerminalServiceFactory::class,
         'tokens' => TokenService::class,

--- a/lib/Service/CoreServiceFactory.php
+++ b/lib/Service/CoreServiceFactory.php
@@ -9,7 +9,7 @@ namespace Stripe\Service;
  * @property AccountService $accounts
  * @property ApplePayDomainService $applePayDomains
  * @property ApplicationFeeService $applicationFees
- * @property BalanceService $balances
+ * @property BalanceService $balance
  * @property BalanceTransactionService $balanceTransactions
  * @property BillingPortal\BillingPortalServiceFactory $billingPortal
  * @property ChargeService $charges
@@ -64,7 +64,7 @@ class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
         'accounts' => AccountService::class,
         'applePayDomains' => ApplePayDomainService::class,
         'applicationFees' => ApplicationFeeService::class,
-        'balances' => BalanceService::class,
+        'balance' => BalanceService::class,
         'balanceTransactions' => BalanceTransactionService::class,
         'billingPortal' => BillingPortal\BillingPortalServiceFactory::class,
         'charges' => ChargeService::class,

--- a/lib/Service/CoreServiceFactory.php
+++ b/lib/Service/CoreServiceFactory.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Service factory class for API resources in the root namespace.
+ *
+ * @property AccountLinkService $accountLinks
+ * @property AccountService $accounts
+ * @property ApplePayDomainService $applePayDomains
+ * @property ApplicationFeeService $applicationFees
+ * @property BalanceTransactionService $balanceTransactions
+ * @property BalanceService $balances
+ * @property ChargeService $charges
+ * @property Checkout\CheckoutServiceFactory $checkout
+ * @property CountrySpecService $countrySpecs
+ * @property CouponService $coupons
+ * @property CreditNoteService $creditNotes
+ * @property CustomerService $customers
+ * @property DisputeService $disputes
+ * @property EphemeralKeyService $ephemeralKeys
+ * @property EventService $events
+ * @property ExchangeRateService $exchangeRates
+ * @property FileLinkService $fileLinks
+ * @property FileService $files
+ * @property InvoiceItemService $invoiceItems
+ * @property InvoiceService $invoices
+ * @property Issuing\IssuingServiceFactory $issuing
+ * @property MandateService $mandates
+ * @property OrderReturnService $orderReturns
+ * @property OrderService $orders
+ * @property PaymentIntentService $paymentIntents
+ * @property PaymentMethodService $paymentMethods
+ * @property PayoutService $payouts
+ * @property PlanService $plans
+ * @property ProductService $products
+ * @property Radar\RadarServiceFactory $radar
+ * @property RefundService $refunds
+ * @property Reporting\ReportingServiceFactory $reporting
+ * @property ReviewService $reviews
+ * @property SetupIntentService $setupIntents
+ * @property Sigma\SigmaServiceFactory $sigma
+ * @property SkuService $skus
+ * @property SourceService $sources
+ * @property SubscriptionItemService $subscriptionItems
+ * @property SubscriptionScheduleService $subscriptionSchedules
+ * @property SubscriptionService $subscriptions
+ * @property TaxRateService $taxRates
+ * @property Terminal\TerminalServiceFactory $terminal
+ * @property TokenService $tokens
+ * @property TopupService $topups
+ * @property TransferService $transfers
+ * @property WebhookEndpointService $webhookEndpoints
+ */
+class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'accountLinks' => AccountLinkService::class,
+        'accounts' => AccountService::class,
+        'applePayDomains' => ApplePayDomainService::class,
+        'applicationFees' => ApplicationFeeService::class,
+        'balanceTransactions' => BalanceTransactionService::class,
+        'balances' => BalanceService::class,
+        'charges' => ChargeService::class,
+        'checkout' => Checkout\CheckoutServiceFactory::class,
+        'countrySpecs' => CountrySpecService::class,
+        'coupons' => CouponService::class,
+        'creditNotes' => CreditNoteService::class,
+        'customers' => CustomerService::class,
+        'disputes' => DisputeService::class,
+        'ephemeralKeys' => EphemeralKeyService::class,
+        'events' => EventService::class,
+        'exchangeRates' => ExchangeRateService::class,
+        'fileLinks' => FileLinkService::class,
+        'files' => FileService::class,
+        'invoiceItems' => InvoiceItemService::class,
+        'invoices' => InvoiceService::class,
+        'issuing' => Issuing\IssuingServiceFactory::class,
+        'mandates' => MandateService::class,
+        'orderReturns' => OrderReturnService::class,
+        'orders' => OrderService::class,
+        'paymentIntents' => PaymentIntentService::class,
+        'paymentMethods' => PaymentMethodService::class,
+        'payouts' => PayoutService::class,
+        'plans' => PlanService::class,
+        'products' => ProductService::class,
+        'radar' => Radar\RadarServiceFactory::class,
+        'refunds' => RefundService::class,
+        'reporting' => Reporting\ReportingServiceFactory::class,
+        'reviews' => ReviewService::class,
+        'setupIntents' => SetupIntentService::class,
+        'sigma' => Sigma\SigmaServiceFactory::class,
+        'skus' => SkuService::class,
+        'sources' => SourceService::class,
+        'subscriptionItems' => SubscriptionItemService::class,
+        'subscriptionSchedules' => SubscriptionScheduleService::class,
+        'subscriptions' => SubscriptionService::class,
+        'taxRates' => TaxRateService::class,
+        'terminal' => Terminal\TerminalServiceFactory::class,
+        'tokens' => TokenService::class,
+        'topups' => TopupService::class,
+        'transfers' => TransferService::class,
+        'webhookEndpoints' => WebhookEndpointService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/CountrySpecService.php
+++ b/lib/Service/CountrySpecService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service;
+
+class CountrySpecService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Lists all Country Spec objects available in the API.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/country_specs', $params, $opts);
+    }
+
+    /**
+     * Returns a Country Spec for a given Country code.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CountrySpec
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/country_specs/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/CouponService.php
+++ b/lib/Service/CouponService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Stripe\Service;
+
+class CouponService extends AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/coupons';
+    }
+
+    /**
+     * List all coupons.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a coupon.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Coupon
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Delete a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Coupon
+     */
+    public function delete($id, $params = [], $opts = [])
+    {
+        return $this->deleteObject($id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Coupon
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Coupon
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Service/CouponService.php
+++ b/lib/Service/CouponService.php
@@ -2,13 +2,15 @@
 
 namespace Stripe\Service;
 
-class CouponService extends AbstractService
+class CouponService extends \Stripe\Service\AbstractService
 {
     /**
-     * List all coupons.
+     * Returns a list of your coupons.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -18,10 +20,25 @@ class CouponService extends AbstractService
     }
 
     /**
-     * Create a coupon.
+     * You can create coupons easily via the <a
+     * href="https://dashboard.stripe.com/coupons">coupon management</a> page of the
+     * Stripe dashboard. Coupon creation is also accessible via the API if you need to
+     * create coupons on the fly.
+     *
+     * A coupon has either a <code>percent_off</code> or an <code>amount_off</code> and
+     * <code>currency</code>. If you set an <code>amount_off</code>, that amount will
+     * be subtracted from any invoice’s subtotal. For example, an invoice with a
+     * subtotal of <currency>100</currency> will have a final total of
+     * <currency>0</currency> if a coupon with an <code>amount_off</code> of
+     * <amount>200</amount> is applied to it and an invoice with a subtotal of
+     * <currency>300</currency> will have a final total of <currency>100</currency> if
+     * a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to
+     * it.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Coupon
      */
@@ -31,11 +48,17 @@ class CouponService extends AbstractService
     }
 
     /**
-     * Delete a coupon.
+     * You can delete coupons via the <a
+     * href="https://dashboard.stripe.com/coupons">coupon management</a> page of the
+     * Stripe dashboard. However, deleting a coupon does not affect any customers who
+     * have already applied the coupon; it means that new customers can’t redeem the
+     * coupon. You can also delete coupons via the API.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Coupon
      */
@@ -45,11 +68,13 @@ class CouponService extends AbstractService
     }
 
     /**
-     * Retrieve a coupon.
+     * Retrieves the coupon with the given ID.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Coupon
      */
@@ -59,11 +84,14 @@ class CouponService extends AbstractService
     }
 
     /**
-     * Update a coupon.
+     * Updates the metadata of a coupon. Other coupon details (currency, duration,
+     * amount_off) are, by design, not editable.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Coupon
      */

--- a/lib/Service/CouponService.php
+++ b/lib/Service/CouponService.php
@@ -4,76 +4,71 @@ namespace Stripe\Service;
 
 class CouponService extends AbstractService
 {
-    public function basePath()
-    {
-        return '/v1/coupons';
-    }
-
     /**
      * List all coupons.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function all($params = [], $opts = [])
+    public function all($params = null, $opts = null)
     {
-        return $this->allObjects($params, $opts);
+        return $this->request('get', '/v1/coupons', $params, $opts);
     }
 
     /**
      * Create a coupon.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Coupon
      */
-    public function create($params = [], $opts = [])
+    public function create($params = null, $opts = null)
     {
-        return $this->createObject($params, $opts);
+        return $this->request('post', '/v1/coupons', $params, $opts);
     }
 
     /**
      * Delete a coupon.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Coupon
      */
-    public function delete($id, $params = [], $opts = [])
+    public function delete($id, $params = null, $opts = null)
     {
-        return $this->deleteObject($id, $params, $opts);
+        return $this->request('delete', $this->buildPath('/v1/coupons/%s', $id), $params, $opts);
     }
 
     /**
      * Retrieve a coupon.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Coupon
      */
-    public function retrieve($id, $params = [], $opts = [])
+    public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->retrieveObject($id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/coupons/%s', $id), $params, $opts);
     }
 
     /**
      * Update a coupon.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Coupon
      */
-    public function update($id, $params = [], $opts = [])
+    public function update($id, $params = null, $opts = null)
     {
-        return $this->updateObject($id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/coupons/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/CreditNoteService.php
+++ b/lib/Service/CreditNoteService.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Stripe\Service;
+
+class CreditNoteService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of credit notes.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/credit_notes', $params, $opts);
+    }
+
+    /**
+     * When retrieving a credit note, you’ll get a <strong>lines</strong> property
+     * containing the the first handful of those items. There is also a URL where you
+     * can retrieve the full (paginated) list of line items.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allLines($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/credit_notes/%s/lines', $parentId), $params, $opts);
+    }
+
+    /**
+     * Issue a credit note to adjust the amount of a finalized invoice. For a
+     * <code>status=open</code> invoice, a credit note reduces its
+     * <code>amount_due</code>. For a <code>status=paid</code> invoice, a credit note
+     * does not affect its <code>amount_due</code>. Instead, it can result in any
+     * combination of the following:.
+     *
+     * <ul>  <li>Refund: create a new refund (using <code>refund_amount</code>) or link
+     * an existing refund (using <code>refund</code>).</li>  <li>Customer balance
+     * credit: credit the customer’s balance (using <code>credit_amount</code>) which
+     * will be automatically applied to their next invoice when it’s finalized.</li>
+     * <li>Outside of Stripe credit: record the amount that is or will be credited
+     * outside of Stripe (using <code>out_of_band_amount</code>).</li> </ul>
+     *
+     * For post-payment credit notes the sum of the refund, credit and outside of
+     * Stripe amounts must equal the credit note total.
+     *
+     * You may issue multiple credit notes for an invoice. Each credit note will
+     * increment the invoice’s <code>pre_payment_credit_notes_amount</code> or
+     * <code>post_payment_credit_notes_amount</code> depending on its
+     * <code>status</code> at the time of credit note creation.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/credit_notes', $params, $opts);
+    }
+
+    /**
+     * Get a preview of a credit note without creating it.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function preview($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/credit_notes/preview', $params, $opts);
+    }
+
+    /**
+     * When retrieving a credit note preview, you’ll get a <strong>lines</strong>
+     * property containing the first handful of those items. This URL you can retrieve
+     * the full (paginated) list of line items.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function previewLines($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/credit_notes/preview/lines', $params, $opts);
+    }
+
+    /**
+     * Retrieves the credit note object with the given identifier.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/credit_notes/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing credit note.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/credit_notes/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Marks a credit note as void. Learn more about <a
+     * href="/docs/billing/invoices/credit-notes#voiding">voiding credit notes</a>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CreditNote
+     */
+    public function voidCreditNote($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/credit_notes/%s/void', $id), $params, $opts);
+    }
+}

--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -2,13 +2,16 @@
 
 namespace Stripe\Service;
 
-class CustomerService extends AbstractService
+class CustomerService extends \Stripe\Service\AbstractService
 {
     /**
-     * List all customers.
+     * Returns a list of your customers. The customers are returned sorted by creation
+     * date, with the most recent customers appearing first.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -18,11 +21,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * List customer balance transactions.
+     * Returns a list of transactions that updated the customer’s <a
+     * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -32,11 +38,13 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * List all sources.
+     * List sources for a specified customer.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -46,11 +54,13 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * List all tax IDs.
+     * Returns a list of tax IDs for a customer.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -60,10 +70,12 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Create a customer.
+     * Creates a new customer object.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Customer
      */
@@ -73,11 +85,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Create a balance transaction.
+     * Creates an immutable transaction that updates the customer’s <a
+     * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
@@ -87,13 +102,21 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Create a source.
+     * When you create a new credit card, you must specify a customer or recipient on
+     * which to create it.
+     *
+     * If the card’s owner has no default card, then the new card will become the
+     * default. However, if the owner already has a default, then it will not change.
+     * To change the default, you should <a href="/docs/api#update_customer">update the
+     * customer</a> to have a new <code>default_source</code>.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
      *
-     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AlipayAccount|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
      */
     public function createSource($parentId, $params = null, $opts = null)
     {
@@ -101,11 +124,13 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Create a tax ID.
+     * Creates a new <code>TaxID</code> object for a customer.
      *
      * @param string $parentId
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\TaxId
      */
@@ -115,11 +140,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Delete a customer.
+     * Permanently deletes a customer. It cannot be undone. Also immediately cancels
+     * any active subscriptions on the customer.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Customer
      */
@@ -129,13 +157,15 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Delete a customer discount.
+     * Removes the currently applied discount on a customer.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
      *
-     * @return \Stripe\Discount
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Customer
      */
     public function deleteDiscount($id, $params = null, $opts = null)
     {
@@ -143,14 +173,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Delete a source.
-     *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
      *
-     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AlipayAccount|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
      */
     public function deleteSource($parentId, $id, $params = null, $opts = null)
     {
@@ -158,12 +188,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Delete a tax ID.
+     * Deletes an existing <code>TaxID</code> object.
      *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\TaxId
      */
@@ -173,11 +205,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Retrieve a customer.
+     * Retrieves the details of an existing customer. You need only supply the unique
+     * customer identifier that was returned upon customer creation.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Customer
      */
@@ -187,12 +222,15 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Retrieve a balance transaction.
+     * Retrieves a specific transaction that updated the customer’s <a
+     * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
      *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
@@ -202,14 +240,16 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Retrieve a source.
+     * Retrieve a specified source for a given customer.
      *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
      *
-     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AlipayAccount|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
      */
     public function retrieveSource($parentId, $id, $params = null, $opts = null)
     {
@@ -217,12 +257,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Retrieve a tax ID.
+     * Retrieves the <code>TaxID</code> object with the given identifier.
      *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\TaxId
      */
@@ -232,11 +274,25 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Update a customer.
+     * Updates the specified customer by setting the values of the parameters passed.
+     * Any parameters not provided will be left unchanged. For example, if you pass the
+     * <strong>source</strong> parameter, that becomes the customer’s active source
+     * (e.g., a card) to be used for all charges in the future. When you update a
+     * customer to a new valid card source by passing the <strong>source</strong>
+     * parameter: for each of the customer’s current subscriptions, if the subscription
+     * bills automatically and is in the <code>past_due</code> state, then the latest
+     * open invoice for the subscription with automatic collection enabled will be
+     * retried. This retry will not count as an automatic retry, and will not affect
+     * the next regularly scheduled payment for the invoice. Changing the
+     * <strong>default_source</strong> for a customer will not trigger this behavior.
+     *
+     * This request accepts mostly the same arguments as the customer creation call.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Customer
      */
@@ -246,12 +302,15 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Update a balance transaction.
+     * Most customer balance transaction fields are immutable, but you may update its
+     * <code>description</code> and <code>metadata</code>.
      *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
@@ -261,14 +320,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Update a source.
-     *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
      *
-     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AlipayAccount|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
      */
     public function updateSource($parentId, $id, $params = null, $opts = null)
     {
@@ -276,14 +335,14 @@ class CustomerService extends AbstractService
     }
 
     /**
-     * Verify a source.
-     *
      * @param string $parentId
-     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
      *
-     * @return \Stripe\BankAccount
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\AlipayAccount|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
      */
     public function verifySource($parentId, $id, $params = null, $opts = null)
     {

--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -4,303 +4,289 @@ namespace Stripe\Service;
 
 class CustomerService extends AbstractService
 {
-    const BALANCE_TRANSACTIONS = 'balance_transactions';
-    const SOURCES = 'sources';
-    const TAX_IDS = 'tax_ids';
-
-    public function basePath()
-    {
-        return '/v1/customers';
-    }
-
     /**
      * List all customers.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function all($params = [], $opts = [])
+    public function all($params = null, $opts = null)
     {
-        return $this->allObjects($params, $opts);
+        return $this->request('get', '/v1/customers', $params, $opts);
     }
 
     /**
      * List customer balance transactions.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function allBalanceTransactions($customerId, $params = [], $opts = [])
+    public function allBalanceTransactions($parentId, $params = null, $opts = null)
     {
-        return $this->allNestedObjects(self::BALANCE_TRANSACTIONS, $customerId, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/balance_transactions', $parentId), $params, $opts);
     }
 
     /**
      * List all sources.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function allSources($customerId, $params = [], $opts = [])
+    public function allSources($parentId, $params = null, $opts = null)
     {
-        return $this->allNestedObjects(self::SOURCES, $customerId, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/sources', $parentId), $params, $opts);
     }
 
     /**
      * List all tax IDs.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function allTaxIds($customerId, $params = [], $opts = [])
+    public function allTaxIds($parentId, $params = null, $opts = null)
     {
-        return $this->allNestedObjects(self::TAX_IDS, $customerId, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/tax_ids', $parentId), $params, $opts);
     }
 
     /**
      * Create a customer.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Customer
      */
-    public function create($params = [], $opts = [])
+    public function create($params = null, $opts = null)
     {
-        return $this->createObject($params, $opts);
+        return $this->request('post', '/v1/customers', $params, $opts);
     }
 
     /**
      * Create a balance transaction.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
-    public function createBalanceTransaction($customerId, $params = [], $opts = [])
+    public function createBalanceTransaction($parentId, $params = null, $opts = null)
     {
-        return $this->createNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s/balance_transactions', $parentId), $params, $opts);
     }
 
     /**
      * Create a source.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
      */
-    public function createSource($customerId, $params = [], $opts = [])
+    public function createSource($parentId, $params = null, $opts = null)
     {
-        return $this->createNestedObject(self::SOURCES, $customerId, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s/sources', $parentId), $params, $opts);
     }
 
     /**
      * Create a tax ID.
      *
-     * @param string $customerId
-     * @param array $params
-     * @param array $opts
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\TaxId
      */
-    public function createTaxId($customerId, $params = [], $opts = [])
+    public function createTaxId($parentId, $params = null, $opts = null)
     {
-        return $this->createNestedObject(self::TAX_IDS, $customerId, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s/tax_ids', $parentId), $params, $opts);
     }
 
     /**
      * Delete a customer.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Customer
      */
-    public function delete($id, $params = [], $opts = [])
+    public function delete($id, $params = null, $opts = null)
     {
-        return $this->deleteObject($id, $params, $opts);
+        return $this->request('delete', $this->buildPath('/v1/customers/%s', $id), $params, $opts);
     }
 
     /**
      * Delete a customer discount.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Discount
      */
-    public function deleteDiscount($id, $params = [], $opts = [])
+    public function deleteDiscount($id, $params = null, $opts = null)
     {
-        return $this->request('delete', $this->instancePath($id) . '/discount', $params, $opts);
+        return $this->request('delete', $this->buildPath('/v1/customers/%s/discount', $id), $params, $opts);
     }
 
     /**
      * Delete a source.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
      */
-    public function deleteSource($customerId, $id, $params = [], $opts = [])
+    public function deleteSource($parentId, $id, $params = null, $opts = null)
     {
-        return $this->deleteNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+        return $this->request('delete', $this->buildPath('/v1/customers/%s/sources/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Delete a tax ID.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\TaxId
      */
-    public function deleteTaxId($customerId, $id, $params = [], $opts = [])
+    public function deleteTaxId($parentId, $id, $params = null, $opts = null)
     {
-        return $this->deleteNestedObject(self::TAX_IDS, $customerId, $id, $params, $opts);
+        return $this->request('delete', $this->buildPath('/v1/customers/%s/tax_ids/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Retrieve a customer.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Customer
      */
-    public function retrieve($id, $params = [], $opts = [])
+    public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->retrieveObject($id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s', $id), $params, $opts);
     }
 
     /**
      * Retrieve a balance transaction.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
-    public function retrieveBalanceTransaction($customerId, $id, $params = [], $opts = [])
+    public function retrieveBalanceTransaction($parentId, $id, $params = null, $opts = null)
     {
-        return $this->retrieveNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/balance_transactions/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Retrieve a source.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
      */
-    public function retrieveSource($customerId, $id, $params = [], $opts = [])
+    public function retrieveSource($parentId, $id, $params = null, $opts = null)
     {
-        return $this->retrieveNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/sources/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Retrieve a tax ID.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\TaxId
      */
-    public function retrieveTaxId($customerId, $id, $params = [], $opts = [])
+    public function retrieveTaxId($parentId, $id, $params = null, $opts = null)
     {
-        return $this->retrieveNestedObject(self::TAX_IDS, $customerId, $id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/customers/%s/tax_ids/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Update a customer.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Customer
      */
-    public function update($id, $params = [], $opts = [])
+    public function update($id, $params = null, $opts = null)
     {
-        return $this->updateObject($id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s', $id), $params, $opts);
     }
 
     /**
      * Update a balance transaction.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\CustomerBalanceTransaction
      */
-    public function updateBalanceTransaction($customerId, $id, $params = [], $opts = [])
+    public function updateBalanceTransaction($parentId, $id, $params = null, $opts = null)
     {
-        return $this->updateNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s/balance_transactions/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Update a source.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
      */
-    public function updateSource($customerId, $id, $params = [], $opts = [])
+    public function updateSource($parentId, $id, $params = null, $opts = null)
     {
-        return $this->updateNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/customers/%s/sources/%s', $parentId, $id), $params, $opts);
     }
 
     /**
      * Verify a source.
      *
-     * @param string $customerId
+     * @param string $parentId
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount
      */
-    public function verifySource($customerId, $id, $params = [], $opts = [])
+    public function verifySource($parentId, $id, $params = null, $opts = null)
     {
-        return $this->request(
-            'post',
-            $this->instanceNestedPath($customerId, self::SOURCES, $id) . '/verify',
-            $params,
-            $opts
-        );
+        return $this->request('post', $this->buildPath('/v1/customers/%s/sources/%s/verify', $parentId, $id), $params, $opts);
     }
 }

--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Stripe\Service;
+
+class CustomerService extends AbstractService
+{
+    const BALANCE_TRANSACTIONS = 'balance_transactions';
+    const SOURCES = 'sources';
+    const TAX_IDS = 'tax_ids';
+
+    public function basePath()
+    {
+        return '/v1/customers';
+    }
+
+    /**
+     * List all customers.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * List customer balance transactions.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function allBalanceTransactions($customerId, $params = [], $opts = [])
+    {
+        return $this->allNestedObjects(self::BALANCE_TRANSACTIONS, $customerId, $params, $opts);
+    }
+
+    /**
+     * List all sources.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function allSources($customerId, $params = [], $opts = [])
+    {
+        return $this->allNestedObjects(self::SOURCES, $customerId, $params, $opts);
+    }
+
+    /**
+     * List all tax IDs.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function allTaxIds($customerId, $params = [], $opts = [])
+    {
+        return $this->allNestedObjects(self::TAX_IDS, $customerId, $params, $opts);
+    }
+
+    /**
+     * Create a customer.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Customer
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Create a balance transaction.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\CustomerBalanceTransaction
+     */
+    public function createBalanceTransaction($customerId, $params = [], $opts = [])
+    {
+        return $this->createNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $params, $opts);
+    }
+
+    /**
+     * Create a source.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     */
+    public function createSource($customerId, $params = [], $opts = [])
+    {
+        return $this->createNestedObject(self::SOURCES, $customerId, $params, $opts);
+    }
+
+    /**
+     * Create a tax ID.
+     *
+     * @param string $customerId
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\TaxId
+     */
+    public function createTaxId($customerId, $params = [], $opts = [])
+    {
+        return $this->createNestedObject(self::TAX_IDS, $customerId, $params, $opts);
+    }
+
+    /**
+     * Delete a customer.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Customer
+     */
+    public function delete($id, $params = [], $opts = [])
+    {
+        return $this->deleteObject($id, $params, $opts);
+    }
+
+    /**
+     * Delete a customer discount.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Discount
+     */
+    public function deleteDiscount($id, $params = [], $opts = [])
+    {
+        return $this->request('delete', $this->instancePath($id) . '/discount', $params, $opts);
+    }
+
+    /**
+     * Delete a source.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     */
+    public function deleteSource($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->deleteNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Delete a tax ID.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\TaxId
+     */
+    public function deleteTaxId($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->deleteNestedObject(self::TAX_IDS, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a customer.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Customer
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a balance transaction.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\CustomerBalanceTransaction
+     */
+    public function retrieveBalanceTransaction($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->retrieveNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a source.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     */
+    public function retrieveSource($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->retrieveNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a tax ID.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\TaxId
+     */
+    public function retrieveTaxId($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->retrieveNestedObject(self::TAX_IDS, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Update a customer.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Customer
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a balance transaction.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\CustomerBalanceTransaction
+     */
+    public function updateBalanceTransaction($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->updateNestedObject(self::BALANCE_TRANSACTIONS, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Update a source.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\BankAccount|\Stripe\Card|\Stripe\Source
+     */
+    public function updateSource($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->updateNestedObject(self::SOURCES, $customerId, $id, $params, $opts);
+    }
+
+    /**
+     * Verify a source.
+     *
+     * @param string $customerId
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\BankAccount
+     */
+    public function verifySource($customerId, $id, $params = [], $opts = [])
+    {
+        return $this->request(
+            'post',
+            $this->instanceNestedPath($customerId, self::SOURCES, $id) . '/verify',
+            $params,
+            $opts
+        );
+    }
+}

--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -174,9 +174,9 @@ class CustomerService extends \Stripe\Service\AbstractService
 
     /**
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -191,9 +191,9 @@ class CustomerService extends \Stripe\Service\AbstractService
      * Deletes an existing <code>TaxID</code> object.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -226,9 +226,9 @@ class CustomerService extends \Stripe\Service\AbstractService
      * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -243,9 +243,9 @@ class CustomerService extends \Stripe\Service\AbstractService
      * Retrieve a specified source for a given customer.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -260,9 +260,9 @@ class CustomerService extends \Stripe\Service\AbstractService
      * Retrieves the <code>TaxID</code> object with the given identifier.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -306,9 +306,9 @@ class CustomerService extends \Stripe\Service\AbstractService
      * <code>description</code> and <code>metadata</code>.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -321,9 +321,9 @@ class CustomerService extends \Stripe\Service\AbstractService
 
     /**
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -336,9 +336,9 @@ class CustomerService extends \Stripe\Service\AbstractService
 
     /**
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *

--- a/lib/Service/DisputeService.php
+++ b/lib/Service/DisputeService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Stripe\Service;
+
+class DisputeService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your disputes.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/disputes', $params, $opts);
+    }
+
+    /**
+     * Closing the dispute for a charge indicates that you do not have any evidence to
+     * submit and are essentially dismissing the dispute, acknowledging it as lost.
+     *
+     * The status of the dispute will change from <code>needs_response</code> to
+     * <code>lost</code>. <em>Closing a dispute is irreversible</em>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Dispute
+     */
+    public function close($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/disputes/%s/close', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the dispute with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Dispute
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/disputes/%s', $id), $params, $opts);
+    }
+
+    /**
+     * When you get a dispute, contacting your customer is always the best first step.
+     * If that doesn’t work, you can submit evidence to help us resolve the dispute in
+     * your favor. You can do this in your <a
+     * href="https://dashboard.stripe.com/disputes">dashboard</a>, but if you prefer,
+     * you can use the API to submit evidence programmatically.
+     *
+     * Depending on your dispute type, different evidence fields will give you a better
+     * chance of winning your dispute. To figure out which evidence fields to provide,
+     * see our <a href="/docs/disputes/categories">guide to dispute types</a>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Dispute
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/disputes/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/EphemeralKeyService.php
+++ b/lib/Service/EphemeralKeyService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Stripe\Service;
+
+class EphemeralKeyService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Invalidates a short-lived API key for a given resource.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\EphemeralKey
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/ephemeral_keys/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a short-lived API key for a given resource.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\EphemeralKey
+     */
+    public function create($params = null, $opts = null)
+    {
+        if (!$opts || !isset($opts['stripe_version'])) {
+            throw new \Stripe\Exception\InvalidArgumentException('stripe_version must be specified to create an ephemeral key');
+        }
+
+        return $this->request('post', '/v1/ephemeral_keys', $params, $opts);
+    }
+}

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Stripe\Service;
+
+class EventService extends \Stripe\Service\AbstractService
+{
+    /**
+     * List events, going back up to 30 days. Each event data is rendered according to
+     * Stripe API version at its creation time, specified in <a
+     * href="/docs/api/events/object">event object</a> <code>api_version</code>
+     * attribute (not according to your current Stripe API version or
+     * <code>Stripe-Version</code> header).
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/events', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an event. Supply the unique identifier of the event,
+     * which you might have received in a webhook.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Event
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/events/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/ExchangeRateService.php
+++ b/lib/Service/ExchangeRateService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Stripe\Service;
+
+class ExchangeRateService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of objects that contain the rates at which foreign currencies are
+     * converted to one another. Only shows the currencies for which Stripe supports.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/exchange_rates', $params, $opts);
+    }
+
+    /**
+     * Retrieves the exchange rates from the given currency to every supported
+     * currency.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\ExchangeRate
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/exchange_rates/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/FileLinkService.php
+++ b/lib/Service/FileLinkService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Stripe\Service;
+
+class FileLinkService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of file links.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/file_links', $params, $opts);
+    }
+
+    /**
+     * Creates a new file link object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\FileLink
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/file_links', $params, $opts);
+    }
+
+    /**
+     * Retrieves the file link with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\FileLink
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/file_links/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing file link object. Expired links can no longer be updated.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\FileLink
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/file_links/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Stripe\Service;
+
+class FileService extends AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/files';
+    }
+
+    /**
+     * List all files.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a file.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\File
+     */
+    public function create($params = [], $opts = [])
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        if (!isset($opts->apiBase)) {
+            $opts->apiBase = $this->getClient()->getFilesBase();
+        }
+
+        // Manually flatten params, otherwise curl's multipart encoder will
+        // choke on nested arrays.
+        $flatParams = \array_column(\Stripe\Util\Util::flattenParams($params), 1, 0);
+
+        return $this->createObject($flatParams, $opts);
+    }
+
+    /**
+     * Retrieve a file.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\File
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -2,19 +2,42 @@
 
 namespace Stripe\Service;
 
-class FileService extends AbstractService
+class FileService extends \Stripe\Service\AbstractService
 {
     /**
-     * List all files.
+     * Returns a list of the files that your account has access to. The files are
+     * returned sorted by creation date, with the most recently created files appearing
+     * first.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
     public function all($params = null, $opts = null)
     {
         return $this->request('get', '/v1/files', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing file object. Supply the unique file ID from
+     * a file, and Stripe will return the corresponding file object. To access file
+     * contents, see the <a href="/docs/file-upload#download-file-contents">File Upload
+     * Guide</a>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\File
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/files/%s', $id), $params, $opts);
     }
 
     /**
@@ -37,19 +60,5 @@ class FileService extends AbstractService
         $flatParams = \array_column(\Stripe\Util\Util::flattenParams($params), 1, 0);
 
         return $this->request('post', '/v1/files', $flatParams, $opts);
-    }
-
-    /**
-     * Retrieve a file.
-     *
-     * @param string $id
-     * @param null|array $params
-     * @param null|array|\Stripe\Util\RequestOptions $opts
-     *
-     * @return \Stripe\File
-     */
-    public function retrieve($id, $params = null, $opts = null)
-    {
-        return $this->request('get', $this->buildPath('/v1/files/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -4,33 +4,28 @@ namespace Stripe\Service;
 
 class FileService extends AbstractService
 {
-    public function basePath()
-    {
-        return '/v1/files';
-    }
-
     /**
      * List all files.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function all($params = [], $opts = [])
+    public function all($params = null, $opts = null)
     {
-        return $this->allObjects($params, $opts);
+        return $this->request('get', '/v1/files', $params, $opts);
     }
 
     /**
      * Create a file.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\File
      */
-    public function create($params = [], $opts = [])
+    public function create($params = null, $opts = null)
     {
         $opts = \Stripe\Util\RequestOptions::parse($opts);
         if (!isset($opts->apiBase)) {
@@ -38,23 +33,23 @@ class FileService extends AbstractService
         }
 
         // Manually flatten params, otherwise curl's multipart encoder will
-        // choke on nested arrays.
+        // choke on nested null|arrays.
         $flatParams = \array_column(\Stripe\Util\Util::flattenParams($params), 1, 0);
 
-        return $this->createObject($flatParams, $opts);
+        return $this->request('post', '/v1/files', $flatParams, $opts);
     }
 
     /**
      * Retrieve a file.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\File
      */
-    public function retrieve($id, $params = [], $opts = [])
+    public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->retrieveObject($id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/files/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/InvoiceItemService.php
+++ b/lib/Service/InvoiceItemService.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Stripe\Service;
+
+class InvoiceItemService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your invoice items. Invoice items are returned sorted by
+     * creation date, with the most recently created invoice items appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/invoiceitems', $params, $opts);
+    }
+
+    /**
+     * Creates an item to be added to a draft invoice. If no invoice is specified, the
+     * item will be on the next invoice created for the customer specified.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\InvoiceItem
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/invoiceitems', $params, $opts);
+    }
+
+    /**
+     * Deletes an invoice item, removing it from an invoice. Deleting invoice items is
+     * only possible when they’re not attached to invoices, or if it’s attached to a
+     * draft invoice.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\InvoiceItem
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/invoiceitems/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the invoice item with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\InvoiceItem
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/invoiceitems/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the amount or description of an invoice item on an upcoming invoice.
+     * Updating an invoice item is only possible before the invoice it’s attached to is
+     * closed.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\InvoiceItem
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoiceitems/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/InvoiceService.php
+++ b/lib/Service/InvoiceService.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Stripe\Service;
+
+class InvoiceService extends \Stripe\Service\AbstractService
+{
+    /**
+     * You can list all invoices, or list the invoices for a specific customer. The
+     * invoices are returned sorted by creation date, with the most recently created
+     * invoices appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/invoices', $params, $opts);
+    }
+
+    /**
+     * When retrieving an invoice, you’ll get a <strong>lines</strong> property
+     * containing the total count of line items and the first handful of those items.
+     * There is also a URL where you can retrieve the full (paginated) list of line
+     * items.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allLines($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/invoices/%s/lines', $parentId), $params, $opts);
+    }
+
+    /**
+     * This endpoint creates a draft invoice for a given customer. The draft invoice
+     * created pulls in all pending invoice items on that customer, including
+     * prorations.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/invoices', $params, $opts);
+    }
+
+    /**
+     * Permanently deletes a draft invoice. This cannot be undone. Attempts to delete
+     * invoices that are no longer in a draft state will fail; once an invoice has been
+     * finalized, it must be <a href="#void_invoice">voided</a>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/invoices/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Stripe automatically finalizes drafts before sending and attempting payment on
+     * invoices. However, if you’d like to finalize a draft invoice manually, you can
+     * do so using this method.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function finalizeInvoice($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s/finalize', $id), $params, $opts);
+    }
+
+    /**
+     * Marking an invoice as uncollectible is useful for keeping track of bad debts
+     * that can be written off for accounting purposes.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function markUncollectible($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s/mark_uncollectible', $id), $params, $opts);
+    }
+
+    /**
+     * Stripe automatically creates and then attempts to collect payment on invoices
+     * for customers on subscriptions according to your <a
+     * href="https://dashboard.stripe.com/account/billing/automatic">subscriptions
+     * settings</a>. However, if you’d like to attempt payment on an invoice out of the
+     * normal collection schedule or for some other reason, you can do so.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function pay($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s/pay', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the invoice with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/invoices/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Stripe will automatically send invoices to customers according to your <a
+     * href="https://dashboard.stripe.com/account/billing/automatic">subscriptions
+     * settings</a>. However, if you’d like to manually send an invoice to your
+     * customer out of the normal schedule, you can do so. When sending invoices that
+     * have already been paid, there will be no reference to the payment in the email.
+     *
+     * Requests made in test-mode result in no emails being sent, despite sending an
+     * <code>invoice.sent</code> event.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function sendInvoice($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s/send', $id), $params, $opts);
+    }
+
+    /**
+     * At any time, you can preview the upcoming invoice for a customer. This will show
+     * you all the charges that are pending, including subscription renewal charges,
+     * invoice item charges, etc. It will also show you any discount that is applicable
+     * to the customer.
+     *
+     * Note that when you are viewing an upcoming invoice, you are simply viewing a
+     * preview – the invoice has not yet been created. As such, the upcoming invoice
+     * will not show up in invoice listing calls, and you cannot use the API to pay or
+     * edit the invoice. If you want to change the amount that your customer will be
+     * billed, you can add, remove, or update pending invoice items, or update the
+     * customer’s discount.
+     *
+     * You can preview the effects of updating a subscription, including a preview of
+     * what proration will take place. To ensure that the actual proration is
+     * calculated exactly the same as the previewed proration, you should pass a
+     * <code>proration_date</code> parameter when doing the actual subscription update.
+     * The value passed in should be the same as the
+     * <code>subscription_proration_date</code> returned on the upcoming invoice
+     * resource. The recommended way to get only the prorations being previewed is to
+     * consider only proration line items where <code>period[start]</code> is equal to
+     * the <code>subscription_proration_date</code> on the upcoming invoice resource.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function upcoming($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/invoices/upcoming', $params, $opts);
+    }
+
+    /**
+     * When retrieving an upcoming invoice, you’ll get a <strong>lines</strong>
+     * property containing the total count of line items and the first handful of those
+     * items. There is also a URL where you can retrieve the full (paginated) list of
+     * line items.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function upcomingLines($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/invoices/upcoming/lines', $params, $opts);
+    }
+
+    /**
+     * Draft invoices are fully editable. Once an invoice is <a
+     * href="/docs/billing/invoices/workflow#finalized">finalized</a>, monetary values,
+     * as well as <code>collection_method</code>, become uneditable.
+     *
+     * If you would like to stop the Stripe Billing engine from automatically
+     * finalizing, reattempting payments on, sending reminders for, or <a
+     * href="/docs/billing/invoices/reconciliation">automatically reconciling</a>
+     * invoices, pass <code>auto_advance=false</code>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is
+     * similar to <a href="#delete_invoice">deletion</a>, however it only applies to
+     * finalized invoices and maintains a papertrail where the invoice can still be
+     * found.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice
+     */
+    public function voidInvoice($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/invoices/%s/void', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Issuing/AuthorizationService.php
+++ b/lib/Service/Issuing/AuthorizationService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+class AuthorizationService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Issuing <code>Authorization</code> objects. The objects are
+     * sorted in descending order by creation date, with the most recently created
+     * object appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/issuing/authorizations', $params, $opts);
+    }
+
+    /**
+     * Approves a pending Issuing <code>Authorization</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Authorization
+     */
+    public function approve($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/authorizations/%s/approve', $id), $params, $opts);
+    }
+
+    /**
+     * Declines a pending Issuing <code>Authorization</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Authorization
+     */
+    public function decline($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/authorizations/%s/decline', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves an Issuing <code>Authorization</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Authorization
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/issuing/authorizations/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified Issuing <code>Authorization</code> object by setting the
+     * values of the parameters passed. Any parameters not provided will be left
+     * unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Authorization
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/authorizations/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Issuing/AuthorizationService.php
+++ b/lib/Service/Issuing/AuthorizationService.php
@@ -22,7 +22,10 @@ class AuthorizationService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Approves a pending Issuing <code>Authorization</code> object.
+     * Approves a pending Issuing <code>Authorization</code> object. This request
+     * should be made within the timeout window of the <a
+     * href="/docs/issuing/controls/real-time-authorizations">real-time
+     * authorization</a> flow.
      *
      * @param string $id
      * @param null|array $params
@@ -38,7 +41,10 @@ class AuthorizationService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Declines a pending Issuing <code>Authorization</code> object.
+     * Declines a pending Issuing <code>Authorization</code> object. This request
+     * should be made within the timeout window of the <a
+     * href="/docs/issuing/controls/real-time-authorizations">real time
+     * authorization</a> flow.
      *
      * @param string $id
      * @param null|array $params

--- a/lib/Service/Issuing/CardService.php
+++ b/lib/Service/Issuing/CardService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+class CardService extends \Stripe\Service\AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/issuing/cards';
+    }
+
+    /**
+     * List all cards.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a card.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Issuing\Card
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Retrieve a card details.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Issuing\CardDetails
+     */
+    public function details($id, $params = [], $opts = [])
+    {
+        return $this->request('get', $this->instancePath($id) . '/details', $params, $opts);
+    }
+
+    /**
+     * Retrieve a card.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Issuing\Card
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a card.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Issuing\Card
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Service/Issuing/CardService.php
+++ b/lib/Service/Issuing/CardService.php
@@ -4,16 +4,15 @@ namespace Stripe\Service\Issuing;
 
 class CardService extends \Stripe\Service\AbstractService
 {
-    public function basePath()
-    {
-        return '/v1/issuing/cards';
-    }
-
     /**
-     * List all cards.
+     * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in
+     * descending order by creation date, with the most recently created object
+     * appearing first.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -23,10 +22,12 @@ class CardService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Create a card.
+     * Creates an Issuing <code>Card</code> object.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Issuing\Card
      */
@@ -36,13 +37,17 @@ class CardService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Retrieve a card details.
+     * For virtual cards only. Retrieves an Issuing <code>card_details</code> object
+     * that contains <a href="/docs/issuing/cards/management#virtual-card-info">the
+     * sensitive details</a> of a virtual card.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
      *
-     * @return \Stripe\Issuing\CardDetails
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Card
      */
     public function details($id, $params = null, $opts = null)
     {
@@ -50,11 +55,13 @@ class CardService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Retrieve a card.
+     * Retrieves an Issuing <code>Card</code> object.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Issuing\Card
      */
@@ -64,11 +71,14 @@ class CardService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Update a card.
+     * Updates the specified Issuing <code>Card</code> object by setting the values of
+     * the parameters passed. Any parameters not provided will be left unchanged.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Issuing\Card
      */

--- a/lib/Service/Issuing/CardService.php
+++ b/lib/Service/Issuing/CardService.php
@@ -12,68 +12,68 @@ class CardService extends \Stripe\Service\AbstractService
     /**
      * List all cards.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function all($params = [], $opts = [])
+    public function all($params = null, $opts = null)
     {
-        return $this->allObjects($params, $opts);
+        return $this->request('get', '/v1/issuing/cards', $params, $opts);
     }
 
     /**
      * Create a card.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Issuing\Card
      */
-    public function create($params = [], $opts = [])
+    public function create($params = null, $opts = null)
     {
-        return $this->createObject($params, $opts);
+        return $this->request('post', '/v1/issuing/cards', $params, $opts);
     }
 
     /**
      * Retrieve a card details.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Issuing\CardDetails
      */
-    public function details($id, $params = [], $opts = [])
+    public function details($id, $params = null, $opts = null)
     {
-        return $this->request('get', $this->instancePath($id) . '/details', $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/issuing/cards/%s/details', $id), $params, $opts);
     }
 
     /**
      * Retrieve a card.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Issuing\Card
      */
-    public function retrieve($id, $params = [], $opts = [])
+    public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->retrieveObject($id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/issuing/cards/%s', $id), $params, $opts);
     }
 
     /**
      * Update a card.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Issuing\Card
      */
-    public function update($id, $params = [], $opts = [])
+    public function update($id, $params = null, $opts = null)
     {
-        return $this->updateObject($id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/issuing/cards/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/Issuing/CardService.php
+++ b/lib/Service/Issuing/CardService.php
@@ -38,7 +38,7 @@ class CardService extends \Stripe\Service\AbstractService
 
     /**
      * For virtual cards only. Retrieves an Issuing <code>card_details</code> object
-     * that contains <a href="/docs/issuing/cards/management#virtual-card-info">the
+     * that contains <a href="/docs/issuing/cards/virtual#virtual-card-info">the
      * sensitive details</a> of a virtual card.
      *
      * @param string $id

--- a/lib/Service/Issuing/CardholderService.php
+++ b/lib/Service/Issuing/CardholderService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+class CardholderService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Issuing <code>Cardholder</code> objects. The objects are
+     * sorted in descending order by creation date, with the most recently created
+     * object appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/issuing/cardholders', $params, $opts);
+    }
+
+    /**
+     * Creates a new Issuing <code>Cardholder</code> object that can be issued cards.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Cardholder
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/issuing/cardholders', $params, $opts);
+    }
+
+    /**
+     * Retrieves an Issuing <code>Cardholder</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Cardholder
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/issuing/cardholders/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified Issuing <code>Cardholder</code> object by setting the
+     * values of the parameters passed. Any parameters not provided will be left
+     * unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Cardholder
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/cardholders/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Issuing/DisputeService.php
+++ b/lib/Service/Issuing/DisputeService.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+class DisputeService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Issuing <code>Dispute</code> objects. The objects are sorted
+     * in descending order by creation date, with the most recently created object
+     * appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/issuing/disputes', $params, $opts);
+    }
+
+    /**
+     * Creates an Issuing <code>Dispute</code> object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Dispute
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/issuing/disputes', $params, $opts);
+    }
+
+    /**
+     * Retrieves an Issuing <code>Dispute</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Dispute
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/issuing/disputes/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified Issuing <code>Dispute</code> object by setting the values
+     * of the parameters passed. Any parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Dispute
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/disputes/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Issuing/IssuingServiceFactory.php
+++ b/lib/Service/Issuing/IssuingServiceFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * Service factory class for API resources in the Issuing namespace.
+ *
+ * @property AuthorizationService $authorizations
+ * @property CardholderService $cardholders
+ * @property CardService $cards
+ * @property DisputeService $disputes
+ * @property TransactionService $transactions
+ */
+class IssuingServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'authorizations' => AuthorizationService::class,
+        'cardholders' => CardholderService::class,
+        'cards' => CardService::class,
+        'disputes' => DisputeService::class,
+        'transactions' => TransactionService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Issuing/TransactionService.php
+++ b/lib/Service/Issuing/TransactionService.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+class TransactionService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Issuing <code>Transaction</code> objects. The objects are
+     * sorted in descending order by creation date, with the most recently created
+     * object appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/issuing/transactions', $params, $opts);
+    }
+
+    /**
+     * Retrieves an Issuing <code>Transaction</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Transaction
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/issuing/transactions/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified Issuing <code>Transaction</code> object by setting the
+     * values of the parameters passed. Any parameters not provided will be left
+     * unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Issuing\Transaction
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/issuing/transactions/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/MandateService.php
+++ b/lib/Service/MandateService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Stripe\Service;
+
+class MandateService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Retrieves a Mandate object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Mandate
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/mandates/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/OrderReturnService.php
+++ b/lib/Service/OrderReturnService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Stripe\Service;
+
+class OrderReturnService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your order returns. The returns are returned sorted by
+     * creation date, with the most recently created return appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/order_returns', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing order return. Supply the unique order ID
+     * from either an order return creation request or the order return list, and
+     * Stripe will return the corresponding order information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\OrderReturn
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/order_returns/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/OrderService.php
+++ b/lib/Service/OrderService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Stripe\Service;
+
+class OrderService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your orders. The orders are returned sorted by creation date,
+     * with the most recently created orders appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/orders', $params, $opts);
+    }
+
+    /**
+     * Creates a new order object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Order
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/orders', $params, $opts);
+    }
+
+    /**
+     * Pay an order by providing a <code>source</code> to create a payment.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Order
+     */
+    public function pay($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/orders/%s/pay', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing order. Supply the unique order ID from
+     * either an order creation request or the order list, and Stripe will return the
+     * corresponding order information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Order
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/orders/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Return all or part of an order. The order must have a status of
+     * <code>paid</code> or <code>fulfilled</code> before it can be returned. Once all
+     * items have been returned, the order will become <code>canceled</code> or
+     * <code>returned</code> depending on which status the order started in.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Order
+     */
+    public function returnOrder($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/orders/%s/returns', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specific order by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Order
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/orders/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/PaymentIntentService.php
+++ b/lib/Service/PaymentIntentService.php
@@ -2,13 +2,15 @@
 
 namespace Stripe\Service;
 
-class PaymentIntentService extends AbstractService
+class PaymentIntentService extends \Stripe\Service\AbstractService
 {
     /**
-     * List all payment intents.
+     * Returns a list of PaymentIntents.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\Collection
      */
@@ -18,11 +20,43 @@ class PaymentIntentService extends AbstractService
     }
 
     /**
-     * Capture a payment intent.
+     * A PaymentIntent object can be canceled when it is in one of these statuses:
+     * <code>requires_payment_method</code>, <code>requires_capture</code>,
+     * <code>requires_confirmation</code>, <code>requires_action</code>.
+     *
+     * Once canceled, no additional charges will be made by the PaymentIntent and any
+     * operations on the PaymentIntent will fail with an error. For PaymentIntents with
+     * <code>status='requires_capture'</code>, the remaining
+     * <code>amount_capturable</code> will automatically be refunded.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payment_intents/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * Capture the funds of an existing uncaptured PaymentIntent when its status is
+     * <code>requires_capture</code>.
+     *
+     * Uncaptured PaymentIntents will be canceled exactly seven days after they are
+     * created.
+     *
+     * Learn more about <a href="/docs/payments/capture-later">separate authorization
+     * and capture</a>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\PaymentIntent
      */
@@ -32,11 +66,39 @@ class PaymentIntentService extends AbstractService
     }
 
     /**
-     * Confirm a payment intent.
+     * Confirm that your customer intends to pay with current or provided payment
+     * method. Upon confirmation, the PaymentIntent will attempt to initiate a payment.
+     *
+     * If the selected payment method requires additional authentication steps, the
+     * PaymentIntent will transition to the <code>requires_action</code> status and
+     * suggest additional actions via <code>next_action</code>. If payment fails, the
+     * PaymentIntent will transition to the <code>requires_payment_method</code>
+     * status. If payment succeeds, the PaymentIntent will transition to the
+     * <code>succeeded</code> status (or <code>requires_capture</code>, if
+     * <code>capture_method</code> is set to <code>manual</code>).
+     *
+     * If the <code>confirmation_method</code> is <code>automatic</code>, payment may
+     * be attempted using our <a
+     * href="/docs/stripe-js/reference#stripe-handle-card-payment">client SDKs</a> and
+     * the PaymentIntent’s <a
+     * href="#payment_intent_object-client_secret">client_secret</a>. After
+     * <code>next_action</code>s are handled by the client, no additional confirmation
+     * is required to complete the payment.
+     *
+     * If the <code>confirmation_method</code> is <code>manual</code>, all payment
+     * attempts must be initiated using a secret key. If any actions are required for
+     * the payment, the PaymentIntent will return to the
+     * <code>requires_confirmation</code> state after those actions are completed. Your
+     * server needs to then explicitly re-confirm the PaymentIntent to initiate the
+     * next payment attempt. Read the <a
+     * href="/docs/payments/payment-intents/web-manual">expanded documentation</a> to
+     * learn more about manual confirmation.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\PaymentIntent
      */
@@ -46,10 +108,22 @@ class PaymentIntentService extends AbstractService
     }
 
     /**
-     * Create a payment intent.
+     * Creates a PaymentIntent object.
+     *
+     * After the PaymentIntent is created, attach a payment method and <a
+     * href="/docs/api/payment_intents/confirm">confirm</a> to continue the payment.
+     * You can read more about the different payment flows available via the Payment
+     * Intents API <a href="/docs/payments/payment-intents">here</a>.
+     *
+     * When <code>confirm=true</code> is used during creation, it is equivalent to
+     * creating and confirming the PaymentIntent in the same call. You may use any
+     * parameters available in the <a href="/docs/api/payment_intents/confirm">confirm
+     * API</a> when <code>confirm=true</code> is supplied.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\PaymentIntent
      */
@@ -59,11 +133,20 @@ class PaymentIntentService extends AbstractService
     }
 
     /**
-     * Retrieve a payment intent.
+     * Retrieves the details of a PaymentIntent that has previously been created.
+     *
+     * Client-side retrieval using a publishable key is allowed when the
+     * <code>client_secret</code> is provided in the query string.
+     *
+     * When retrieved with a publishable key, only a subset of properties will be
+     * returned. Please refer to the <a href="#payment_intent_object">payment
+     * intent</a> object reference for more details.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\PaymentIntent
      */
@@ -73,11 +156,19 @@ class PaymentIntentService extends AbstractService
     }
 
     /**
-     * Update a payment intent.
+     * Updates properties on a PaymentIntent object without confirming.
+     *
+     * Depending on which properties you update, you may need to confirm the
+     * PaymentIntent again. For example, updating the <code>payment_method</code> will
+     * always require you to confirm the PaymentIntent again. If you prefer to update
+     * and confirm at the same time, we recommend updating properties via the <a
+     * href="/docs/api/payment_intents/confirm">confirm API</a> instead.
      *
      * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\PaymentIntent
      */

--- a/lib/Service/PaymentIntentService.php
+++ b/lib/Service/PaymentIntentService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Stripe\Service;
+
+class PaymentIntentService extends AbstractService
+{
+    public function basePath()
+    {
+        return '/v1/payment_intents';
+    }
+
+    /**
+     * List all payment intents.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Capture a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function capture($id, $params = [], $opts = [])
+    {
+        return $this->request('post', $this->instancePath($id) . '/capture', $params, $opts);
+    }
+
+    /**
+     * Confirm a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function confirm($id, $params = [], $opts = [])
+    {
+        return $this->request('post', $this->instancePath($id) . '/confirm', $params, $opts);
+    }
+
+    /**
+     * Create a payment intent.
+     *
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Retrieve a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     *
+     * @return \Stripe\PaymentIntent
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Service/PaymentIntentService.php
+++ b/lib/Service/PaymentIntentService.php
@@ -4,90 +4,85 @@ namespace Stripe\Service;
 
 class PaymentIntentService extends AbstractService
 {
-    public function basePath()
-    {
-        return '/v1/payment_intents';
-    }
-
     /**
      * List all payment intents.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\Collection
      */
-    public function all($params = [], $opts = [])
+    public function all($params = null, $opts = null)
     {
-        return $this->allObjects($params, $opts);
+        return $this->request('get', '/v1/payment_intents', $params, $opts);
     }
 
     /**
      * Capture a payment intent.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\PaymentIntent
      */
-    public function capture($id, $params = [], $opts = [])
+    public function capture($id, $params = null, $opts = null)
     {
-        return $this->request('post', $this->instancePath($id) . '/capture', $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/payment_intents/%s/capture', $id), $params, $opts);
     }
 
     /**
      * Confirm a payment intent.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\PaymentIntent
      */
-    public function confirm($id, $params = [], $opts = [])
+    public function confirm($id, $params = null, $opts = null)
     {
-        return $this->request('post', $this->instancePath($id) . '/confirm', $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/payment_intents/%s/confirm', $id), $params, $opts);
     }
 
     /**
      * Create a payment intent.
      *
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\PaymentIntent
      */
-    public function create($params = [], $opts = [])
+    public function create($params = null, $opts = null)
     {
-        return $this->createObject($params, $opts);
+        return $this->request('post', '/v1/payment_intents', $params, $opts);
     }
 
     /**
      * Retrieve a payment intent.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\PaymentIntent
      */
-    public function retrieve($id, $params = [], $opts = [])
+    public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->retrieveObject($id, $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/payment_intents/%s', $id), $params, $opts);
     }
 
     /**
      * Update a payment intent.
      *
      * @param string $id
-     * @param array $params
-     * @param array $opts
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\PaymentIntent
      */
-    public function update($id, $params = [], $opts = [])
+    public function update($id, $params = null, $opts = null)
     {
-        return $this->updateObject($id, $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/payment_intents/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/PaymentMethodService.php
+++ b/lib/Service/PaymentMethodService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Stripe\Service;
+
+class PaymentMethodService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of PaymentMethods for a given Customer.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/payment_methods', $params, $opts);
+    }
+
+    /**
+     * Attaches a PaymentMethod object to a Customer.
+     *
+     * To use this PaymentMethod as the default for invoice or subscription payments,
+     * set <a
+     * href="/docs/api/customers/update#update_customer-invoice_settings-default_payment_method"><code>invoice_settings.default_payment_method</code></a>,
+     * on the Customer to the PaymentMethod’s ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentMethod
+     */
+    public function attach($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payment_methods/%s/attach', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a PaymentMethod object. Read the <a
+     * href="/docs/stripe-js/reference#stripe-create-payment-method">Stripe.js
+     * reference</a> to learn how to create PaymentMethods via Stripe.js.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentMethod
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/payment_methods', $params, $opts);
+    }
+
+    /**
+     * Detaches a PaymentMethod object from a Customer.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentMethod
+     */
+    public function detach($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payment_methods/%s/detach', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a PaymentMethod object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentMethod
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/payment_methods/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates a PaymentMethod object. A PaymentMethod must be attached a customer to
+     * be updated.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\PaymentMethod
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payment_methods/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/PaymentMethodService.php
+++ b/lib/Service/PaymentMethodService.php
@@ -22,6 +22,17 @@ class PaymentMethodService extends \Stripe\Service\AbstractService
     /**
      * Attaches a PaymentMethod object to a Customer.
      *
+     * To attach a new PaymentMethod to a customer for future payments, we recommend
+     * you use a <a href="/docs/api/setup_intents">SetupIntent</a> or a PaymentIntent
+     * with <a
+     * href="/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
+     * These approaches will perform any necessary steps to ensure that the
+     * PaymentMethod can be used in a future payment. Using the
+     * <code>/v1/payment_methods/:id/attach</code> endpoint does not ensure that future
+     * payments can be made with the attached PaymentMethod. See <a
+     * href="/docs/payments/payment-intents#future-usage">Optimizing cards for future
+     * payments</a> for more information about setting up future payments.
+     *
      * To use this PaymentMethod as the default for invoice or subscription payments,
      * set <a
      * href="/docs/api/customers/update#update_customer-invoice_settings-default_payment_method"><code>invoice_settings.default_payment_method</code></a>,

--- a/lib/Service/PayoutService.php
+++ b/lib/Service/PayoutService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Stripe\Service;
+
+class PayoutService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of existing payouts sent to third-party bank accounts or that
+     * Stripe has sent you. The payouts are returned in sorted order, with the most
+     * recently created payouts appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/payouts', $params, $opts);
+    }
+
+    /**
+     * A previously created payout can be canceled if it has not yet been paid out.
+     * Funds will be refunded to your available balance. You may not cancel automatic
+     * Stripe payouts.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Payout
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payouts/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * To send funds to your own bank account, you create a new payout object. Your <a
+     * href="#balance">Stripe balance</a> must be able to cover the payout amount, or
+     * you’ll receive an “Insufficient Funds” error.
+     *
+     * If your API key is in test mode, money won’t actually be sent, though everything
+     * else will occur as if in live mode.
+     *
+     * If you are creating a manual payout on a Stripe account that uses multiple
+     * payment source types, you’ll need to specify the source type balance that the
+     * payout should draw from. The <a href="#balance_object">balance object</a>
+     * details available and pending amounts by source type.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Payout
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/payouts', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing payout. Supply the unique payout ID from
+     * either a payout creation request or the payout list, and Stripe will return the
+     * corresponding payout information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Payout
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/payouts/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified payout by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged. This request accepts only the
+     * metadata as arguments.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Payout
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/payouts/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/PlanService.php
+++ b/lib/Service/PlanService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Stripe\Service;
+
+class PlanService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your plans.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/plans', $params, $opts);
+    }
+
+    /**
+     * You can create plans using the API, or in the Stripe <a
+     * href="https://dashboard.stripe.com/subscriptions/products">Dashboard</a>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Plan
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/plans', $params, $opts);
+    }
+
+    /**
+     * Deleting plans means new subscribers can’t be added. Existing subscribers aren’t
+     * affected.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Plan
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/plans/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the plan with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Plan
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/plans/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified plan by setting the values of the parameters passed. Any
+     * parameters not provided are left unchanged. By design, you cannot change a
+     * plan’s ID, amount, currency, or billing cycle.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Plan
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/plans/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/PriceService.php
+++ b/lib/Service/PriceService.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace Stripe\Service\Issuing;
+namespace Stripe\Service;
 
-class CardService extends \Stripe\Service\AbstractService
+class PriceService extends \Stripe\Service\AbstractService
 {
     /**
-     * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in
-     * descending order by creation date, with the most recently created object
-     * appearing first.
+     * Returns a list of your prices.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
@@ -18,26 +16,27 @@ class CardService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/cards', $params, $opts);
+        return $this->request('get', '/v1/prices', $params, $opts);
     }
 
     /**
-     * Creates an Issuing <code>Card</code> object.
+     * Creates a new price for an existing product. The price can be recurring or
+     * one-time.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Issuing\Card
+     * @return \Stripe\Price
      */
     public function create($params = null, $opts = null)
     {
-        return $this->request('post', '/v1/issuing/cards', $params, $opts);
+        return $this->request('post', '/v1/prices', $params, $opts);
     }
 
     /**
-     * Retrieves an Issuing <code>Card</code> object.
+     * Retrieves the price with the given ID.
      *
      * @param string $id
      * @param null|array $params
@@ -45,16 +44,16 @@ class CardService extends \Stripe\Service\AbstractService
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Issuing\Card
+     * @return \Stripe\Price
      */
     public function retrieve($id, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/issuing/cards/%s', $id), $params, $opts);
+        return $this->request('get', $this->buildPath('/v1/prices/%s', $id), $params, $opts);
     }
 
     /**
-     * Updates the specified Issuing <code>Card</code> object by setting the values of
-     * the parameters passed. Any parameters not provided will be left unchanged.
+     * Updates the specified price by setting the values of the parameters passed. Any
+     * parameters not provided are left unchanged.
      *
      * @param string $id
      * @param null|array $params
@@ -62,10 +61,10 @@ class CardService extends \Stripe\Service\AbstractService
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Issuing\Card
+     * @return \Stripe\Price
      */
     public function update($id, $params = null, $opts = null)
     {
-        return $this->request('post', $this->buildPath('/v1/issuing/cards/%s', $id), $params, $opts);
+        return $this->request('post', $this->buildPath('/v1/prices/%s', $id), $params, $opts);
     }
 }

--- a/lib/Service/ProductService.php
+++ b/lib/Service/ProductService.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Stripe\Service;
+
+class ProductService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your products. The products are returned sorted by creation
+     * date, with the most recently created products appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/products', $params, $opts);
+    }
+
+    /**
+     * Creates a new product object. To create a product for use with orders, see <a
+     * href="#create_product">Products</a>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Product
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/products', $params, $opts);
+    }
+
+    /**
+     * Delete a product. Deleting a product with type=<code>good</code> is only
+     * possible if it has no SKUs associated with it. Deleting a product with
+     * type=<code>service</code> is only possible if it has no plans associated with
+     * it.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Product
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/products/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing product. Supply the unique product ID from
+     * either a product creation request or the product list, and Stripe will return
+     * the corresponding product information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Product
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/products/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specific product by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Product
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/products/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/ProductService.php
+++ b/lib/Service/ProductService.php
@@ -21,8 +21,7 @@ class ProductService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * Creates a new product object. To create a product for use with orders, see <a
-     * href="#create_product">Products</a>.
+     * Creates a new product object.
      *
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts

--- a/lib/Service/Radar/EarlyFraudWarningService.php
+++ b/lib/Service/Radar/EarlyFraudWarningService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+class EarlyFraudWarningService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of early fraud warnings.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/radar/early_fraud_warnings', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an early fraud warning that has previously been
+     * created.
+     *
+     * Please refer to the <a href="#early_fraud_warning_object">early fraud
+     * warning</a> object reference for more details.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\EarlyFraudWarning
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/radar/early_fraud_warnings/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Radar/RadarServiceFactory.php
+++ b/lib/Service/Radar/RadarServiceFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+/**
+ * Service factory class for API resources in the Radar namespace.
+ *
+ * @property EarlyFraudWarningService $earlyFraudWarnings
+ * @property ValueListItemService $valueListItems
+ * @property ValueListService $valueLists
+ */
+class RadarServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'earlyFraudWarnings' => EarlyFraudWarningService::class,
+        'valueListItems' => ValueListItemService::class,
+        'valueLists' => ValueListService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Radar/ValueListItemService.php
+++ b/lib/Service/Radar/ValueListItemService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+class ValueListItemService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of <code>ValueListItem</code> objects. The objects are sorted in
+     * descending order by creation date, with the most recently created object
+     * appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/radar/value_list_items', $params, $opts);
+    }
+
+    /**
+     * Creates a new <code>ValueListItem</code> object, which is added to the specified
+     * parent value list.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueListItem
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/radar/value_list_items', $params, $opts);
+    }
+
+    /**
+     * Deletes a <code>ValueListItem</code> object, removing it from its parent value
+     * list.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueListItem
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/radar/value_list_items/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a <code>ValueListItem</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueListItem
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/radar/value_list_items/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Radar/ValueListService.php
+++ b/lib/Service/Radar/ValueListService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+class ValueListService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of <code>ValueList</code> objects. The objects are sorted in
+     * descending order by creation date, with the most recently created object
+     * appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/radar/value_lists', $params, $opts);
+    }
+
+    /**
+     * Creates a new <code>ValueList</code> object, which can then be referenced in
+     * rules.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueList
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/radar/value_lists', $params, $opts);
+    }
+
+    /**
+     * Deletes a <code>ValueList</code> object, also deleting any items contained
+     * within the value list. To be deleted, a value list must not be referenced in any
+     * rules.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueList
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/radar/value_lists/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a <code>ValueList</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueList
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/radar/value_lists/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates a <code>ValueList</code> object by setting the values of the parameters
+     * passed. Any parameters not provided will be left unchanged. Note that
+     * <code>item_type</code> is immutable.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Radar\ValueList
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/radar/value_lists/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/RefundService.php
+++ b/lib/Service/RefundService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Service;
+
+class RefundService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of all refunds you’ve previously created. The refunds are
+     * returned in sorted order, with the most recent refunds appearing first. For
+     * convenience, the 10 most recent refunds are always available by default on the
+     * charge object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/refunds', $params, $opts);
+    }
+
+    /**
+     * Create a refund.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Refund
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/refunds', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing refund.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Refund
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/refunds/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified refund by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * This request only accepts <code>metadata</code> as an argument.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Refund
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/refunds/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Reporting/ReportRunService.php
+++ b/lib/Service/Reporting/ReportRunService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+class ReportRunService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of Report Runs, with the most recent appearing first. (Requires a
+     * <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.).
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/reporting/report_runs', $params, $opts);
+    }
+
+    /**
+     * Creates a new object and begin running the report. (Requires a <a
+     * href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.).
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Reporting\ReportRun
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/reporting/report_runs', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing Report Run. (Requires a <a
+     * href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.).
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Reporting\ReportRun
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/reporting/report_runs/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Reporting/ReportTypeService.php
+++ b/lib/Service/Reporting/ReportTypeService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+class ReportTypeService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a full list of Report Types. (Requires a <a
+     * href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.).
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/reporting/report_types', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of a Report Type. (Requires a <a
+     * href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.).
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Reporting\ReportType
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/reporting/report_types/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Reporting/ReportingServiceFactory.php
+++ b/lib/Service/Reporting/ReportingServiceFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+/**
+ * Service factory class for API resources in the Reporting namespace.
+ *
+ * @property ReportRunService $reportRuns
+ * @property ReportTypeService $reportTypes
+ */
+class ReportingServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'reportRuns' => ReportRunService::class,
+        'reportTypes' => ReportTypeService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Stripe\Service;
+
+class ReviewService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of <code>Review</code> objects that have <code>open</code> set to
+     * <code>true</code>. The objects are sorted in descending order by creation date,
+     * with the most recently created object appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/reviews', $params, $opts);
+    }
+
+    /**
+     * Approves a <code>Review</code> object, closing it and removing it from the list
+     * of reviews.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Review
+     */
+    public function approve($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/reviews/%s/approve', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a <code>Review</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Review
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/reviews/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/SetupIntentService.php
+++ b/lib/Service/SetupIntentService.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Stripe\Service;
+
+class SetupIntentService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of SetupIntents.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/setup_intents', $params, $opts);
+    }
+
+    /**
+     * A SetupIntent object can be canceled when it is in one of these statuses:
+     * <code>requires_payment_method</code>, <code>requires_capture</code>,
+     * <code>requires_confirmation</code>, <code>requires_action</code>.
+     *
+     * Once canceled, setup is abandoned and any operations on the SetupIntent will
+     * fail with an error.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SetupIntent
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/setup_intents/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * Confirm that your customer intends to set up the current or provided payment
+     * method. For example, you would confirm a SetupIntent when a customer hits the
+     * “Save” button on a payment method management page on your website.
+     *
+     * If the selected payment method does not require any additional steps from the
+     * customer, the SetupIntent will transition to the <code>succeeded</code> status.
+     *
+     * Otherwise, it will transition to the <code>requires_action</code> status and
+     * suggest additional actions via <code>next_action</code>. If setup fails, the
+     * SetupIntent will transition to the <code>requires_payment_method</code> status.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SetupIntent
+     */
+    public function confirm($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/setup_intents/%s/confirm', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a SetupIntent object.
+     *
+     * After the SetupIntent is created, attach a payment method and <a
+     * href="/docs/api/setup_intents/confirm">confirm</a> to collect any required
+     * permissions to charge the payment method later.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SetupIntent
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/setup_intents', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of a SetupIntent that has previously been created.
+     *
+     * Client-side retrieval using a publishable key is allowed when the
+     * <code>client_secret</code> is provided in the query string.
+     *
+     * When retrieved with a publishable key, only a subset of properties will be
+     * returned. Please refer to the <a href="#setup_intent_object">SetupIntent</a>
+     * object reference for more details.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SetupIntent
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/setup_intents/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates a SetupIntent object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SetupIntent
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/setup_intents/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Sigma/ScheduledQueryRunService.php
+++ b/lib/Service/Sigma/ScheduledQueryRunService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service\Sigma;
+
+class ScheduledQueryRunService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of scheduled query runs.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/sigma/scheduled_query_runs', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an scheduled query run.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Sigma\ScheduledQueryRun
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/sigma/scheduled_query_runs/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Sigma/SigmaServiceFactory.php
+++ b/lib/Service/Sigma/SigmaServiceFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\Sigma;
+
+/**
+ * Service factory class for API resources in the Sigma namespace.
+ *
+ * @property ScheduledQueryRunService $scheduledQueryRuns
+ */
+class SigmaServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'scheduledQueryRuns' => ScheduledQueryRunService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/SkuService.php
+++ b/lib/Service/SkuService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Stripe\Service;
+
+class SkuService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your SKUs. The SKUs are returned sorted by creation date, with
+     * the most recently created SKUs appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/skus', $params, $opts);
+    }
+
+    /**
+     * Creates a new SKU associated with a product.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SKU
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/skus', $params, $opts);
+    }
+
+    /**
+     * Delete a SKU. Deleting a SKU is only possible until it has been used in an
+     * order.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SKU
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/skus/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing SKU. Supply the unique SKU identifier from
+     * either a SKU creation request or from the product, and Stripe will return the
+     * corresponding SKU information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SKU
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/skus/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specific SKU by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * Note that a SKU’s <code>attributes</code> are not editable. Instead, you would
+     * need to deactivate the existing SKU and create a new one with the new attribute
+     * values.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SKU
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/skus/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/SourceService.php
+++ b/lib/Service/SourceService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Stripe\Service;
+
+class SourceService extends \Stripe\Service\AbstractService
+{
+    /**
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function allTransactions($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/sources/%s/source_transactions', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a new source object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/sources', $params, $opts);
+    }
+
+    /**
+     * Delete a specified source for a given customer.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function detach($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/customers/%s/sources/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves an existing source object. Supply the unique source ID from a source
+     * creation request and Stripe will return the corresponding up-to-date source
+     * object information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/sources/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified source by setting the values of the parameters passed. Any
+     * parameters not provided will be left unchanged.
+     *
+     * This request accepts the <code>metadata</code> and <code>owner</code> as
+     * arguments. It is also possible to update type specific information for selected
+     * payment methods. Please refer to our <a href="/docs/sources">payment method
+     * guides</a> for more detail.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/sources/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Verify a given source.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Source
+     */
+    public function verify($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/sources/%s/verify', $id), $params, $opts);
+    }
+}

--- a/lib/Service/SourceService.php
+++ b/lib/Service/SourceService.php
@@ -37,9 +37,9 @@ class SourceService extends \Stripe\Service\AbstractService
      * Delete a specified source for a given customer.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *

--- a/lib/Service/SubscriptionItemService.php
+++ b/lib/Service/SubscriptionItemService.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Stripe\Service;
+
+class SubscriptionItemService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your subscription items for a given subscription.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/subscription_items', $params, $opts);
+    }
+
+    /**
+     * For the specified subscription item, returns a list of summary objects. Each
+     * object in the list provides usage information that’s been summarized from
+     * multiple usage records and over a subscription billing period (e.g., 15 usage
+     * records in the billing plan’s month of September).
+     *
+     * The list is sorted in reverse-chronological order (newest first). The first list
+     * item represents the most current usage period that hasn’t ended yet. Since new
+     * usage records can still be added, the returned summary information for the
+     * subscription item’s ID should be seen as unstable until the subscription billing
+     * period ends.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allUsageRecordSummaries($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/subscription_items/%s/usage_record_summaries', $parentId), $params, $opts);
+    }
+
+    /**
+     * Adds a new item to an existing subscription. No existing items will be changed
+     * or replaced.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionItem
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/subscription_items', $params, $opts);
+    }
+
+    /**
+     * Creates a usage record for a specified subscription item and date, and fills it
+     * with a quantity.
+     *
+     * Usage records provide <code>quantity</code> information that Stripe uses to
+     * track how much a customer is using your service. With usage information and the
+     * pricing model set up by the <a
+     * href="https://stripe.com/docs/billing/subscriptions/metered-billing">metered
+     * billing</a> plan, Stripe helps you send accurate invoices to your customers.
+     *
+     * The default calculation for usage is to add up all the <code>quantity</code>
+     * values of the usage records within a billing period. You can change this default
+     * behavior with the billing plan’s <code>aggregate_usage</code> <a
+     * href="/docs/api/plans/create#create_plan-aggregate_usage">parameter</a>. When
+     * there is more than one usage record with the same timestamp, Stripe adds the
+     * <code>quantity</code> values together. In most cases, this is the desired
+     * resolution, however, you can change this behavior with the <code>action</code>
+     * parameter.
+     *
+     * The default pricing model for metered billing is <a
+     * href="/docs/api/plans/object#plan_object-billing_scheme">per-unit pricing</a>.
+     * For finer granularity, you can configure metered billing to have a <a
+     * href="https://stripe.com/docs/billing/subscriptions/tiers">tiered pricing</a>
+     * model.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\UsageRecord
+     */
+    public function createUsageRecord($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscription_items/%s/usage_records', $parentId), $params, $opts);
+    }
+
+    /**
+     * Deletes an item from the subscription. Removing a subscription item from a
+     * subscription will not cancel the subscription.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionItem
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/subscription_items/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the invoice item with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionItem
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/subscription_items/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the plan or quantity of an item on a current subscription.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionItem
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscription_items/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/SubscriptionScheduleService.php
+++ b/lib/Service/SubscriptionScheduleService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Stripe\Service;
+
+class SubscriptionScheduleService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Retrieves the list of your subscription schedules.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/subscription_schedules', $params, $opts);
+    }
+
+    /**
+     * Cancels a subscription schedule and its associated subscription immediately (if
+     * the subscription schedule has an active subscription). A subscription schedule
+     * can only be canceled if its status is <code>not_started</code> or
+     * <code>active</code>.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionSchedule
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscription_schedules/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a new subscription schedule object. Each customer can have up to 25
+     * active or scheduled subscriptions.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionSchedule
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/subscription_schedules', $params, $opts);
+    }
+
+    /**
+     * Releases the subscription schedule immediately, which will stop scheduling of
+     * its phases, but leave any existing subscription in place. A schedule can only be
+     * released if its status is <code>not_started</code> or <code>active</code>. If
+     * the subscription schedule is currently associated with a subscription, releasing
+     * it will remove its <code>subscription</code> property and set the subscription’s
+     * ID to the <code>released_subscription</code> property.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionSchedule
+     */
+    public function release($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscription_schedules/%s/release', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing subscription schedule. You only need to
+     * supply the unique subscription schedule identifier that was returned upon
+     * subscription schedule creation.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionSchedule
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/subscription_schedules/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing subscription schedule.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SubscriptionSchedule
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscription_schedules/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/SubscriptionService.php
+++ b/lib/Service/SubscriptionService.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Stripe\Service;
+
+class SubscriptionService extends \Stripe\Service\AbstractService
+{
+    /**
+     * By default, returns a list of subscriptions that have not been canceled. In
+     * order to list canceled subscriptions, specify <code>status=canceled</code>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/subscriptions', $params, $opts);
+    }
+
+    /**
+     * Cancels a customer’s subscription immediately. The customer will not be charged
+     * again for the subscription.
+     *
+     * Note, however, that any pending invoice items that you’ve created will still be
+     * charged for at the end of the period, unless manually <a
+     * href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel
+     * at the end of the period, any pending prorations will also be left in place and
+     * collected at the end of the period. But if the subscription is set to cancel
+     * immediately, pending prorations will be removed.
+     *
+     * By default, upon subscription cancellation, Stripe will stop automatic
+     * collection of all finalized invoices for the customer. This is intended to
+     * prevent unexpected payment attempts after the customer has canceled a
+     * subscription. However, you can resume automatic collection of the invoices
+     * manually after subscription cancellation to have us proceed. Or, you could check
+     * for unpaid invoices before allowing the customer to cancel the subscription at
+     * all.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Subscription
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/subscriptions/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Creates a new subscription on an existing customer. Each customer can have up to
+     * 25 active or scheduled subscriptions.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Subscription
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/subscriptions', $params, $opts);
+    }
+
+    /**
+     * Removes the currently applied discount on a subscription.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Subscription
+     */
+    public function deleteDiscount($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/subscriptions/%s/discount', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the subscription with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Subscription
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/subscriptions/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing subscription on a customer to match the specified
+     * parameters. When changing plans or quantities, we will optionally prorate the
+     * price we charge next month to make up for any price changes. To preview how the
+     * proration will be calculated, use the <a href="#upcoming_invoice">upcoming
+     * invoice</a> endpoint.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Subscription
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/subscriptions/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/TaxRateService.php
+++ b/lib/Service/TaxRateService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Stripe\Service;
+
+class TaxRateService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your tax rates. Tax rates are returned sorted by creation
+     * date, with the most recently created tax rates appearing first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/tax_rates', $params, $opts);
+    }
+
+    /**
+     * Creates a new tax rate.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TaxRate
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/tax_rates', $params, $opts);
+    }
+
+    /**
+     * Retrieves a tax rate with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TaxRate
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/tax_rates/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates an existing tax rate.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TaxRate
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/tax_rates/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Terminal/ConnectionTokenService.php
+++ b/lib/Service/Terminal/ConnectionTokenService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+class ConnectionTokenService extends \Stripe\Service\AbstractService
+{
+    /**
+     * To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived
+     * connection token from Stripe, proxied through your server. On your backend, add
+     * an endpoint that creates and returns a connection token.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\ConnectionToken
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/terminal/connection_tokens', $params, $opts);
+    }
+}

--- a/lib/Service/Terminal/LocationService.php
+++ b/lib/Service/Terminal/LocationService.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+class LocationService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of <code>Location</code> objects.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/terminal/locations', $params, $opts);
+    }
+
+    /**
+     * Creates a new <code>Location</code> object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Location
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/terminal/locations', $params, $opts);
+    }
+
+    /**
+     * Deletes a <code>Location</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Location
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/terminal/locations/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a <code>Location</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Location
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/terminal/locations/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates a <code>Location</code> object by setting the values of the parameters
+     * passed. Any parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Location
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/terminal/locations/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Terminal/ReaderService.php
+++ b/lib/Service/Terminal/ReaderService.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+class ReaderService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of <code>Reader</code> objects.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/terminal/readers', $params, $opts);
+    }
+
+    /**
+     * Creates a new <code>Reader</code> object.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Reader
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/terminal/readers', $params, $opts);
+    }
+
+    /**
+     * Deletes a <code>Reader</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Reader
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/terminal/readers/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves a <code>Reader</code> object.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Reader
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/terminal/readers/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates a <code>Reader</code> object by setting the values of the parameters
+     * passed. Any parameters not provided will be left unchanged.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Terminal\Reader
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/terminal/readers/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/Terminal/TerminalServiceFactory.php
+++ b/lib/Service/Terminal/TerminalServiceFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+/**
+ * Service factory class for API resources in the Terminal namespace.
+ *
+ * @property ConnectionTokenService $connectionTokens
+ * @property LocationService $locations
+ * @property ReaderService $readers
+ */
+class TerminalServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'connectionTokens' => ConnectionTokenService::class,
+        'locations' => LocationService::class,
+        'readers' => ReaderService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Stripe\Service;
+
+class TokenService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Creates a single-use token that represents a bank account’s details. This token
+     * can be used with any API method in place of a bank account dictionary. This
+     * token can be used only once, by attaching it to a <a href="#accounts">Custom
+     * account</a>.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Token
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/tokens', $params, $opts);
+    }
+
+    /**
+     * Retrieves the token with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Token
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/tokens/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/TopupService.php
+++ b/lib/Service/TopupService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Stripe\Service;
+
+class TopupService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of top-ups.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/topups', $params, $opts);
+    }
+
+    /**
+     * Cancels a top-up. Only pending top-ups can be canceled.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Topup
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/topups/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * Top up the balance of an account.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Topup
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/topups', $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of a top-up that has previously been created. Supply the
+     * unique top-up ID that was returned from your previous request, and Stripe will
+     * return the corresponding top-up information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Topup
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/topups/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the metadata of a top-up. Other top-up details are not editable by
+     * design.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Topup
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/topups/%s', $id), $params, $opts);
+    }
+}

--- a/lib/Service/TransferService.php
+++ b/lib/Service/TransferService.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Stripe\Service;
+
+class TransferService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of existing transfers sent to connected accounts. The transfers
+     * are returned in sorted order, with the most recently created transfers appearing
+     * first.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/transfers', $params, $opts);
+    }
+
+    /**
+     * You can see a list of the reversals belonging to a specific transfer. Note that
+     * the 10 most recent reversals are always available by default on the transfer
+     * object. If you need more than those 10, you can use this API method and the
+     * <code>limit</code> and <code>starting_after</code> parameters to page through
+     * additional reversals.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function allReversals($parentId, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/transfers/%s/reversals', $parentId), $params, $opts);
+    }
+
+    /**
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Transfer
+     */
+    public function cancel($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/transfers/%s/cancel', $id), $params, $opts);
+    }
+
+    /**
+     * To send funds from your Stripe account to a connected account, you create a new
+     * transfer object. Your <a href="#balance">Stripe balance</a> must be able to
+     * cover the transfer amount, or you’ll receive an “Insufficient Funds” error.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Transfer
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/transfers', $params, $opts);
+    }
+
+    /**
+     * When you create a new reversal, you must specify a transfer to create it on.
+     *
+     * When reversing transfers, you can optionally reverse part of the transfer. You
+     * can do so as many times as you wish until the entire transfer has been reversed.
+     *
+     * Once entirely reversed, a transfer can’t be reversed again. This method will
+     * return an error when called on an already-reversed transfer, or when trying to
+     * reverse more money than is left on a transfer.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TransferReversal
+     */
+    public function createReversal($parentId, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/transfers/%s/reversals', $parentId), $params, $opts);
+    }
+
+    /**
+     * Retrieves the details of an existing transfer. Supply the unique transfer ID
+     * from either a transfer creation request or the transfer list, and Stripe will
+     * return the corresponding transfer information.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Transfer
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/transfers/%s', $id), $params, $opts);
+    }
+
+    /**
+     * By default, you can see the 10 most recent reversals stored directly on the
+     * transfer object, but you can also retrieve details about a specific reversal
+     * stored on the transfer.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TransferReversal
+     */
+    public function retrieveReversal($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/transfers/%s/reversals/%s', $parentId, $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified transfer by setting the values of the parameters passed.
+     * Any parameters not provided will be left unchanged.
+     *
+     * This request accepts only metadata as an argument.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Transfer
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/transfers/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the specified reversal by setting the values of the parameters passed.
+     * Any parameters not provided will be left unchanged.
+     *
+     * This request only accepts metadata and description as arguments.
+     *
+     * @param string $parentId
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     * @param mixed $id
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\TransferReversal
+     */
+    public function updateReversal($parentId, $id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/transfers/%s/reversals/%s', $parentId, $id), $params, $opts);
+    }
+}

--- a/lib/Service/TransferService.php
+++ b/lib/Service/TransferService.php
@@ -119,9 +119,9 @@ class TransferService extends \Stripe\Service\AbstractService
      * stored on the transfer.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -158,9 +158,9 @@ class TransferService extends \Stripe\Service\AbstractService
      * This request only accepts metadata and description as arguments.
      *
      * @param string $parentId
+     * @param string $id
      * @param null|array $params
      * @param null|array|\Stripe\Util\RequestOptions $opts
-     * @param mixed $id
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *

--- a/lib/Service/WebhookEndpointService.php
+++ b/lib/Service/WebhookEndpointService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Stripe\Service;
+
+class WebhookEndpointService extends \Stripe\Service\AbstractService
+{
+    /**
+     * Returns a list of your webhook endpoints.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection
+     */
+    public function all($params = null, $opts = null)
+    {
+        return $this->request('get', '/v1/webhook_endpoints', $params, $opts);
+    }
+
+    /**
+     * A webhook endpoint must have a <code>url</code> and a list of
+     * <code>enabled_events</code>. You may optionally specify the Boolean
+     * <code>connect</code> parameter. If set to true, then a Connect webhook endpoint
+     * that notifies the specified <code>url</code> about events from all connected
+     * accounts is created; otherwise an account webhook endpoint that notifies the
+     * specified <code>url</code> only about events from your account is created. You
+     * can also create webhook endpoints in the <a
+     * href="https://dashboard.stripe.com/account/webhooks">webhooks settings</a>
+     * section of the Dashboard.
+     *
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\WebhookEndpoint
+     */
+    public function create($params = null, $opts = null)
+    {
+        return $this->request('post', '/v1/webhook_endpoints', $params, $opts);
+    }
+
+    /**
+     * You can also delete webhook endpoints via the <a
+     * href="https://dashboard.stripe.com/account/webhooks">webhook endpoint
+     * management</a> page of the Stripe dashboard.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\WebhookEndpoint
+     */
+    public function delete($id, $params = null, $opts = null)
+    {
+        return $this->request('delete', $this->buildPath('/v1/webhook_endpoints/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Retrieves the webhook endpoint with the given ID.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\WebhookEndpoint
+     */
+    public function retrieve($id, $params = null, $opts = null)
+    {
+        return $this->request('get', $this->buildPath('/v1/webhook_endpoints/%s', $id), $params, $opts);
+    }
+
+    /**
+     * Updates the webhook endpoint. You may edit the <code>url</code>, the list of
+     * <code>enabled_events</code>, and the status of your endpoint.
+     *
+     * @param string $id
+     * @param null|array $params
+     * @param null|array|\Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\WebhookEndpoint
+     */
+    public function update($id, $params = null, $opts = null)
+    {
+        return $this->request('post', $this->buildPath('/v1/webhook_endpoints/%s', $id), $params, $opts);
+    }
+}

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Stripe;
+
+class StripeClient implements StripeClientInterface
+{
+    /**
+     * @var string default base URL for Stripe's API
+     */
+    const DEFAULT_API_BASE = 'https://api.stripe.com';
+
+    /**
+     * @var string default base URL for Stripe's OAuth API
+     */
+    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
+
+    /**
+     * @var string default base URL for Stripe's Files API
+     */
+    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
+
+    private $apiKey;
+    private $clientId;
+
+    private $apiBase;
+    private $connectBase;
+    private $filesBase;
+
+    /**
+     * Initializes a new instance of the {@link StripeClient} class.
+     *
+     * @param null|string $apiKey the API key used by the client to make requests
+     * @param null|string $clientId the client ID used by the client in OAuth requests
+     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
+     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
+     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     */
+    public function __construct(
+        $apiKey,
+        $clientId = null,
+        $apiBase = null,
+        $connectBase = null,
+        $filesBase = null
+    ) {
+        if (null !== $apiKey && ('' === $apiKey)) {
+            $msg = 'API key cannot be the empty string.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+        if (null !== $apiKey && (\preg_match('/\s/', $apiKey))) {
+            $msg = 'API key cannot contain whitespace.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        $this->apiKey = $apiKey;
+        $this->clientId = $clientId;
+
+        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
+        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
+        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+    }
+
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return null|string the API key used by the client to send requests
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return null|string the client ID used by the client in OAuth requests
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string the base URL for Stripe's API
+     */
+    public function getApiBase()
+    {
+        return $this->apiBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string the base URL for Stripe's OAuth API
+     */
+    public function getConnectBase()
+    {
+        return $this->connectBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string the base URL for Stripe's Files API
+     */
+    public function getFilesBase()
+    {
+        return $this->filesBase;
+    }
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\StripeObject the object returned by Stripe's API
+     */
+    public function request($method, $path, $params, $opts)
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $baseUrl = $opts->apiBase ?: $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+
+        return $obj;
+    }
+
+    private function apiKeyForRequest($opts)
+    {
+        $apiKey = $opts->apiKey ?: $this->getApiKey();
+
+        if (null === $apiKey) {
+            $msg = 'No API key provided. Set your API key when constructing the '
+                . 'StripeClient instance, or provide it on a per-request basis '
+                . 'using the `api_key` key in the $opts argument.';
+
+            throw new Exception\AuthenticationException($msg);
+        }
+
+        return $apiKey;
+    }
+}

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -9,8 +9,8 @@ namespace Stripe;
  * @property \Stripe\Service\AccountService $accounts
  * @property \Stripe\Service\ApplePayDomainService $applePayDomains
  * @property \Stripe\Service\ApplicationFeeService $applicationFees
+ * @property \Stripe\Service\BalanceService $balance
  * @property \Stripe\Service\BalanceTransactionService $balanceTransactions
- * @property \Stripe\Service\BalanceService $balances
  * @property \Stripe\Service\BillingPortal\BillingPortalServiceFactory $billingPortal
  * @property \Stripe\Service\ChargeService $charges
  * @property \Stripe\Service\Checkout\CheckoutServiceFactory $checkout

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -2,150 +2,69 @@
 
 namespace Stripe;
 
-class StripeClient implements StripeClientInterface
+/**
+ * Client used to send requests to Stripe's API.
+ *
+ * @property \Stripe\Service\AccountLinkService $accountLinks
+ * @property \Stripe\Service\AccountService $accounts
+ * @property \Stripe\Service\ApplePayDomainService $applePayDomains
+ * @property \Stripe\Service\ApplicationFeeService $applicationFees
+ * @property \Stripe\Service\BalanceTransactionService $balanceTransactions
+ * @property \Stripe\Service\BalanceService $balances
+ * @property \Stripe\Service\ChargeService $charges
+ * @property \Stripe\Service\Checkout\CheckoutServiceFactory $checkout
+ * @property \Stripe\Service\CountrySpecService $countrySpecs
+ * @property \Stripe\Service\CouponService $coupons
+ * @property \Stripe\Service\CreditNoteService $creditNotes
+ * @property \Stripe\Service\CustomerService $customers
+ * @property \Stripe\Service\DisputeService $disputes
+ * @property \Stripe\Service\EphemeralKeyService $ephemeralKeys
+ * @property \Stripe\Service\EventService $events
+ * @property \Stripe\Service\ExchangeRateService $exchangeRates
+ * @property \Stripe\Service\FileLinkService $fileLinks
+ * @property \Stripe\Service\FileService $files
+ * @property \Stripe\Service\InvoiceItemService $invoiceItems
+ * @property \Stripe\Service\InvoiceService $invoices
+ * @property \Stripe\Service\Issuing\IssuingServiceFactory $issuing
+ * @property \Stripe\Service\MandateService $mandates
+ * @property \Stripe\Service\OrderReturnService $orderReturns
+ * @property \Stripe\Service\OrderService $orders
+ * @property \Stripe\Service\PaymentIntentService $paymentIntents
+ * @property \Stripe\Service\PaymentMethodService $paymentMethods
+ * @property \Stripe\Service\PayoutService $payouts
+ * @property \Stripe\Service\PlanService $plans
+ * @property \Stripe\Service\ProductService $products
+ * @property \Stripe\Service\Radar\RadarServiceFactory $radar
+ * @property \Stripe\Service\RefundService $refunds
+ * @property \Stripe\Service\Reporting\ReportingServiceFactory $reporting
+ * @property \Stripe\Service\ReviewService $reviews
+ * @property \Stripe\Service\SetupIntentService $setupIntents
+ * @property \Stripe\Service\Sigma\SigmaServiceFactory $sigma
+ * @property \Stripe\Service\SkuService $skus
+ * @property \Stripe\Service\SourceService $sources
+ * @property \Stripe\Service\SubscriptionItemService $subscriptionItems
+ * @property \Stripe\Service\SubscriptionScheduleService $subscriptionSchedules
+ * @property \Stripe\Service\SubscriptionService $subscriptions
+ * @property \Stripe\Service\TaxRateService $taxRates
+ * @property \Stripe\Service\Terminal\TerminalServiceFactory $terminal
+ * @property \Stripe\Service\TokenService $tokens
+ * @property \Stripe\Service\TopupService $topups
+ * @property \Stripe\Service\TransferService $transfers
+ * @property \Stripe\Service\WebhookEndpointService $webhookEndpoints
+ */
+class StripeClient extends BaseStripeClient
 {
     /**
-     * @var string default base URL for Stripe's API
+     * @var \Stripe\Service\CoreServiceFactory
      */
-    const DEFAULT_API_BASE = 'https://api.stripe.com';
+    private $coreServiceFactory;
 
-    /**
-     * @var string default base URL for Stripe's OAuth API
-     */
-    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
-
-    /**
-     * @var string default base URL for Stripe's Files API
-     */
-    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
-
-    private $apiKey;
-    private $clientId;
-
-    private $apiBase;
-    private $connectBase;
-    private $filesBase;
-
-    /**
-     * Initializes a new instance of the {@link StripeClient} class.
-     *
-     * @param null|string $apiKey the API key used by the client to make requests
-     * @param null|string $clientId the client ID used by the client in OAuth requests
-     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
-     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
-     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
-     */
-    public function __construct(
-        $apiKey,
-        $clientId = null,
-        $apiBase = null,
-        $connectBase = null,
-        $filesBase = null
-    ) {
-        if (null !== $apiKey && ('' === $apiKey)) {
-            $msg = 'API key cannot be the empty string.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
-        }
-        if (null !== $apiKey && (\preg_match('/\s/', $apiKey))) {
-            $msg = 'API key cannot contain whitespace.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
+    public function __get($name)
+    {
+        if (null === $this->coreServiceFactory) {
+            $this->coreServiceFactory = new \Stripe\Service\CoreServiceFactory($this);
         }
 
-        $this->apiKey = $apiKey;
-        $this->clientId = $clientId;
-
-        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
-        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
-        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
-    }
-
-    /**
-     * Gets the API key used by the client to send requests.
-     *
-     * @return null|string the API key used by the client to send requests
-     */
-    public function getApiKey()
-    {
-        return $this->apiKey;
-    }
-
-    /**
-     * Gets the client ID used by the client in OAuth requests.
-     *
-     * @return null|string the client ID used by the client in OAuth requests
-     */
-    public function getClientId()
-    {
-        return $this->clientId;
-    }
-
-    /**
-     * Gets the base URL for Stripe's API.
-     *
-     * @return string the base URL for Stripe's API
-     */
-    public function getApiBase()
-    {
-        return $this->apiBase;
-    }
-
-    /**
-     * Gets the base URL for Stripe's OAuth API.
-     *
-     * @return string the base URL for Stripe's OAuth API
-     */
-    public function getConnectBase()
-    {
-        return $this->connectBase;
-    }
-
-    /**
-     * Gets the base URL for Stripe's Files API.
-     *
-     * @return string the base URL for Stripe's Files API
-     */
-    public function getFilesBase()
-    {
-        return $this->filesBase;
-    }
-
-    /**
-     * Sends a request to Stripe's API.
-     *
-     * @param string $method the HTTP method
-     * @param string $path the path of the request
-     * @param array $params the parameters of the request
-     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
-     *
-     * @return \Stripe\StripeObject the object returned by Stripe's API
-     */
-    public function request($method, $path, $params, $opts)
-    {
-        $opts = \Stripe\Util\RequestOptions::parse($opts);
-        $baseUrl = $opts->apiBase ?: $this->getApiBase();
-        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
-        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
-        $opts->discardNonPersistentHeaders();
-        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
-        $obj->setLastResponse($response);
-
-        return $obj;
-    }
-
-    private function apiKeyForRequest($opts)
-    {
-        $apiKey = $opts->apiKey ?: $this->getApiKey();
-
-        if (null === $apiKey) {
-            $msg = 'No API key provided. Set your API key when constructing the '
-                . 'StripeClient instance, or provide it on a per-request basis '
-                . 'using the `api_key` key in the $opts argument.';
-
-            throw new Exception\AuthenticationException($msg);
-        }
-
-        return $apiKey;
+        return $this->coreServiceFactory->__get($name);
     }
 }

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -11,6 +11,7 @@ namespace Stripe;
  * @property \Stripe\Service\ApplicationFeeService $applicationFees
  * @property \Stripe\Service\BalanceTransactionService $balanceTransactions
  * @property \Stripe\Service\BalanceService $balances
+ * @property \Stripe\Service\BillingPortal\BillingPortalServiceFactory $billingPortal
  * @property \Stripe\Service\ChargeService $charges
  * @property \Stripe\Service\Checkout\CheckoutServiceFactory $checkout
  * @property \Stripe\Service\CountrySpecService $countrySpecs
@@ -33,6 +34,7 @@ namespace Stripe;
  * @property \Stripe\Service\PaymentMethodService $paymentMethods
  * @property \Stripe\Service\PayoutService $payouts
  * @property \Stripe\Service\PlanService $plans
+ * @property \Stripe\Service\PriceService $prices
  * @property \Stripe\Service\ProductService $products
  * @property \Stripe\Service\Radar\RadarServiceFactory $radar
  * @property \Stripe\Service\RefundService $refunds

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Interface for a Stripe client.
+ */
+interface StripeClientInterface
+{
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return null|string the API key used by the client to send requests
+     */
+    public function getApiKey();
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return null|string the client ID used by the client in OAuth requests
+     */
+    public function getClientId();
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string the base URL for Stripe's API
+     */
+    public function getApiBase();
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string the base URL for Stripe's OAuth API
+     */
+    public function getConnectBase();
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string the base URL for Stripe's Files API
+     */
+    public function getFilesBase();
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\StripeObject the object returned by Stripe's API
+     */
+    public function request($method, $path, $params, $opts);
+}

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -2,22 +2,30 @@
 
 namespace Stripe\Util;
 
-use Stripe\Exception;
-
 class RequestOptions
 {
     /**
-     * @var array a list of headers that should be persisted across requests
+     * @var array<string> a list of headers that should be persisted across requests
      */
     public static $HEADERS_TO_PERSIST = [
         'Stripe-Account',
         'Stripe-Version',
     ];
 
+    /** @var array<string, string> */
     public $headers;
+
+    /** @var null|string */
     public $apiKey;
+
+    /** @var null|string */
     public $apiBase;
 
+    /**
+     * @param null|string $key
+     * @param array<string, string> $headers
+     * @param null|string $base
+     */
     public function __construct($key = null, $headers = [], $base = null)
     {
         $this->apiKey = $key;
@@ -25,6 +33,9 @@ class RequestOptions
         $this->apiBase = $base;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function __debugInfo()
     {
         return [
@@ -38,13 +49,14 @@ class RequestOptions
      * Unpacks an options array and merges it into the existing RequestOptions
      * object.
      *
-     * @param null|array|string $options a key => value array
+     * @param null|array|RequestOptions|string $options a key => value array
+     * @param bool $strict when true, forbid string form and arbitrary keys in array form
      *
      * @return RequestOptions
      */
-    public function merge($options)
+    public function merge($options, $strict = false)
     {
-        $other_options = self::parse($options);
+        $other_options = self::parse($options, $strict);
         if (null === $other_options->apiKey) {
             $other_options->apiKey = $this->apiKey;
         }
@@ -71,11 +83,14 @@ class RequestOptions
     /**
      * Unpacks an options array into an RequestOptions object.
      *
-     * @param null|array|string $options a key => value array
+     * @param null|array|RequestOptions|string $options a key => value array
+     * @param bool $strict when true, forbid string form and arbitrary keys in array form
+     *
+     * @throws \Stripe\Exception\InvalidArgumentException
      *
      * @return RequestOptions
      */
-    public static function parse($options)
+    public static function parse($options, $strict = false)
     {
         if ($options instanceof self) {
             return $options;
@@ -86,6 +101,13 @@ class RequestOptions
         }
 
         if (\is_string($options)) {
+            if ($strict) {
+                $message = 'Do not pass a string for request options. If you want to set the '
+                    . 'API key, pass an array like ["api_key" => <apiKey>] instead.';
+
+                throw new \Stripe\Exception\InvalidArgumentException($message);
+            }
+
             return new RequestOptions($options, [], null);
         }
 
@@ -93,20 +115,32 @@ class RequestOptions
             $headers = [];
             $key = null;
             $base = null;
+
             if (\array_key_exists('api_key', $options)) {
                 $key = $options['api_key'];
+                unset($options['api_key']);
             }
             if (\array_key_exists('idempotency_key', $options)) {
                 $headers['Idempotency-Key'] = $options['idempotency_key'];
+                unset($options['idempotency_key']);
             }
             if (\array_key_exists('stripe_account', $options)) {
                 $headers['Stripe-Account'] = $options['stripe_account'];
+                unset($options['stripe_account']);
             }
             if (\array_key_exists('stripe_version', $options)) {
                 $headers['Stripe-Version'] = $options['stripe_version'];
+                unset($options['stripe_version']);
             }
             if (\array_key_exists('api_base', $options)) {
                 $base = $options['api_base'];
+                unset($options['api_base']);
+            }
+
+            if ($strict && !empty($options)) {
+                $message = 'Got unexpected keys in options array: ' . \implode(', ', \array_keys($options));
+
+                throw new \Stripe\Exception\InvalidArgumentException($message);
             }
 
             return new RequestOptions($key, $headers, $base);
@@ -117,7 +151,7 @@ class RequestOptions
            . 'per-request options, which must be an array. (HINT: you can set '
            . 'a global apiKey by "Stripe::setApiKey(<apiKey>)")';
 
-        throw new Exception\InvalidArgumentException($message);
+        throw new \Stripe\Exception\InvalidArgumentException($message);
     }
 
     private function redactedApiKey()

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ * @covers \Stripe\BaseStripeClient
+ */
+final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    {
+        $client = new BaseStripeClient(null);
+        static::assertNotNull($client);
+        static::assertNull($client->getApiKey());
+    }
+
+    public function testCtorThrowsIfApiKeyIsEmpty()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot be the empty string.');
+
+        $client = new BaseStripeClient('');
+    }
+
+    public function testCtorThrowsIfApiKeyContainsWhitespace()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot contain whitespace.');
+
+        $client = new BaseStripeClient("sk_test_123\n");
+    }
+
+    public function testRequestWithClientApiKey()
+    {
+        $client = new BaseStripeClient('sk_test_client', null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_client', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestWithOptsApiKey()
+    {
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
+        static::assertNotNull($charge);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_opts', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
+    {
+        $this->expectException(\Stripe\Exception\AuthenticationException::class);
+        $this->expectExceptionMessage('No API key provided.');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
+}

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -8,9 +8,9 @@ namespace Stripe;
  */
 final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    public function testCtorDoesNotThrowWhenNoParams()
     {
-        $client = new BaseStripeClient(null);
+        $client = new BaseStripeClient();
         static::assertNotNull($client);
         static::assertNull($client->getApiKey());
     }
@@ -33,7 +33,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 
     public function testRequestWithClientApiKey()
     {
-        $client = new BaseStripeClient('sk_test_client', null, MOCK_URL);
+        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], []);
         static::assertNotNull($charge);
         $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
@@ -43,9 +43,8 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 
     public function testRequestWithOptsApiKey()
     {
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
-        static::assertNotNull($charge);
         static::assertNotNull($charge);
         $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
         $optsReflector->setAccessible(true);
@@ -57,7 +56,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\AuthenticationException::class);
         $this->expectExceptionMessage('No API key provided.');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], []);
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
@@ -68,7 +67,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#Do not pass a string for request options.#');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], 'foo');
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
@@ -79,7 +78,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Got unexpected keys in options array: foo');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], ['foo' => 'bar']);
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -25,10 +25,18 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         static::assertNull($client->getApiKey());
     }
 
+    public function testCtorThrowsIfConfigIsUnexpectedType()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$config must be a string or an array');
+
+        $client = new BaseStripeClient(234);
+    }
+
     public function testCtorThrowsIfApiKeyIsEmpty()
     {
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot be the empty string.');
+        $this->expectExceptionMessage('api_key cannot be the empty string');
 
         $client = new BaseStripeClient('');
     }
@@ -36,9 +44,25 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
     public function testCtorThrowsIfApiKeyContainsWhitespace()
     {
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot contain whitespace.');
+        $this->expectExceptionMessage('api_key cannot contain whitespace');
 
         $client = new BaseStripeClient("sk_test_123\n");
+    }
+
+    public function testCtorThrowsIfApiKeyIsUnexpectedType()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('api_key must be null or a string');
+
+        $client = new BaseStripeClient(['api_key' => 234]);
+    }
+
+    public function testCtorThrowsIfConfigArrayContainsUnexpectedKey()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Found unknown key(s) in configuration array: foo');
+
+        $client = new BaseStripeClient(['foo' => 'bar']);
     }
 
     public function testRequestWithClientApiKey()

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -62,4 +62,26 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
     }
+
+    public function testRequestThrowsIfOptsIsString()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('#Do not pass a string for request options.#');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], 'foo');
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
+
+    public function testRequestThrowsIfOptsIsArrayWithUnexpectedKeys()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Got unexpected keys in options array: foo');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], ['foo' => 'bar']);
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
 }

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service;
 
 /**
  * @internal
+ * @covers \Stripe\Service\AbstractService
  */
 final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ */
+final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
+{
+    const TEST_RESOURCE_ID = '25OFF';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    public function setUpMockService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        // Testing with CouponService, because testing abstract classes is hard in PHP :/
+        $this->service = new \Stripe\Service\CouponService($this->client);
+    }
+
+    public function testRetrieveThrowsIfIdNullIsNull()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resource ID cannot be null or whitespace.');
+
+        $this->service->retrieve(null);
+    }
+
+    public function testRetrieveThrowsIfIdNullIsEmpty()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resource ID cannot be null or whitespace.');
+
+        $this->service->retrieve('');
+    }
+
+    public function testRetrieveThrowsIfIdNullIsWhitespace()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resource ID cannot be null or whitespace.');
+
+        $this->service->retrieve(' ');
+    }
+}

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -9,7 +9,10 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_RESOURCE_ID = '25OFF';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var CouponService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -26,6 +26,14 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         $this->service = new \Stripe\Service\CouponService($this->client);
     }
 
+    public function testNullGetsEmptyStringified()
+    {
+      $this->expectException(\Stripe\Exception\InvalidRequestException::class);
+      $this->service->update("id", [
+        "doesnotexist" => null
+      ]);
+    }
+
     public function testRetrieveThrowsIfIdNullIsNull()
     {
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -28,10 +28,10 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testNullGetsEmptyStringified()
     {
-      $this->expectException(\Stripe\Exception\InvalidRequestException::class);
-      $this->service->update("id", [
-        "doesnotexist" => null
-      ]);
+        $this->expectException(\Stripe\Exception\InvalidRequestException::class);
+        $this->service->update('id', [
+            'doesnotexist' => null,
+        ]);
     }
 
     public function testRetrieveThrowsIfIdNullIsNull()

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -21,7 +21,7 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
      */
     public function setUpMockService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         // Testing with CouponService, because testing abstract classes is hard in PHP :/
         $this->service = new \Stripe\Service\CouponService($this->client);
     }

--- a/tests/Stripe/Service/AccountLinkServiceTest.php
+++ b/tests/Stripe/Service/AccountLinkServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\AccountLinkService
+ */
+final class AccountLinkServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var AccountLinkService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new AccountLinkService($this->client);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/account_links'
+        );
+        $resource = $this->service->create([
+            'account' => 'acct_123',
+            'failure_url' => 'https://stripe.com/failure',
+            'success_url' => 'https://stripe.com/success',
+            'type' => 'custom_account_verification',
+        ]);
+        static::assertInstanceOf(\Stripe\AccountLink::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/AccountLinkServiceTest.php
+++ b/tests/Stripe/Service/AccountLinkServiceTest.php
@@ -21,7 +21,7 @@ final class AccountLinkServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AccountLinkService($this->client);
     }
 

--- a/tests/Stripe/Service/AccountServiceTest.php
+++ b/tests/Stripe/Service/AccountServiceTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\AccountService
+ */
+final class AccountServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'acct_123';
+    const TEST_CAPABILITY_ID = 'acap_123';
+    const TEST_EXTERNALACCOUNT_ID = 'ba_123';
+    const TEST_PERSON_ID = 'person_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var AccountService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new AccountService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Account::class, $resources->data[0]);
+    }
+
+    public function testAllCapabilities()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities'
+        );
+        $resources = $this->service->allCapabilities(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Capability::class, $resources->data[0]);
+    }
+
+    public function testAllExternalAccounts()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
+        );
+        $resources = $this->service->allExternalAccounts(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resources->data[0]);
+    }
+
+    public function testAllPersons()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons'
+        );
+        $resources = $this->service->allPersons(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Person::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts'
+        );
+        $resource = $this->service->create(['type' => 'custom']);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+    }
+
+    public function testCreateExternalAccount()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
+        );
+        $resource = $this->service->createExternalAccount(self::TEST_RESOURCE_ID, [
+            'external_account' => 'btok_123',
+        ]);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
+    }
+
+    public function testCreateLoginLink()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/login_links'
+        );
+        $resource = $this->service->createLoginLink(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\LoginLink::class, $resource);
+    }
+
+    public function testCreatePerson()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons'
+        );
+        $resource = $this->service->createPerson(self::TEST_RESOURCE_ID, [
+            'dob' => [
+                'day' => 1,
+                'month' => 1,
+                'year' => 1980,
+            ],
+        ]);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testDeleteExternalAccount()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
+        );
+        $resource = $this->service->deleteExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testDeletePerson()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons/' . self::TEST_PERSON_ID
+        );
+        $resource = $this->service->deletePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testReject()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/reject'
+        );
+        $resource = $this->service->reject(self::TEST_RESOURCE_ID, ['reason' => 'fraud']);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+    }
+
+    public function testRetrieveCapability()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities/' . self::TEST_CAPABILITY_ID
+        );
+        $resource = $this->service->retrieveCapability(self::TEST_RESOURCE_ID, self::TEST_CAPABILITY_ID);
+        static::assertInstanceOf(\Stripe\Capability::class, $resource);
+    }
+
+    public function testRetrieveExternalAccount()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
+        );
+        $resource = $this->service->retrieveExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
+    }
+
+    public function testRetrievePerson()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons/' . self::TEST_PERSON_ID
+        );
+        $resource = $this->service->retrievePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+    }
+
+    public function testUpdateCapability()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities/' . self::TEST_CAPABILITY_ID
+        );
+        $resource = $this->service->updateCapability(self::TEST_RESOURCE_ID, self::TEST_CAPABILITY_ID, [
+            'requested' => true,
+        ]);
+        static::assertInstanceOf(\Stripe\Capability::class, $resource);
+    }
+
+    public function testUpdateExternalAccount()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
+        );
+        $resource = $this->service->updateExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID, [
+            'name' => 'name',
+        ]);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
+    }
+
+    public function testUpdatePerson()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons/' . self::TEST_PERSON_ID
+        );
+        $resource = $this->service->updatePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID, [
+            'first_name' => 'First name',
+        ]);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
+    }
+
+    public function testRetrieveWithId()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/accounts/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+    }
+
+    public function testRetrieveWithoutId()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/account'
+        );
+        $resource = $this->service->retrieve();
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/AccountServiceTest.php
+++ b/tests/Stripe/Service/AccountServiceTest.php
@@ -26,7 +26,7 @@ final class AccountServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AccountService($this->client);
     }
 

--- a/tests/Stripe/Service/ApplePayDomainServiceTest.php
+++ b/tests/Stripe/Service/ApplePayDomainServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ApplePayDomainService
+ */
+final class ApplePayDomainServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'apwc_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ApplePayDomainService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ApplePayDomainService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/apple_pay/domains'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/apple_pay/domains'
+        );
+        $resource = $this->service->create([
+            'domain_name' => 'domain',
+        ]);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/apple_pay/domains/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/apple_pay/domains/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ApplePayDomainServiceTest.php
+++ b/tests/Stripe/Service/ApplePayDomainServiceTest.php
@@ -23,7 +23,7 @@ final class ApplePayDomainServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ApplePayDomainService($this->client);
     }
 

--- a/tests/Stripe/Service/ApplicationFeeServiceTest.php
+++ b/tests/Stripe/Service/ApplicationFeeServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ApplicationFeeService
+ */
+final class ApplicationFeeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'fee_123';
+    const TEST_FEEREFUND_ID = 'fr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ApplicationFeeService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ApplicationFeeService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/application_fees'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplicationFee::class, $resources->data[0]);
+    }
+
+    public function testAllRefunds()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
+        );
+        $resources = $this->service->allRefunds(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resources->data[0]);
+    }
+
+    public function testCreateRefund()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
+        );
+        $resource = $this->service->createRefund(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/application_fees/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\ApplicationFee::class, $resource);
+    }
+
+    public function testRetrieveRefund()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
+        );
+        $resource = $this->service->retrieveRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+    }
+
+    public function testUpdateRefund()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
+        );
+        $resource = $this->service->updateRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ApplicationFeeServiceTest.php
+++ b/tests/Stripe/Service/ApplicationFeeServiceTest.php
@@ -24,7 +24,7 @@ final class ApplicationFeeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ApplicationFeeService($this->client);
     }
 

--- a/tests/Stripe/Service/BalanceServiceTest.php
+++ b/tests/Stripe/Service/BalanceServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\BalanceService
+ */
+final class BalanceServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var BalanceService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new BalanceService($this->client);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/balance'
+        );
+        $resource = $this->service->retrieve();
+        static::assertInstanceOf(\Stripe\Balance::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/BalanceServiceTest.php
+++ b/tests/Stripe/Service/BalanceServiceTest.php
@@ -21,7 +21,7 @@ final class BalanceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new BalanceService($this->client);
     }
 

--- a/tests/Stripe/Service/BalanceTransactionServiceTest.php
+++ b/tests/Stripe/Service/BalanceTransactionServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\BalanceTransactionService
+ */
+final class BalanceTransactionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'txn_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var BalanceTransactionService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new BalanceTransactionService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/balance_transactions'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\BalanceTransaction::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/balance_transactions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\BalanceTransaction::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/BalanceTransactionServiceTest.php
+++ b/tests/Stripe/Service/BalanceTransactionServiceTest.php
@@ -23,7 +23,7 @@ final class BalanceTransactionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new BalanceTransactionService($this->client);
     }
 

--- a/tests/Stripe/Service/BillingPortal/SessionServiceTest.php
+++ b/tests/Stripe/Service/BillingPortal/SessionServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Stripe\Service\BillingPortal;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\BillingPortal\SessionService
+ */
+final class SessionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'cs_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SessionService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
+        $this->service = new SessionService($this->client);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/billing_portal/sessions'
+        );
+        $resource = $this->service->create([
+            'customer' => 'cus_123',
+            'return_url' => 'https://stripe.com/return',
+        ]);
+        static::assertInstanceOf(\Stripe\BillingPortal\Session::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ChargeServiceTest.php
+++ b/tests/Stripe/Service/ChargeServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ChargeService
+ */
+final class ChargeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ch_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ChargeService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ChargeService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/charges'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Charge::class, $resources->data[0]);
+    }
+
+    public function testCapture()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/charges/' . self::TEST_RESOURCE_ID . '/capture'
+        );
+        $resource = $this->service->capture(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/charges'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+            'source' => 'tok_123',
+        ]);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/charges/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/charges/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ChargeServiceTest.php
+++ b/tests/Stripe/Service/ChargeServiceTest.php
@@ -23,7 +23,7 @@ final class ChargeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ChargeService($this->client);
     }
 

--- a/tests/Stripe/Service/Checkout/SessionServiceTest.php
+++ b/tests/Stripe/Service/Checkout/SessionServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Stripe\Service\Checkout;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Checkout\SessionService
+ */
+final class SessionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'cs_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SessionService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SessionService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/checkout/sessions'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Checkout\Session::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/checkout/sessions'
+        );
+        $resource = $this->service->create([
+            'cancel_url' => 'https://stripe.com/cancel',
+            'client_reference_id' => '1234',
+            'line_items' => [
+                [
+                    'amount' => 123,
+                    'currency' => 'usd',
+                    'description' => 'item 1',
+                    'images' => [
+                        'https://stripe.com/img1',
+                    ],
+                    'name' => 'name',
+                    'quantity' => 2,
+                ],
+            ],
+            'payment_intent_data' => [
+                'receipt_email' => 'test@stripe.com',
+            ],
+            'payment_method_types' => ['card'],
+            'success_url' => 'https://stripe.com/success',
+        ]);
+        static::assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/checkout/sessions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Checkout/SessionServiceTest.php
+++ b/tests/Stripe/Service/Checkout/SessionServiceTest.php
@@ -23,7 +23,7 @@ final class SessionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SessionService($this->client);
     }
 

--- a/tests/Stripe/Service/CoreServiceFactoryTest.php
+++ b/tests/Stripe/Service/CoreServiceFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\CoreServiceFactory
+ */
+final class CoreServiceFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var CoreServiceFactory */
+    private $serviceFactory;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->serviceFactory = new CoreServiceFactory($this->client);
+    }
+
+    public function testExposesPropertiesForServices()
+    {
+        static::assertInstanceOf(CouponService::class, $this->serviceFactory->coupons);
+        static::assertInstanceOf(\Stripe\Service\Issuing\IssuingServiceFactory::class, $this->serviceFactory->issuing);
+    }
+
+    public function testMultipleCallsReturnSameInstance()
+    {
+        $service = $this->serviceFactory->coupons;
+        static::assertSame($service, $this->serviceFactory->coupons);
+    }
+}

--- a/tests/Stripe/Service/CoreServiceFactoryTest.php
+++ b/tests/Stripe/Service/CoreServiceFactoryTest.php
@@ -19,7 +19,7 @@ final class CoreServiceFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->serviceFactory = new CoreServiceFactory($this->client);
     }
 

--- a/tests/Stripe/Service/CountrySpecServiceTest.php
+++ b/tests/Stripe/Service/CountrySpecServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\CountrySpecService
+ */
+final class CountrySpecServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'US';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var CountrySpecService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CountrySpecService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/country_specs'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CountrySpec::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/country_specs/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\CountrySpec::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/CountrySpecServiceTest.php
+++ b/tests/Stripe/Service/CountrySpecServiceTest.php
@@ -23,7 +23,7 @@ final class CountrySpecServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CountrySpecService($this->client);
     }
 

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -11,7 +11,10 @@ final class CouponServiceTest extends \PHPUnit\Framework\TestCase
 
     const TEST_RESOURCE_ID = 'COUPON_ID';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var CouponService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service;
 
 /**
  * @internal
+ * @covers \Stripe\Service\CouponService
  */
 final class CouponServiceTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ */
+final class CouponServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'COUPON_ID';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CouponService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/coupons'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/coupons'
+        );
+        $resource = $this->service->create([
+            'percent_off' => 25,
+            'duration' => 'repeating',
+            'duration_in_months' => 3,
+        ]);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/coupons/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -23,7 +23,7 @@ final class CouponServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CouponService($this->client);
     }
 

--- a/tests/Stripe/Service/CreditNoteServiceTest.php
+++ b/tests/Stripe/Service/CreditNoteServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\CreditNoteService
+ */
+final class CreditNoteServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'cn_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var CreditNoteService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CreditNoteService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/credit_notes'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resources->data[0]);
+    }
+
+    public function testAllLines()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/credit_notes/' . self::TEST_RESOURCE_ID . '/lines'
+        );
+        $resources = $this->service->allLines(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CreditNoteLineItem::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/credit_notes'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'invoice' => 'in_132',
+            'reason' => 'duplicate',
+        ]);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+    }
+
+    public function testPreview()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/credit_notes/preview'
+        );
+        $resource = $this->service->preview([
+            'amount' => 100,
+            'invoice' => 'in_123',
+        ]);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+    }
+
+    public function testPreviewLines()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/credit_notes/preview/lines'
+        );
+        $resources = $this->service->previewLines([
+            'amount' => 100,
+            'invoice' => 'in_123',
+        ]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CreditNoteLineItem::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/credit_notes/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/credit_notes/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+    }
+
+    public function testVoidCreditNote()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/credit_notes/' . self::TEST_RESOURCE_ID . '/void'
+        );
+        $resource = $this->service->voidCreditNote(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/CreditNoteServiceTest.php
+++ b/tests/Stripe/Service/CreditNoteServiceTest.php
@@ -23,7 +23,7 @@ final class CreditNoteServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CreditNoteService($this->client);
     }
 

--- a/tests/Stripe/Service/CustomerServiceTest.php
+++ b/tests/Stripe/Service/CustomerServiceTest.php
@@ -14,7 +14,10 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
     const TEST_SOURCE_ID = 'card_123';
     const TEST_TAX_ID_ID = 'txi_123';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var CustomerService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/CustomerServiceTest.php
+++ b/tests/Stripe/Service/CustomerServiceTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ */
+final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'cus_123';
+    const TEST_CUSTOMER_BALANCE_TRANSACTION_ID = 'cbtxn_123';
+    const TEST_SOURCE_ID = 'card_123';
+    const TEST_TAX_ID_ID = 'txi_123';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CustomerService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Customer::class, $resources->data[0]);
+    }
+
+    public function testAllBalanceTransactions()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions'
+        );
+        $resources = $this->service->allBalanceTransactions(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CustomerBalanceTransaction::class, $resources->data[0]);
+    }
+
+    public function testAllSources()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
+        );
+        $resources = $this->service->allSources(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+    }
+
+    public function testAllTaxIds()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids'
+        );
+        $resources = $this->service->allTaxIds(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\TaxId::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers'
+        );
+        $resource = $this->service->create();
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
+    }
+
+    public function testCreateBalanceTransaction()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions'
+        );
+        $resource = $this->service->createBalanceTransaction(self::TEST_RESOURCE_ID, [
+            'amount' => 1234,
+            'currency' => 'usd',
+        ]);
+        static::assertInstanceOf(\Stripe\CustomerBalanceTransaction::class, $resource);
+    }
+
+    public function testCreateSource()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
+        );
+        $resource = $this->service->createSource(self::TEST_RESOURCE_ID, ['source' => 'tok_123']);
+    }
+
+    public function testCreateTaxId()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids'
+        );
+        $resource = $this->service->createTaxId(self::TEST_RESOURCE_ID, [
+            'type' => \Stripe\TaxId::TYPE_EU_VAT,
+            'value' => '11111',
+        ]);
+        static::assertInstanceOf(\Stripe\TaxId::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
+    }
+
+    public function testDeleteDiscount()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/discount'
+        );
+        $resource = $this->service->deleteDiscount(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Discount::class, $resource);
+    }
+
+    public function testDeleteSource()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
+        );
+        $resource = $this->service->deleteSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID);
+    }
+
+    public function testDeleteTaxId()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids/' . self::TEST_TAX_ID_ID
+        );
+        $resource = $this->service->deleteTaxId(self::TEST_RESOURCE_ID, self::TEST_TAX_ID_ID);
+        static::assertInstanceOf(\Stripe\TaxId::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
+    }
+
+    public function testRetrieveBalanceTransaction()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions/'
+                . self::TEST_CUSTOMER_BALANCE_TRANSACTION_ID
+        );
+        $resource = $this->service->retrieveBalanceTransaction(
+            self::TEST_RESOURCE_ID,
+            self::TEST_CUSTOMER_BALANCE_TRANSACTION_ID
+        );
+        static::assertInstanceOf(\Stripe\CustomerBalanceTransaction::class, $resource);
+    }
+
+    public function testRetrieveSource()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
+        );
+        $resource = $this->service->retrieveSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID);
+    }
+
+    public function testRetrieveTaxId()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids/' . self::TEST_TAX_ID_ID
+        );
+        $resource = $this->service->retrieveTaxId(self::TEST_RESOURCE_ID, self::TEST_TAX_ID_ID);
+        static::assertInstanceOf(\Stripe\TaxId::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
+    }
+
+    public function testUpdateBalanceTransaction()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions/'
+                . self::TEST_CUSTOMER_BALANCE_TRANSACTION_ID
+        );
+        $resource = $this->service->updateBalanceTransaction(
+            self::TEST_RESOURCE_ID,
+            self::TEST_CUSTOMER_BALANCE_TRANSACTION_ID,
+            ['description' => 'new']
+        );
+        static::assertInstanceOf(\Stripe\CustomerBalanceTransaction::class, $resource);
+    }
+
+    public function testUpdateSource()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID
+        );
+        $resource = $this->service->updateSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, ['name' => 'name']);
+    }
+
+    public function testVerifySource()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID . '/verify'
+        );
+        $resource = $this->service->verifySource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, ['amounts' => [32, 45]]);
+    }
+}

--- a/tests/Stripe/Service/CustomerServiceTest.php
+++ b/tests/Stripe/Service/CustomerServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service;
 
 /**
  * @internal
+ * @covers \Stripe\Service\CustomerService
  */
 final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
 {
@@ -59,6 +60,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
         );
         $resources = $this->service->allSources(self::TEST_RESOURCE_ID);
         static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\AlipayAccount::class, $resources->data[0]);
     }
 
     public function testAllTaxIds()
@@ -125,6 +127,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
         );
         $resource = $this->service->delete(self::TEST_RESOURCE_ID);
         static::assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertTrue($resource->isDeleted());
     }
 
     public function testDeleteDiscount()
@@ -135,6 +138,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
         );
         $resource = $this->service->deleteDiscount(self::TEST_RESOURCE_ID);
         static::assertInstanceOf(\Stripe\Discount::class, $resource);
+        static::assertTrue($resource->isDeleted());
     }
 
     public function testDeleteSource()
@@ -154,6 +158,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
         );
         $resource = $this->service->deleteTaxId(self::TEST_RESOURCE_ID, self::TEST_TAX_ID_ID);
         static::assertInstanceOf(\Stripe\TaxId::class, $resource);
+        static::assertTrue($resource->isDeleted());
     }
 
     public function testRetrieve()
@@ -242,5 +247,6 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources/' . self::TEST_SOURCE_ID . '/verify'
         );
         $resource = $this->service->verifySource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, ['amounts' => [32, 45]]);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
     }
 }

--- a/tests/Stripe/Service/CustomerServiceTest.php
+++ b/tests/Stripe/Service/CustomerServiceTest.php
@@ -26,7 +26,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CustomerService($this->client);
     }
 

--- a/tests/Stripe/Service/DisputeServiceTest.php
+++ b/tests/Stripe/Service/DisputeServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\DisputeService
+ */
+final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'dp_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var DisputeService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new DisputeService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/disputes'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resources->data[0]);
+    }
+
+    public function testClose()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/disputes/' . self::TEST_RESOURCE_ID . '/close'
+        );
+        $resource = $this->service->close(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/disputes/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/disputes/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/DisputeServiceTest.php
+++ b/tests/Stripe/Service/DisputeServiceTest.php
@@ -23,7 +23,7 @@ final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new DisputeService($this->client);
     }
 

--- a/tests/Stripe/Service/EphemeralKeyServiceTest.php
+++ b/tests/Stripe/Service/EphemeralKeyServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\EphemeralKeyService
+ */
+final class EphemeralKeyServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ek_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var EphemeralKeyService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new EphemeralKeyService($this->client);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/ephemeral_keys',
+            null,
+            ['Stripe-Version: 2017-05-25']
+        );
+        $resource = $this->service->create([
+            'customer' => 'cus_123',
+        ], ['stripe_version' => '2017-05-25']);
+        static::assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
+    }
+
+    public function testCreateWithoutExplicitApiVersion()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $resource = $this->service->create([
+            'customer' => 'cus_123',
+        ]);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/ephemeral_keys/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/EphemeralKeyServiceTest.php
+++ b/tests/Stripe/Service/EphemeralKeyServiceTest.php
@@ -23,7 +23,7 @@ final class EphemeralKeyServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EphemeralKeyService($this->client);
     }
 

--- a/tests/Stripe/Service/EventServiceTest.php
+++ b/tests/Stripe/Service/EventServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\EventService
+ */
+final class EventServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'evt_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var EventService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new EventService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/events'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Event::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/events/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Event::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/EventServiceTest.php
+++ b/tests/Stripe/Service/EventServiceTest.php
@@ -23,7 +23,7 @@ final class EventServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EventService($this->client);
     }
 

--- a/tests/Stripe/Service/ExchangeRateServiceTest.php
+++ b/tests/Stripe/Service/ExchangeRateServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ExchangeRateService
+ */
+final class ExchangeRateServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ExchangeRateService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ExchangeRateService($this->client);
+    }
+
+    public function testAll()
+    {
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ExchangeRate::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $resource = $this->service->retrieve('usd');
+        static::assertInstanceOf(\Stripe\ExchangeRate::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ExchangeRateServiceTest.php
+++ b/tests/Stripe/Service/ExchangeRateServiceTest.php
@@ -21,7 +21,7 @@ final class ExchangeRateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ExchangeRateService($this->client);
     }
 

--- a/tests/Stripe/Service/FileLinkServiceTest.php
+++ b/tests/Stripe/Service/FileLinkServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\FileLinkService
+ */
+final class FileLinkServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'link_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var FileLinkService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new FileLinkService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/file_links'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/file_links'
+        );
+        $resource = $this->service->create([
+            'file' => 'file_123',
+        ]);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/file_links/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/file_links/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/FileLinkServiceTest.php
+++ b/tests/Stripe/Service/FileLinkServiceTest.php
@@ -23,7 +23,7 @@ final class FileLinkServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new FileLinkService($this->client);
     }
 

--- a/tests/Stripe/Service/FileServiceTest.php
+++ b/tests/Stripe/Service/FileServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ */
+final class FileServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'file_123';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new FileService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/files'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\File::class, $resources->data[0]);
+    }
+
+    public function testCreateWithCURLFile()
+    {
+        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $service = new FileService($client);
+
+        $this->expectsRequest(
+            'post',
+            '/v1/files',
+            null,
+            ['Content-Type: multipart/form-data'],
+            true,
+            MOCK_URL
+        );
+        $curlFile = new \CURLFile(__DIR__ . '/../../data/test.png');
+        $resource = $service->create([
+            'purpose' => 'dispute_evidence',
+            'file' => $curlFile,
+            'file_link_data' => ['create' => true],
+        ]);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
+    }
+
+    public function testCreateWithFileHandle()
+    {
+        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $service = new FileService($client);
+
+        $this->expectsRequest(
+            'post',
+            '/v1/files',
+            null,
+            ['Content-Type: multipart/form-data'],
+            true,
+            MOCK_URL
+        );
+        $fp = \fopen(__DIR__ . '/../../data/test.png', 'rb');
+        $resource = $service->create([
+            'purpose' => 'dispute_evidence',
+            'file' => $fp,
+            'file_link_data' => ['create' => true],
+        ]);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/files/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/FileServiceTest.php
+++ b/tests/Stripe/Service/FileServiceTest.php
@@ -11,7 +11,10 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     const TEST_RESOURCE_ID = 'file_123';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var FileService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/FileServiceTest.php
+++ b/tests/Stripe/Service/FileServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service;
 
 /**
  * @internal
+ * @covers \Stripe\Service\FileService
  */
 final class FileServiceTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Stripe/Service/FileServiceTest.php
+++ b/tests/Stripe/Service/FileServiceTest.php
@@ -23,7 +23,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new FileService($this->client);
     }
 
@@ -40,7 +40,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateWithCURLFile()
     {
-        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'files_base' => MOCK_URL]);
         $service = new FileService($client);
 
         $this->expectsRequest(
@@ -62,7 +62,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateWithFileHandle()
     {
-        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'files_base' => MOCK_URL]);
         $service = new FileService($client);
 
         $this->expectsRequest(

--- a/tests/Stripe/Service/InvoiceItemServiceTest.php
+++ b/tests/Stripe/Service/InvoiceItemServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\InvoiceItemService
+ */
+final class InvoiceItemServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ii_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var InvoiceItemService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new InvoiceItemService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoiceitems'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoiceitems'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+            'customer' => 'cus_123',
+        ]);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/InvoiceItemServiceTest.php
+++ b/tests/Stripe/Service/InvoiceItemServiceTest.php
@@ -23,7 +23,7 @@ final class InvoiceItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new InvoiceItemService($this->client);
     }
 

--- a/tests/Stripe/Service/InvoiceServiceTest.php
+++ b/tests/Stripe/Service/InvoiceServiceTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\InvoiceService
+ */
+final class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'in_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var InvoiceService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new InvoiceService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resources->data[0]);
+    }
+
+    public function testAllLines()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/lines'
+        );
+        $resources = $this->service->allLines(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices'
+        );
+        $resource = $this->service->create([
+            'customer' => 'cus_123',
+        ]);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testFinalizeInvoice()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/finalize'
+        );
+        $resource = $this->service->finalizeInvoice(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testMarkUncollectible()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/mark_uncollectible'
+        );
+        $resource = $this->service->markUncollectible(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testPay()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/pay'
+        );
+        $resource = $this->service->pay(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testSendInvoice()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/send'
+        );
+        $resource = $this->service->sendInvoice(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testUpcoming()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices/upcoming'
+        );
+        $resource = $this->service->upcoming(['customer' => 'cus_123']);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testUpcomingLines()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices/upcoming/lines'
+        );
+        $resources = $this->service->upcomingLines();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\InvoiceLineItem::class, $resources->data[0]);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+
+    public function testVoidInvoice()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/void'
+        );
+        $resource = $this->service->voidInvoice(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/InvoiceServiceTest.php
+++ b/tests/Stripe/Service/InvoiceServiceTest.php
@@ -23,7 +23,7 @@ final class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new InvoiceService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
+++ b/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Issuing\AuthorizationService
+ */
+final class AuthorizationServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'iauth_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var AuthorizationService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new AuthorizationService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/authorizations'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resources->data[0]);
+    }
+
+    public function testApprove()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID . '/approve'
+        );
+        $resource = $this->service->approve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+    }
+
+    public function testDecline()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID . '/decline'
+        );
+        $resource = $this->service->decline(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID,
+            ['metadata' => ['key' => 'value']]
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
+++ b/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
@@ -23,7 +23,7 @@ final class AuthorizationServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AuthorizationService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service\Issuing;
 
 /**
  * @internal
+ * @covers \Stripe\Service\Issuing\CardService
  */
 final class CardServiceTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Stripe/Service/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardServiceTest.php
@@ -11,7 +11,10 @@ final class CardServiceTest extends \PHPUnit\Framework\TestCase
 
     const TEST_RESOURCE_ID = 'ic_123';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var CardService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * @internal
+ */
+final class CardServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ic_123';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CardService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cards'
+        );
+        $resource = $this->service->create([
+            'currency' => 'usd',
+            'type' => 'physical',
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+
+    public function testDetails()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID . '/details'
+        );
+        $resource = $this->service->details(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\CardDetails::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardServiceTest.php
@@ -23,7 +23,7 @@ final class CardServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CardService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/CardholderServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardholderServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Issuing\CardholderService
+ */
+final class CardholderServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ich_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var CardholderService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new CardholderService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cardholders'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $params = [
+            'billing' => [
+                'address' => [
+                    'city' => 'city',
+                    'country' => 'US',
+                    'line1' => 'line1',
+                    'postal_code' => 'postal_code',
+                ],
+            ],
+            'name' => 'Cardholder Name',
+            'type' => 'individual',
+        ];
+
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cardholders',
+            $params
+        );
+        $resource = $this->service->create($params);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/cardholders/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/cardholders/' . self::TEST_RESOURCE_ID,
+            ['metadata' => ['key' => 'value']]
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Issuing/CardholderServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardholderServiceTest.php
@@ -23,7 +23,7 @@ final class CardholderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CardholderService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/DisputeServiceTest.php
+++ b/tests/Stripe/Service/Issuing/DisputeServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Issuing\DisputeService
+ */
+final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'idp_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var DisputeService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new DisputeService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/disputes'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $params = [
+            'reason' => 'fraudulent',
+            'disputed_transaction' => 'ipi_123',
+        ];
+
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/disputes',
+            $params
+        );
+        $resource = $this->service->create($params);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/disputes/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/disputes/' . self::TEST_RESOURCE_ID,
+            ['metadata' => ['key' => 'value']]
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Issuing/DisputeServiceTest.php
+++ b/tests/Stripe/Service/Issuing/DisputeServiceTest.php
@@ -23,7 +23,7 @@ final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new DisputeService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/DisputeServiceTest.php
+++ b/tests/Stripe/Service/Issuing/DisputeServiceTest.php
@@ -40,10 +40,7 @@ final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testCreate()
     {
-        $params = [
-            'reason' => 'fraudulent',
-            'disputed_transaction' => 'ipi_123',
-        ];
+        $params = [];
 
         $this->expectsRequest(
             'post',

--- a/tests/Stripe/Service/Issuing/TransactionServiceTest.php
+++ b/tests/Stripe/Service/Issuing/TransactionServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Issuing\TransactionService
+ */
+final class TransactionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'ipi_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var TransactionService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new TransactionService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/transactions'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/issuing/transactions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/issuing/transactions/' . self::TEST_RESOURCE_ID,
+            ['metadata' => ['key' => 'value']]
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Issuing/TransactionServiceTest.php
+++ b/tests/Stripe/Service/Issuing/TransactionServiceTest.php
@@ -23,7 +23,7 @@ final class TransactionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TransactionService($this->client);
     }
 

--- a/tests/Stripe/Service/MandateServiceTest.php
+++ b/tests/Stripe/Service/MandateServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\MandateService
+ */
+final class MandateServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'mandate_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var MandateService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new MandateService($this->client);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/mandates/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Mandate::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/MandateServiceTest.php
+++ b/tests/Stripe/Service/MandateServiceTest.php
@@ -23,7 +23,7 @@ final class MandateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new MandateService($this->client);
     }
 

--- a/tests/Stripe/Service/OrderReturnServiceTest.php
+++ b/tests/Stripe/Service/OrderReturnServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\OrderReturnService
+ */
+final class OrderReturnServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'orret_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var OrderReturnService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new OrderReturnService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/order_returns'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/order_returns/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/OrderReturnServiceTest.php
+++ b/tests/Stripe/Service/OrderReturnServiceTest.php
@@ -23,7 +23,7 @@ final class OrderReturnServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new OrderReturnService($this->client);
     }
 

--- a/tests/Stripe/Service/OrderServiceTest.php
+++ b/tests/Stripe/Service/OrderServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\OrderService
+ */
+final class OrderServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'or_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var OrderService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new OrderService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/orders'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Order::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/orders'
+        );
+        $resource = $this->service->create([
+            'currency' => 'usd',
+        ]);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
+    }
+
+    public function testPay()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/orders/' . self::TEST_RESOURCE_ID . '/pay'
+        );
+        $resource = $this->service->pay(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/orders/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
+    }
+
+    public function testReturnOrder()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/orders/' . self::TEST_RESOURCE_ID . '/returns'
+        );
+        $resource = $this->service->returnOrder(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/orders/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/OrderServiceTest.php
+++ b/tests/Stripe/Service/OrderServiceTest.php
@@ -23,7 +23,7 @@ final class OrderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new OrderService($this->client);
     }
 

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -11,7 +11,10 @@ final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
 
     const TEST_RESOURCE_ID = 'pi_123';
 
+    /** @var \Stripe\StripeClient */
     private $client;
+
+    /** @var PaymentIntentService */
     private $service;
 
     /**

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ */
+final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'pi_123';
+
+    private $client;
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new PaymentIntentService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payment_intents'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
+    }
+
+    public function testCapture()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/capture'
+        );
+        $resource = $this->service->capture(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testConfirm()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/confirm'
+        );
+        $resource = $this->service->confirm(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_intents'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+            'payment_method_types' => ['card'],
+        ]);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -4,6 +4,7 @@ namespace Stripe\Service;
 
 /**
  * @internal
+ * @covers \Stripe\Service\PaymentIntentService
  */
 final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
 {
@@ -35,6 +36,16 @@ final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
         $resources = $this->service->all();
         static::assertInternalType('array', $resources->data);
         static::assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/cancel'
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testCapture()

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -23,7 +23,7 @@ final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PaymentIntentService($this->client);
     }
 

--- a/tests/Stripe/Service/PaymentMethodServiceTest.php
+++ b/tests/Stripe/Service/PaymentMethodServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\PaymentMethodService
+ */
+final class PaymentMethodServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'pm_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var PaymentMethodService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new PaymentMethodService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payment_methods'
+        );
+        $resources = $this->service->all([
+            'customer' => 'cus_123',
+            'type' => 'card',
+        ]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resources->data[0]);
+    }
+
+    public function testAttach()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_methods/' . self::TEST_RESOURCE_ID . '/attach'
+        );
+        $resource = $this->service->attach(self::TEST_RESOURCE_ID, [
+            'customer' => 'cus_123',
+        ]);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_methods'
+        );
+        $resource = $this->service->create([
+            'type' => 'card',
+        ]);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+    }
+
+    public function testDetach()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_methods/' . self::TEST_RESOURCE_ID . '/detach'
+        );
+        $resource = $this->service->detach(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payment_methods/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payment_methods/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/PaymentMethodServiceTest.php
+++ b/tests/Stripe/Service/PaymentMethodServiceTest.php
@@ -23,7 +23,7 @@ final class PaymentMethodServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PaymentMethodService($this->client);
     }
 

--- a/tests/Stripe/Service/PayoutServiceTest.php
+++ b/tests/Stripe/Service/PayoutServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\PayoutService
+ */
+final class PayoutServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'po_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var PayoutService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new PayoutService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payouts'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Payout::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payouts/' . self::TEST_RESOURCE_ID . '/cancel'
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payouts'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+        ]);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/payouts/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/payouts/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/PayoutServiceTest.php
+++ b/tests/Stripe/Service/PayoutServiceTest.php
@@ -23,7 +23,7 @@ final class PayoutServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PayoutService($this->client);
     }
 

--- a/tests/Stripe/Service/PlanServiceTest.php
+++ b/tests/Stripe/Service/PlanServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\PlanService
+ */
+final class PlanServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'plan';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var PlanService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new PlanService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/plans'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Plan::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/plans'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'interval' => 'month',
+            'currency' => 'usd',
+            'nickname' => self::TEST_RESOURCE_ID,
+            'id' => self::TEST_RESOURCE_ID,
+        ]);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/plans/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/plans/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/plans/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/PlanServiceTest.php
+++ b/tests/Stripe/Service/PlanServiceTest.php
@@ -23,7 +23,7 @@ final class PlanServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PlanService($this->client);
     }
 

--- a/tests/Stripe/Service/PriceServiceTest.php
+++ b/tests/Stripe/Service/PriceServiceTest.php
@@ -1,21 +1,21 @@
 <?php
 
-namespace Stripe\Service\Issuing;
+namespace Stripe\Service;
 
 /**
  * @internal
- * @covers \Stripe\Service\Issuing\CardService
+ * @covers \Stripe\Service\PriceService
  */
-final class CardServiceTest extends \PHPUnit\Framework\TestCase
+final class PriceServiceTest extends \PHPUnit\Framework\TestCase
 {
     use \Stripe\TestHelper;
 
-    const TEST_RESOURCE_ID = 'ic_123';
+    const TEST_RESOURCE_ID = 'prod_123';
 
     /** @var \Stripe\StripeClient */
     private $client;
 
-    /** @var CardService */
+    /** @var PriceService */
     private $service;
 
     /**
@@ -24,52 +24,58 @@ final class CardServiceTest extends \PHPUnit\Framework\TestCase
     protected function setUpService()
     {
         $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
-        $this->service = new CardService($this->client);
+        $this->service = new PriceService($this->client);
     }
 
     public function testAll()
     {
         $this->expectsRequest(
             'get',
-            '/v1/issuing/cards'
+            '/v1/prices'
         );
         $resources = $this->service->all();
         static::assertInternalType('array', $resources->data);
-        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
+        static::assertInstanceOf(\Stripe\Price::class, $resources->data[0]);
     }
 
     public function testCreate()
     {
         $this->expectsRequest(
             'post',
-            '/v1/issuing/cards'
+            '/v1/prices'
         );
         $resource = $this->service->create([
+            'unit_amount' => 2000,
             'currency' => 'usd',
-            'type' => 'physical',
+            'recurring' => [
+                'interval' => 'month',
+            ],
+            'product_data' => [
+                'name' => 'Product Name',
+            ],
         ]);
-        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Price::class, $resource);
     }
 
     public function testRetrieve()
     {
         $this->expectsRequest(
             'get',
-            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+            '/v1/prices/' . self::TEST_RESOURCE_ID
         );
         $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
-        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Price::class, $resource);
     }
 
     public function testUpdate()
     {
         $this->expectsRequest(
             'post',
-            '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
+            '/v1/prices/' . self::TEST_RESOURCE_ID
         );
         $resource = $this->service->update(self::TEST_RESOURCE_ID, [
             'metadata' => ['key' => 'value'],
         ]);
-        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Price::class, $resource);
     }
 }

--- a/tests/Stripe/Service/ProductServiceTest.php
+++ b/tests/Stripe/Service/ProductServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ProductService
+ */
+final class ProductServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'prod_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ProductService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ProductService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/products'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Product::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/products'
+        );
+        $resource = $this->service->create([
+            'name' => 'name',
+            'type' => 'good',
+        ]);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/products/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/products/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/products/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ProductServiceTest.php
+++ b/tests/Stripe/Service/ProductServiceTest.php
@@ -23,7 +23,7 @@ final class ProductServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ProductService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
+++ b/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Radar\EarlyFraudWarningService
+ */
+final class EarlyFraudWarningServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'issfr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var EarlyFraudWarningService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new EarlyFraudWarningService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/early_fraud_warnings'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/early_fraud_warnings/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
+++ b/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
@@ -23,7 +23,7 @@ final class EarlyFraudWarningServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EarlyFraudWarningService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Radar\ValueListItemService
+ */
+final class ValueListItemServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'rsli_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ValueListItemService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ValueListItemService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/value_list_items'
+        );
+        $resources = $this->service->all([
+            'value_list' => 'rsl_123',
+        ]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/value_list_items'
+        );
+        $resource = $this->service->create([
+            'value_list' => 'rsl_123',
+            'value' => 'value',
+        ]);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/radar/value_list_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/value_list_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
@@ -23,7 +23,7 @@ final class ValueListItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ValueListItemService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/ValueListServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Radar\ValueListService
+ */
+final class ValueListServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'rsl_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ValueListService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ValueListService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/value_lists'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/value_lists'
+        );
+        $resource = $this->service->create([
+            'alias' => 'alias',
+            'name' => 'name',
+        ]);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Radar/ValueListServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListServiceTest.php
@@ -23,7 +23,7 @@ final class ValueListServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ValueListService($this->client);
     }
 

--- a/tests/Stripe/Service/RefundServiceTest.php
+++ b/tests/Stripe/Service/RefundServiceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\RefundService
+ */
+final class RefundServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 're_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var RefundService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new RefundService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/refunds'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Refund::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/refunds'
+        );
+        $resource = $this->service->create([
+            'charge' => 'ch_123',
+        ]);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/refunds/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/refunds/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/RefundServiceTest.php
+++ b/tests/Stripe/Service/RefundServiceTest.php
@@ -23,7 +23,7 @@ final class RefundServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new RefundService($this->client);
     }
 

--- a/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Reporting\ReportRunService
+ */
+final class ReportRunServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'frr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ReportRunService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ReportRunService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_runs'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $params = [
+            'parameters' => [
+                'connected_account' => 'acct_123',
+            ],
+            'report_type' => 'activity.summary.1',
+        ];
+
+        $this->expectsRequest(
+            'post',
+            '/v1/reporting/report_runs',
+            $params
+        );
+        $resource = $this->service->create($params);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_runs/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
@@ -23,7 +23,7 @@ final class ReportRunServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReportRunService($this->client);
     }
 

--- a/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Reporting\ReportTypeService
+ */
+final class ReportTypeServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'activity.summary.1';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ReportTypeService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ReportTypeService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_types'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Reporting\ReportType::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reporting/report_types/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Reporting\ReportType::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
@@ -23,7 +23,7 @@ final class ReportTypeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReportTypeService($this->client);
     }
 

--- a/tests/Stripe/Service/ReviewServiceTest.php
+++ b/tests/Stripe/Service/ReviewServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\ReviewService
+ */
+final class ReviewServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'prv_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ReviewService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ReviewService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reviews'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Review::class, $resources->data[0]);
+    }
+
+    public function testApprove()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/reviews/' . self::TEST_RESOURCE_ID . '/approve'
+        );
+        $resource = $this->service->approve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Review::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/reviews/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Review::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/ReviewServiceTest.php
+++ b/tests/Stripe/Service/ReviewServiceTest.php
@@ -23,7 +23,7 @@ final class ReviewServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReviewService($this->client);
     }
 

--- a/tests/Stripe/Service/SetupIntentServiceTest.php
+++ b/tests/Stripe/Service/SetupIntentServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SetupIntentService
+ */
+final class SetupIntentServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'seti_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SetupIntentService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SetupIntentService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/setup_intents'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/setup_intents/' . self::TEST_RESOURCE_ID . '/cancel'
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+    }
+
+    public function testConfirm()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/setup_intents/' . self::TEST_RESOURCE_ID . '/confirm'
+        );
+        $resource = $this->service->confirm(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/setup_intents'
+        );
+        $resource = $this->service->create([
+            'payment_method_types' => ['card'],
+        ]);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/setup_intents/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/setup_intents/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(
+            self::TEST_RESOURCE_ID,
+            [
+                'metadata' => ['key' => 'value'],
+            ]
+        );
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/SetupIntentServiceTest.php
+++ b/tests/Stripe/Service/SetupIntentServiceTest.php
@@ -23,7 +23,7 @@ final class SetupIntentServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SetupIntentService($this->client);
     }
 

--- a/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
+++ b/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Stripe\Service\Sigma;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Sigma\ScheduledQueryRunService
+ */
+final class ScheduledQueryRunServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'sqr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ScheduledQueryRunService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ScheduledQueryRunService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/sigma/scheduled_query_runs'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/sigma/scheduled_query_runs/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
+++ b/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
@@ -23,7 +23,7 @@ final class ScheduledQueryRunServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ScheduledQueryRunService($this->client);
     }
 

--- a/tests/Stripe/Service/SkuServiceTest.php
+++ b/tests/Stripe/Service/SkuServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SkuService
+ */
+final class SkuServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'sku_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SkuService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SkuService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/skus'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SKU::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/skus'
+        );
+        $resource = $this->service->create([
+            'currency' => 'usd',
+            'inventory' => [
+                'type' => 'finite',
+                'quantity' => 1,
+            ],
+            'price' => 100,
+            'product' => 'prod_123',
+        ]);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/skus/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/skus/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/skus/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/SkuServiceTest.php
+++ b/tests/Stripe/Service/SkuServiceTest.php
@@ -23,7 +23,7 @@ final class SkuServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SkuService($this->client);
     }
 

--- a/tests/Stripe/Service/SourceServiceTest.php
+++ b/tests/Stripe/Service/SourceServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SourceService
+ */
+final class SourceServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'src_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SourceService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SourceService($this->client);
+    }
+
+    public function testAllTransactions()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/sources/' . self::TEST_RESOURCE_ID . '/source_transactions'
+        );
+        $resources = $this->service->allTransactions(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/sources'
+        );
+        $resource = $this->service->create([
+            'type' => 'card',
+        ]);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
+    }
+
+    public function testDetach()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->detach('cus_123', self::TEST_RESOURCE_ID);
+        //static::assertInstanceOf(\Stripe\Source::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/sources/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
+    }
+
+    public function testVerify()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/sources/' . self::TEST_RESOURCE_ID . '/verify'
+        );
+        $resource = $this->service->verify(self::TEST_RESOURCE_ID, ['values' => [32, 45]]);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/SourceServiceTest.php
+++ b/tests/Stripe/Service/SourceServiceTest.php
@@ -23,7 +23,7 @@ final class SourceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SourceService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionItemServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionItemServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SubscriptionItemService
+ */
+final class SubscriptionItemServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'si_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SubscriptionItemService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SubscriptionItemService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_items',
+            [
+                'subscription' => 'sub_123',
+            ]
+        );
+        $resources = $this->service->all([
+            'subscription' => 'sub_123',
+        ]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resources->data[0]);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_items'
+        );
+        $resource = $this->service->create([
+            'plan' => 'plan',
+            'subscription' => 'sub_123',
+        ]);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/subscription_items/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testCreateUsageRecord()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_records'
+        );
+        $resource = $this->service->createUsageRecord(self::TEST_RESOURCE_ID, [
+            'quantity' => 100,
+            'timestamp' => 12341234,
+            'action' => 'set',
+        ]);
+    }
+
+    public function testListUsageRecordSummaries()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_record_summaries'
+        );
+        $resources = $this->service->allUsageRecordSummaries(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
+    }
+}

--- a/tests/Stripe/Service/SubscriptionItemServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionItemServiceTest.php
@@ -23,7 +23,7 @@ final class SubscriptionItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionItemService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SubscriptionScheduleService
+ */
+final class SubscriptionScheduleServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'sub_sched_123';
+    const TEST_REVISION_ID = 'sub_sched_rev_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SubscriptionScheduleService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SubscriptionScheduleService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID . '/cancel'
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules'
+        );
+        $resource = $this->service->create([
+            'phases' => [
+                [
+                    'plans' => [
+                        ['plan' => 'plan_123', 'quantity' => 2],
+                    ],
+                ],
+            ],
+        ]);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+    }
+
+    public function testRelease()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID . '/release'
+        );
+        $resource = $this->service->release(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
@@ -24,7 +24,7 @@ final class SubscriptionScheduleServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionScheduleService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\SubscriptionService
+ */
+final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'sub_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var SubscriptionService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new SubscriptionService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscriptions'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/subscriptions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscriptions'
+        );
+        $resource = $this->service->create([
+            'customer' => 'cus_123',
+        ]);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
+    }
+
+    public function testDeleteDiscount()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/subscriptions/' . self::TEST_RESOURCE_ID . '/discount'
+        );
+        $resource = $this->service->deleteDiscount(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Discount::class, $resource);
+        static::assertTrue($resource->isDeleted());
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscriptions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/subscriptions/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -23,7 +23,7 @@ final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionService($this->client);
     }
 

--- a/tests/Stripe/Service/TaxRateServiceTest.php
+++ b/tests/Stripe/Service/TaxRateServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\TaxRateService
+ */
+final class TaxRateServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'txr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var TaxRateService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new TaxRateService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/tax_rates'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/tax_rates'
+        );
+        $resource = $this->service->create([
+            'display_name' => 'name',
+            'inclusive' => false,
+            'percentage' => 10.15,
+        ]);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/tax_rates/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/tax_rates/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/TaxRateServiceTest.php
+++ b/tests/Stripe/Service/TaxRateServiceTest.php
@@ -23,7 +23,7 @@ final class TaxRateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TaxRateService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Terminal\ConnectionTokenService
+ */
+final class ConnectionTokenServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ConnectionTokenService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ConnectionTokenService($this->client);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/terminal/connection_tokens'
+        );
+        $resource = $this->service->create();
+        static::assertInstanceOf(\Stripe\Terminal\ConnectionToken::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
@@ -21,7 +21,7 @@ final class ConnectionTokenServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ConnectionTokenService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/LocationServiceTest.php
+++ b/tests/Stripe/Service/Terminal/LocationServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Terminal\LocationService
+ */
+final class LocationServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'tml_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var LocationService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new LocationService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/terminal/locations'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/terminal/locations',
+            [
+                'display_name' => 'name',
+                'address' => [
+                    'line1' => 'line1',
+                    'country' => 'US',
+                    'state' => 'CA',
+                    'postal_code' => '12345',
+                    'city' => 'San Francisco',
+                ],
+            ]
+        );
+        $resource = $this->service->create(
+            [
+                'display_name' => 'name',
+                'address' => [
+                    'line1' => 'line1',
+                    'country' => 'US',
+                    'state' => 'CA',
+                    'postal_code' => '12345',
+                    'city' => 'San Francisco',
+                ],
+            ]
+        );
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Terminal/LocationServiceTest.php
+++ b/tests/Stripe/Service/Terminal/LocationServiceTest.php
@@ -23,7 +23,7 @@ final class LocationServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new LocationService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/ReaderServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ReaderServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\Terminal\ReaderService
+ */
+final class ReaderServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'tml_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var ReaderService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new ReaderService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/terminal/readers'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/terminal/readers',
+            ['registration_code' => 'a-b-c']
+        );
+        $resource = $this->service->create(['registration_code' => 'a-b-c']);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/Terminal/ReaderServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ReaderServiceTest.php
@@ -23,7 +23,7 @@ final class ReaderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReaderService($this->client);
     }
 

--- a/tests/Stripe/Service/TokenServiceTest.php
+++ b/tests/Stripe/Service/TokenServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\TokenService
+ */
+final class TokenServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'tok_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var TokenService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new TokenService($this->client);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/tokens'
+        );
+        $resource = $this->service->create(['card' => 'tok_visa']);
+        static::assertInstanceOf(\Stripe\Token::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/tokens/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Token::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/TokenServiceTest.php
+++ b/tests/Stripe/Service/TokenServiceTest.php
@@ -23,7 +23,7 @@ final class TokenServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TokenService($this->client);
     }
 

--- a/tests/Stripe/Service/TopupServiceTest.php
+++ b/tests/Stripe/Service/TopupServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\TopupService
+ */
+final class TopupServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'tu_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var TopupService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new TopupService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/topups'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Topup::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/topups/' . self::TEST_RESOURCE_ID . '/cancel'
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/topups'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+            'source' => 'tok_123',
+            'description' => 'description',
+            'statement_descriptor' => 'statement descriptor',
+        ]);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/topups/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/topups/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/TopupServiceTest.php
+++ b/tests/Stripe/Service/TopupServiceTest.php
@@ -23,7 +23,7 @@ final class TopupServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TopupService($this->client);
     }
 

--- a/tests/Stripe/Service/TransferServiceTest.php
+++ b/tests/Stripe/Service/TransferServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\TransferService
+ */
+final class TransferServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'tr_123';
+    const TEST_REVERSAL_ID = 'trr_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var TransferService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new TransferService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/transfers'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resources->data[0]);
+    }
+
+    public function testAllReversals()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
+        );
+        $resources = $this->service->allReversals(self::TEST_RESOURCE_ID);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resources->data[0]);
+    }
+
+    public function testCancel()
+    {
+        // stripe-mock does not support this anymore so we stub it
+        $this->stubRequest(
+            'post',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID . '/cancel',
+            [],
+            null,
+            false,
+            [
+                'object' => 'transfer',
+            ]
+        );
+        $resource = $this->service->cancel(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/transfers'
+        );
+        $resource = $this->service->create([
+            'amount' => 100,
+            'currency' => 'usd',
+            'destination' => 'acct_123',
+        ]);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
+    }
+
+    public function testCreateReversal()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
+        );
+        $resource = $this->service->createReversal(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
+    }
+
+    public function testRetrieveReversal()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals/' . self::TEST_REVERSAL_ID
+        );
+        $resource = $this->service->retrieveReversal(self::TEST_RESOURCE_ID, self::TEST_REVERSAL_ID);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'metadata' => ['key' => 'value'],
+        ]);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
+    }
+
+    public function testUpdateReversal()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals/' . self::TEST_REVERSAL_ID
+        );
+        $resource = $this->service->updateReversal(
+            self::TEST_RESOURCE_ID,
+            self::TEST_REVERSAL_ID,
+            [
+                'metadata' => ['key' => 'value'],
+            ]
+        );
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/TransferServiceTest.php
+++ b/tests/Stripe/Service/TransferServiceTest.php
@@ -24,7 +24,7 @@ final class TransferServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TransferService($this->client);
     }
 

--- a/tests/Stripe/Service/WebhookEndpointServiceTest.php
+++ b/tests/Stripe/Service/WebhookEndpointServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\WebhookEndpointService
+ */
+final class WebhookEndpointServiceTest extends \PHPUnit\Framework\TestCase
+{
+    use \Stripe\TestHelper;
+
+    const TEST_RESOURCE_ID = 'we_123';
+
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var WebhookEndpointService */
+    private $service;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->service = new WebhookEndpointService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/webhook_endpoints'
+        );
+        $resources = $this->service->all();
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/webhook_endpoints'
+        );
+        $resource = $this->service->create([
+            'enabled_events' => ['charge.succeeded'],
+            'url' => 'https://stripe.com',
+        ]);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $this->expectsRequest(
+            'delete',
+            '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->delete(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            'enabled_events' => ['charge.succeeded'],
+        ]);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/WebhookEndpointServiceTest.php
+++ b/tests/Stripe/Service/WebhookEndpointServiceTest.php
@@ -23,7 +23,7 @@ final class WebhookEndpointServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new WebhookEndpointService($this->client);
     }
 

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ */
+final class StripeClientTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    {
+        $client = new StripeClient(null);
+        static::assertNotNull($client);
+        static::assertNull($client->getApiKey());
+    }
+
+    public function testCtorThrowsIfApiKeyIsEmpty()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot be the empty string.');
+
+        $client = new StripeClient('');
+    }
+
+    public function testCtorThrowsIfApiKeyContainsWhitespace()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot contain whitespace.');
+
+        $client = new StripeClient("sk_test_123\n");
+    }
+
+    public function testRequestWithClientApiKey()
+    {
+        $client = new StripeClient('sk_test_client', null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_client', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestWithOptsApiKey()
+    {
+        $client = new StripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
+        static::assertNotNull($charge);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_opts', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
+    {
+        $this->expectException(\Stripe\Exception\AuthenticationException::class);
+        $this->expectExceptionMessage('No API key provided.');
+
+        $client = new StripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
+}

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -8,58 +8,11 @@ namespace Stripe;
  */
 final class StripeClientTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    public function testExposesPropertiesForServices()
     {
-        $client = new StripeClient(null);
-        static::assertNotNull($client);
-        static::assertNull($client->getApiKey());
-    }
-
-    public function testCtorThrowsIfApiKeyIsEmpty()
-    {
-        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot be the empty string.');
-
-        $client = new StripeClient('');
-    }
-
-    public function testCtorThrowsIfApiKeyContainsWhitespace()
-    {
-        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot contain whitespace.');
-
-        $client = new StripeClient("sk_test_123\n");
-    }
-
-    public function testRequestWithClientApiKey()
-    {
-        $client = new StripeClient('sk_test_client', null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
-        static::assertNotNull($charge);
-        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
-        $optsReflector->setAccessible(true);
-        static::assertSame('sk_test_client', $optsReflector->getValue($charge)->apiKey);
-    }
-
-    public function testRequestWithOptsApiKey()
-    {
-        $client = new StripeClient(null, null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
-        static::assertNotNull($charge);
-        static::assertNotNull($charge);
-        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
-        $optsReflector->setAccessible(true);
-        static::assertSame('sk_test_opts', $optsReflector->getValue($charge)->apiKey);
-    }
-
-    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
-    {
-        $this->expectException(\Stripe\Exception\AuthenticationException::class);
-        $this->expectExceptionMessage('No API key provided.');
-
-        $client = new StripeClient(null, null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
-        static::assertNotNull($charge);
-        static::assertSame('ch_123', $charge->id);
+        $client = new StripeClient('sk_test_123');
+        static::assertInstanceOf(\Stripe\Service\CouponService::class, $client->coupons);
+        static::assertInstanceOf(\Stripe\Service\Issuing\IssuingServiceFactory::class, $client->issuing);
+        static::assertInstanceOf(\Stripe\Service\Issuing\CardService::class, $client->issuing->cards);
     }
 }

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -4,6 +4,7 @@ namespace Stripe;
 
 /**
  * @internal
+ * @covers \Stripe\StripeClient
  */
 final class StripeClientTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
r? @ob-stripe @remi-stripe 
cc? @stripe/api-libraries 

Introduces a "client + services" API.

This means, for example, instead of 

```php
\Stripe\Stripe::setApiKey('sk_test_xxx');
$customer = \Stripe\Customer::retrieve(
  'cus_HG97q60gg1Naih'
);
$customer->delete();
```
where `retrieve`, `create`, `update` and `list` are static "collection" methods that live on the class, and `save` and `delete` are instance methods 

users do

```php
$stripe = new \Stripe\StripeClient([
  'api_key' => 'sk_test_xxx',
]);
$stripe->customers->delete('cus_HG97q60gg1Naih', []);
```

where all methods are instance methods of "service" objects that can be accessed via getters from an initialized `$stripe` client.

This has some advantages. It permits invoking "delete" without a previous "retrieve". It permits multiple StripeClients to coexist, with different settings. It also is generally more consistent and more amenable to codegen.


How does `$stripe->customers->delete` work, behind the scenes?

1. `$stripe->customers` triggers `StripeClient.__get`
2. `StripeClient.__get` lazily initializes `new CoreServiceFactory` and calls `CoreServiceFactory.__get`, which is implemented in `AbstractServiceFactory.__get`
3. `AbstractServiceFactory.__get` calls `CoreServiceFactory.getServiceClass`
4. `CoreServiceFactory.getServiceClass` references a static `$classMap`, which has been codegenned mapping from names like 'customers' to ServiceClasses, like `CustomerService`, and lazily initializes the corresponding 'Service' class..
5. That class has methods like `->delete`, which have also been codegenned, and use `AbstractService.request`, and `AbstractService.buildPath`.
7. `AbstractService.request` ends up calling `StripeClient.request` (which is implemented in `BaseStripeClient.request`) to actually perform the HTTP request, as the StripeClient has been passed through through every stage of lazy initialization.

For namespaced resources, `CoreServiceFactory.getServiceClass` actually does not return a Service class directly, it returns another Service factory, and then that service factory has a `.__get` and `.getServiceClass` that resolve to services.