### PR TITLE
Fix telemetry header

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -368,9 +368,9 @@ class ApiRequestor
             $hasFile
         );
 
-        if (isset($rheaders['request-id'])) {
+        if (isset($rheaders['request-id']) && isset($rheaders['request-id'][0])) {
             self::$requestTelemetry = new RequestTelemetry(
-                $rheaders['request-id'],
+                $rheaders['request-id'][0],
                 Util\Util::currentTimeMillis() - $requestStartMs
             );
         }

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -90,7 +90,7 @@ class StripeTelemetryTest extends TestCase
                 }),
                 $this->anything(),
                 $this->anything()
-            )->willReturn(array(self::FAKE_VALID_RESPONSE, 200, ["request-id" => "123"]));
+            )->willReturn(array(self::FAKE_VALID_RESPONSE, 200, ["request-id" => ["req_123"]]));
 
         ApiRequestor::setHttpClient($stub);
 
@@ -103,7 +103,7 @@ class StripeTelemetryTest extends TestCase
         $this->assertArrayHasKey('X-Stripe-Client-Telemetry', $requestheaders);
 
         $data = json_decode($requestheaders['X-Stripe-Client-Telemetry'], true);
-        $this->assertEquals('123', $data['last_request_metrics']['request_id']);
+        $this->assertEquals('req_123', $data['last_request_metrics']['request_id']);
         $this->assertNotNull($data['last_request_metrics']['request_duration_ms']);
 
         ApiRequestor::setHttpClient(null);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

I just noticed a bug with the telemetry header: it's serialized as `{"last_request_metrics":{"request_id":["req_123"],"request_duration_ms":234}}`, i.e. `request_id` is an array instead of a string.

This is because the response headers returned by the requestor is a map of string to list of strings (because a header may be repeated and have multiple values).

In this case we're fairly confident that there will only be a single value for the `Request-Id` header, so we fix this by fetching the first value.
