### PR TITLE
Add support for `mx_rfc` type on `TaxId`

### DIFF
--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -31,6 +31,7 @@ class TaxId extends ApiResource
     const TYPE_CH_VAT  = 'ch_vat';
     const TYPE_EU_VAT  = 'eu_vat';
     const TYPE_IN_GST  = 'in_gst';
+    const TYPE_MX_RFC  = 'mx_rfc';
     const TYPE_NO_VAT  = 'no_vat';
     const TYPE_NZ_GST  = 'nz_gst';
     const TYPE_UNKNOWN = 'unknown';


### PR DESCRIPTION
Adding a new enum per https://stripe.com/docs/api/customer_tax_ids/create#create_tax_id-type

r? @cjavilla-stripe 
cc @stripe/api-libraries 
