### PR TITLE
Use PHPStan in Travis CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,9 @@ charset = utf-8
 
 [*.{json,yml}]
 indent_size = 2
+
+[*.neon]
+indent_style = tab
+
+[Makefile]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ cache:
 before_install:
   # Install various build dependencies. We use `travis_retry` because Composer
   # will occasionally fail intermittently.
-  - travis_retry composer install
+  - travis_retry make vendor
 
   # Unpack and start stripe-mock so that the test suite can talk to it
   - |
@@ -68,5 +68,6 @@ before_install:
 script:
   - ./build.php ${AUTOLOAD}
   - ./vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
+  - if [[ `php -r "echo \version_compare(PHP_VERSION, '7.1', '>=');"` && $AUTOLOAD == 1 ]]; then make phpstan; fi
 
 after_script: ./vendor/bin/coveralls -v

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+export PHPSTAN_VERSION := 0.11.19
+
+vendor: composer.json
+	composer install
+	curl -sfL https://github.com/phpstan/phpstan/releases/download/$(PHPSTAN_VERSION)/phpstan.phar -o vendor/bin/phpstan
+	chmod +x vendor/bin/phpstan
+
+test: vendor
+	vendor/bin/phpunit
+.PHONY: test
+
+fmt: vendor
+	vendor/bin/php-cs-fixer fix -v --using-cache=no .
+.PHONY: fmt
+
+phpstan: vendor
+	vendor/bin/phpstan analyse -c phpstan.neon lib tests
+.PHONY: phpstan
+
+phpstan-baseline: vendor
+	vendor/bin/phpstan analyse -c phpstan.neon --error-format baselineNeon lib tests > phpstan-baseline.neon
+.PHONY: phpstan-baseline

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -129,7 +129,7 @@ class ApiRequestor
         if (!is_array($resp) || !isset($resp['error'])) {
             $msg = "Invalid response object from API: $rbody "
               . "(HTTP response code was $rcode)";
-            throw new Exception\UnexpectedValueException($msg, $rcode, $rbody, $resp, $rheaders);
+            throw new Exception\UnexpectedValueException($msg);
         }
 
         $errorData = $resp['error'];

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -22,7 +22,7 @@ namespace Stripe;
  * @property StripeObject $metadata
  * @property string $name
  * @property string $phone
- * @property string[] preferred_locales
+ * @property string[] $preferred_locales
  * @property mixed $shipping
  * @property Collection $sources
  * @property Collection $subscriptions

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -38,6 +38,9 @@ class CurlClient implements ClientInterface
 
     protected $defaultOptions;
 
+    /** @var \Stripe\Util\RandomGenerator */
+    protected $randomGenerator;
+
     protected $userAgentInfo;
 
     protected $enablePersistentConnections = true;
@@ -380,7 +383,7 @@ class CurlClient implements ClientInterface
      *
      * @param int $errno
      * @param int $rcode
-     * @param array|CaseInsensitiveArray $rheaders
+     * @param array|\Stripe\Util\CaseInsensitiveArray $rheaders
      * @param int $numRetries
      *
      * @return bool
@@ -435,7 +438,7 @@ class CurlClient implements ClientInterface
      * Provides the number of seconds to wait before retrying a request.
      *
      * @param int $numRetries
-     * @param array|CaseInsensitiveArray $rheaders
+     * @param array|\Stripe\Util\CaseInsensitiveArray $rheaders
      *
      * @return int
      */

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -361,7 +361,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         // user intended it to.
         if ($value === null) {
             return "";
-        } elseif (($value instanceof APIResource) && (!$value->saveWithParent)) {
+        } elseif (($value instanceof ApiResource) && (!$value->saveWithParent)) {
             if (!$unsaved) {
                 return null;
             } elseif (isset($value->id)) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,15 @@
+
+
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to undefined constant Stripe\\\\ApiResource\\:\\:OBJECT_NAME\\.$#"
+			count: 1
+			path: lib/ApiResource.php
+
+		-
+			message: "#^Access to undefined constant Stripe\\\\SingletonApiResource\\:\\:OBJECT_NAME\\.$#"
+			count: 1
+			path: lib/SingletonApiResource.php
+
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 1
+	bootstrap: tests/bootstrap.php
+	autoload_directories:
+		- tests

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -4,6 +4,9 @@ namespace Stripe;
 
 class CollectionTest extends TestCase
 {
+    /** @var \Stripe\Collection */
+    private $fixture;
+
     /**
      * @before
      */

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -6,6 +6,27 @@ use Stripe\HttpClient\CurlClient;
 
 class CurlClientTest extends TestCase
 {
+    /** @var \ReflectionProperty */
+    private $initialNetworkRetryDelayProperty;
+
+    /** @var \ReflectionProperty */
+    private $maxNetworkRetryDelayProperty;
+
+    /** @var double */
+    private $origInitialNetworkRetryDelay;
+
+    /** @var int */
+    private $origMaxNetworkRetries;
+
+    /** @var double */
+    private $origMaxNetworkRetryDelay;
+
+    /** @var \ReflectionMethod */
+    private $sleepTimeMethod;
+
+    /** @var \ReflectionMethod */
+    private $shouldRetryMethod;
+
     /**
      * @before
      */
@@ -60,7 +81,7 @@ class CurlClientTest extends TestCase
 
     private function createFakeRandomGenerator($returnValue = 1.0)
     {
-        $fakeRandomGenerator = $this->createMock('Stripe\Util\RandomGenerator', ['randFloat']);
+        $fakeRandomGenerator = $this->createMock('Stripe\Util\RandomGenerator');
         $fakeRandomGenerator->method('randFloat')->willReturn($returnValue);
         return $fakeRandomGenerator;
     }

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -4,6 +4,12 @@ namespace Stripe;
 
 class StripeObjectTest extends TestCase
 {
+    /** @var \ReflectionMethod */
+    private $deepCopyReflector;
+
+    /** @var \ReflectionMethod */
+    private $optsReflector;
+
     /**
      * @before
      */

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -4,6 +4,9 @@ namespace Stripe;
 
 class StripeTest extends TestCase
 {
+    /** @var array */
+    protected $orig;
+
     /**
      * @before
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -140,7 +140,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
      *   Defaults to false.
      * @param string|null $base base URL (e.g. 'https://api.stripe.com')
      *
-     * @return PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     * @return \PHPUnit_Framework_MockObject_Builder_InvocationMocker
      */
     private function prepareRequestMock(
         $method,


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @nauxliu

Add support for [PHPStan](https://github.com/phpstan/phpstan), a static analyzer for PHP.

Because PHPStan requires PHP 7.1 or more recent, we cannot add it as a dev dependency in `composer.json`. I worked around this by setting up a Makefile to download PHPStan separately as a self-contained PHAR archive.

PHPStan offers different analysis levels, from 0 (loosest) to 7 (strictest). Right now I've set it at 1 and fixed most issues it reported. We can increase it and fix more issues in future PRs.

There are two issues I could not fix without some refactoring, so what I did was create a [baseline file](https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff), which is basically the PHPStan equivalent of the `.rubucop_todo.yml` file. The `phpstan-baseline` make target can be used to regenerate the file.