### PR TITLE
Add `AbstractService` and a couple of concrete services

### DIFF
--- a/init.php
+++ b/init.php
@@ -151,3 +151,8 @@ require(dirname(__FILE__) . '/lib/OAuthErrorObject.php');
 require(dirname(__FILE__) . '/lib/Webhook.php');
 require(dirname(__FILE__) . '/lib/WebhookEndpoint.php');
 require(dirname(__FILE__) . '/lib/WebhookSignature.php');
+
+// Services
+require(dirname(__FILE__) . '/lib/Service/AbstractService.php');
+require(dirname(__FILE__) . '/lib/Service/CouponService.php');
+require(dirname(__FILE__) . '/lib/Service/PaymentIntentService.php');

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Abstract base class for all services.
+ */
+abstract class AbstractService
+{
+    /**
+     * @var \Stripe\StripeClientInterface
+     */
+    protected $client = null;
+
+    /**
+     * Initializes a new instance of the {@link AbstractService} class.
+     *
+     * @param \Stripe\StripeClientInterface $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Returns the base path for requests issued by this service. Must be
+     * implemented by all concrete subclasses.
+     *
+     * @return string The base path for requests issued by this service.
+     */
+    abstract public function basePath();
+
+    /**
+     * Gets the client used by this service to send requests.
+     *
+     * @return \Stripe\StripeClientInterface
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    protected function allObjects($params, $opts)
+    {
+        return $this->request("get", $this->basePath(), $params, $opts);
+    }
+
+    protected function createObject($params, $opts)
+    {
+        return $this->request("post", $this->basePath(), $params, $opts);
+    }
+
+    protected function deleteObject($id, $params, $opts)
+    {
+        return $this->request("delete", $this->instancePath($id), $params, $opts);
+    }
+
+    protected function retrieveObject($id, $params, $opts)
+    {
+        return $this->request("get", $this->instancePath($id), $params, $opts);
+    }
+
+    protected function updateObject($id, $params, $opts)
+    {
+        return $this->request("post", $this->instancePath($id), $params, $opts);
+    }
+
+    protected function request($method, $path, $params, $opts)
+    {
+        return $this->getClient()->request($method, $path, $params, $opts);
+    }
+
+    protected function instancePath($id)
+    {
+        if (is_null($id) || trim($id) == "") {
+            $msg = "The resource ID cannot be null or whitespace.";
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        return $this->basePath() . "/" . urlencode($id);
+    }
+}

--- a/lib/Service/CouponService.php
+++ b/lib/Service/CouponService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Stripe\Service;
+
+class CouponService extends AbstractService
+{
+    public function basePath()
+    {
+        return "/v1/coupons";
+    }
+
+    /**
+     * List all coupons.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Create a coupon.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Delete a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function delete($id, $params = [], $opts = [])
+    {
+        return $this->deleteObject($id, $params, $opts);
+    }
+
+    /**
+     * Retrieve a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a coupon.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Coupon
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/lib/Service/PaymentIntentService.php
+++ b/lib/Service/PaymentIntentService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Stripe\Service;
+
+class PaymentIntentService extends AbstractService
+{
+    public function basePath()
+    {
+        return "/v1/payment_intents";
+    }
+
+    /**
+     * List all payment intents.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\Collection
+     */
+    public function all($params = [], $opts = [])
+    {
+        return $this->allObjects($params, $opts);
+    }
+
+    /**
+     * Capture a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\PaymentIntent
+     */
+    public function capture($id, $params = [], $opts = [])
+    {
+        return $this->request("post", $this->instancePath($id) . "/capture", $params, $opts);
+    }
+
+    /**
+     * Confirm a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\PaymentIntent
+     */
+    public function confirm($id, $params = [], $opts = [])
+    {
+        return $this->request("post", $this->instancePath($id) . "/confirm", $params, $opts);
+    }
+
+    /**
+     * Create a payment intent.
+     *
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\PaymentIntent
+     */
+    public function create($params = [], $opts = [])
+    {
+        return $this->createObject($params, $opts);
+    }
+
+    /**
+     * Retrieve a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\PaymentIntent
+     */
+    public function retrieve($id, $params = [], $opts = [])
+    {
+        return $this->retrieveObject($id, $params, $opts);
+    }
+
+    /**
+     * Update a payment intent.
+     *
+     * @param string $id
+     * @param array $params
+     * @param array $opts
+     * @return \Stripe\PaymentIntent
+     */
+    public function update($id, $params = [], $opts = [])
+    {
+        return $this->updateObject($id, $params, $opts);
+    }
+}

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Stripe\Service;
+
+class AbstractServiceTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = "25OFF";
+
+    private $client = null;
+    private $service = null;
+
+    /**
+     * @before
+     */
+    public function setUpMockService()
+    {
+        $this->client = new \Stripe\StripeClient("sk_test_123", null, MOCK_URL);
+        // Testing with CouponService, because testing abstract classes is hard in PHP :/
+        $this->service = new \Stripe\Service\CouponService($this->client);
+    }
+
+    /**
+     * @expectedException \Stripe\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The resource ID cannot be null or whitespace.
+     */
+    public function testRetrieveThrowsIfIdNullIsNull()
+    {
+        $this->service->retrieve(null);
+    }
+
+    /**
+     * @expectedException \Stripe\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The resource ID cannot be null or whitespace.
+     */
+    public function testRetrieveThrowsIfIdNullIsEmpty()
+    {
+        $this->service->retrieve("");
+    }
+
+    /**
+     * @expectedException \Stripe\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The resource ID cannot be null or whitespace.
+     */
+    public function testRetrieveThrowsIfIdNullIsWhitespace()
+    {
+        $this->service->retrieve(" ");
+    }
+}

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Stripe\Service;
+
+class CouponServiceTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = "COUPON_ID";
+
+    private $client = null;
+    private $service = null;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient("sk_test_123", null, MOCK_URL);
+        $this->service = new CouponService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            "get",
+            "/v1/coupons"
+        );
+        $resources = $this->service->all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/coupons"
+        );
+        $resource = $this->service->create([
+            "percent_off" => 25,
+            "duration" => "repeating",
+            "duration_in_months" => 3,
+        ]);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testDelete()
+    {
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->expectsRequest(
+            "delete",
+            "/v1/coupons/" . self::TEST_RESOURCE_ID
+        );
+        $resource->delete();
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            "get",
+            "/v1/coupons/" . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/coupons/" . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+    }
+}

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Stripe\Service;
+
+class PaymentIntentServiceTest extends \Stripe\TestCase
+{
+    const TEST_RESOURCE_ID = "pi_123";
+
+    private $client = null;
+    private $service = null;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient("sk_test_123", null, MOCK_URL);
+        $this->service = new PaymentIntentService($this->client);
+    }
+
+    public function testAll()
+    {
+        $this->expectsRequest(
+            "get",
+            "/v1/payment_intents"
+        );
+        $resources = $this->service->all();
+        $this->assertTrue(is_array($resources->data));
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
+    }
+
+    public function testCapture()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/payment_intents/" . self::TEST_RESOURCE_ID . "/capture"
+        );
+        $resource = $this->service->capture(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testConfirm()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/payment_intents/" . self::TEST_RESOURCE_ID . "/confirm"
+        );
+        $resource = $this->service->confirm(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testCreate()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/payment_intents"
+        );
+        $resource = $this->service->create([
+            "amount" => 100,
+            "currency" => "usd",
+            "payment_method_types" => ["card"],
+        ]);
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testRetrieve()
+    {
+        $this->expectsRequest(
+            "get",
+            "/v1/payment_intents/" . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+
+    public function testUpdate()
+    {
+        $this->expectsRequest(
+            "post",
+            "/v1/payment_intents/" . self::TEST_RESOURCE_ID
+        );
+        $resource = $this->service->update(self::TEST_RESOURCE_ID, [
+            "metadata" => ["key" => "value"],
+        ]);
+        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+    }
+}


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

(Note: this PR targets the `integration-services` branch, not `master`.)

Adds the `AbstractService` base class, and a couple of concrete services:
- `CouponService` (implements all standard CRUDL methods)
- `PaymentIntentService` (implements CRUL + two custom methods)
