### PR TITLE
Early codegen fixes

### DIFF
--- a/init.php
+++ b/init.php
@@ -119,8 +119,8 @@ require(dirname(__FILE__) . '/lib/Reporting/ReportRun.php');
 require(dirname(__FILE__) . '/lib/Reporting/ReportType.php');
 require(dirname(__FILE__) . '/lib/Review.php');
 require(dirname(__FILE__) . '/lib/SetupIntent.php');
-require(dirname(__FILE__) . '/lib/SKU.php');
 require(dirname(__FILE__) . '/lib/Sigma/ScheduledQueryRun.php');
+require(dirname(__FILE__) . '/lib/SKU.php');
 require(dirname(__FILE__) . '/lib/Source.php');
 require(dirname(__FILE__) . '/lib/SourceTransaction.php');
 require(dirname(__FILE__) . '/lib/Subscription.php');
@@ -138,6 +138,7 @@ require(dirname(__FILE__) . '/lib/Transfer.php');
 require(dirname(__FILE__) . '/lib/TransferReversal.php');
 require(dirname(__FILE__) . '/lib/UsageRecord.php');
 require(dirname(__FILE__) . '/lib/UsageRecordSummary.php');
+require(dirname(__FILE__) . '/lib/WebhookEndpoint.php');
 
 // OAuth
 require(dirname(__FILE__) . '/lib/OAuth.php');
@@ -145,5 +146,4 @@ require(dirname(__FILE__) . '/lib/OAuthErrorObject.php');
 
 // Webhooks
 require(dirname(__FILE__) . '/lib/Webhook.php');
-require(dirname(__FILE__) . '/lib/WebhookEndpoint.php');
 require(dirname(__FILE__) . '/lib/WebhookSignature.php');

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -178,6 +178,8 @@ class Account extends ApiResource
      * @param array|null $params
      * @param array|string|null $opts
      *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
      * @return Capability
      */
     public static function updateCapability($id, $capabilityId, $params = null, $opts = null)
@@ -288,16 +290,16 @@ class Account extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Collection The list of persons.
      */
-    public function persons($params = null, $options = null)
+    public function persons($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/persons';
-        list($response, $opts) = $this->_request('get', $url, $params, $options);
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
         $obj = Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;

--- a/lib/ApplePayDomain.php
+++ b/lib/ApplePayDomain.php
@@ -5,6 +5,12 @@ namespace Stripe;
 /**
  * Class ApplePayDomain
  *
+ * @property string $id
+ * @property string $object
+ * @property int $created
+ * @property string $domain_name
+ * @property bool $livemode
+ *
  * @package Stripe
  */
 class ApplePayDomain extends ApiResource

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -33,7 +33,7 @@ class ApplicationFee extends ApiResource
     const PATH_REFUNDS = '/refunds';
 
     /**
-     * @param string|null $id The ID of the application fee on which to create the refund.
+     * @param string $id The ID of the application fee on which to create the fee refund.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -47,8 +47,8 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the application fee to which the refund belongs.
-     * @param array|null $refundId The ID of the refund to retrieve.
+     * @param string $id The ID of the application fee to which the fee refund belongs.
+     * @param string $refundId The ID of the fee refund to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -62,8 +62,8 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the application fee to which the refund belongs.
-     * @param array|null $refundId The ID of the refund to update.
+     * @param string $id The ID of the application fee to which the fee refund belongs.
+     * @param string $refundId The ID of the fee refund to update.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -77,13 +77,13 @@ class ApplicationFee extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the application fee on which to retrieve the refunds.
+     * @param string $id The ID of the application fee on which to retrieve the fee refunds.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Collection The list of refunds.
+     * @return Collection The list of fee refunds.
      */
     public static function allRefunds($id, $params = null, $opts = null)
     {

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -97,17 +97,17 @@ class BankAccount extends ApiResource
     }
 
     /**
-      * @param array|null $params
-      * @param array|string|null $options
+     * @param array|null $params
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
-      *
-      * @return BankAccount The verified bank account.
-      */
-    public function verify($params = null, $options = null)
+     *
+     * @return BankAccount The verified bank account.
+     */
+    public function verify($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/verify';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -5,10 +5,33 @@ namespace Stripe;
 /**
  * Class BitcoinReceiver
  *
- * @package Stripe
- *
  * @deprecated Bitcoin receivers are deprecated. Please use the sources API instead.
  * @link https://stripe.com/docs/sources/bitcoin
+ *
+ * @property string $id
+ * @property string $object
+ * @property bool $active
+ * @property int $amount
+ * @property int $amount_received
+ * @property int $bitcoin_amount
+ * @property int $bitcoin_amount_received
+ * @property string $bitcoin_uri
+ * @property int $created
+ * @property string $currency
+ * @property string $customer
+ * @property string $description
+ * @property string $email
+ * @property bool $filled
+ * @property string $inbound_address
+ * @property bool $livemode
+ * @property StripeObject $metadata
+ * @property string $payment
+ * @property string $refund_address
+ * @property mixed $transactions
+ * @property bool $uncaptured_funds
+ * @property bool $used_for_payment
+ *
+ * @package Stripe
  */
 class BitcoinReceiver extends ApiResource
 {

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -44,6 +44,7 @@ namespace Stripe;
  * @property mixed $source
  * @property string $source_transfer
  * @property string $statement_descriptor
+ * @property string $statement_descriptor_suffix
  * @property string $status
  * @property string $transfer
  * @property mixed $transfer_data
@@ -122,16 +123,16 @@ class Charge extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Charge The captured charge.
      */
-    public function capture($params = null, $options = null)
+    public function capture($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/capture';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -13,6 +13,7 @@ namespace Stripe\Checkout;
  * @property string $customer_email
  * @property mixed $display_items
  * @property bool $livemode
+ * @property string $mode
  * @property string $payment_intent
  * @property string[] $payment_method_types
  * @property string $setup_intent
@@ -20,7 +21,7 @@ namespace Stripe\Checkout;
  * @property string $subscription
  * @property string $success_url
  *
- * @package Stripe
+ * @package Stripe\Checkout
  */
 class Session extends \Stripe\ApiResource
 {

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -8,10 +8,10 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string $customer_balance_transaction
  * @property int $created
  * @property string $currency
  * @property string $customer
+ * @property string $customer_balance_transaction
  * @property string $invoice
  * @property bool $livemode
  * @property string $memo
@@ -22,6 +22,7 @@ namespace Stripe;
  * @property string $refund
  * @property string $status
  * @property string $type
+ * @property int $voided_at
  *
  * @package Stripe
  */

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -9,7 +9,7 @@ namespace Stripe;
  * @property string $object
  * @property mixed $address
  * @property int $balance
- * @property string $created
+ * @property int $created
  * @property string $currency
  * @property string $default_source
  * @property bool $delinquent
@@ -66,17 +66,20 @@ class Customer extends ApiResource
     const PATH_TAX_IDS = '/tax_ids';
 
     /**
+     * @param array|null $params
+     * @param array|string|null $options
+     *
      * @return Customer The updated customer.
      */
-    public function deleteDiscount()
+    public function deleteDiscount($params = null, $options = null)
     {
         $url = $this->instanceUrl() . '/discount';
-        list($response, $opts) = $this->_request('delete', $url);
+        list($response, $opts) = $this->_request('delete', $url, $params, $options);
         $this->refreshFrom(['discount' => null], $opts, true);
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to create the source.
+     * @param string $id The ID of the customer on which to create the source.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -90,8 +93,8 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the source belongs.
-     * @param string|null $sourceId The ID of the source to retrieve.
+     * @param string $id The ID of the customer to which the source belongs.
+     * @param string $sourceId The ID of the source to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -105,8 +108,8 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the source belongs.
-     * @param string|null $sourceId The ID of the source to update.
+     * @param string $id The ID of the customer to which the source belongs.
+     * @param string $sourceId The ID of the source to update.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -120,8 +123,8 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the source belongs.
-     * @param string|null $sourceId The ID of the source to delete.
+     * @param string $id The ID of the customer to which the source belongs.
+     * @param string $sourceId The ID of the source to delete.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -135,7 +138,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to retrieve the sources.
+     * @param string $id The ID of the customer on which to retrieve the sources.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -149,13 +152,13 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to create the tax id.
+     * @param string $id The ID of the customer on which to create the tax id.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return TaxId
      */
     public static function createTaxId($id, $params = null, $opts = null)
     {
@@ -163,14 +166,14 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the tax id belongs.
-     * @param string|null $taxIdId The ID of the tax id to retrieve.
+     * @param string $id The ID of the customer to which the tax id belongs.
+     * @param string $taxIdId The ID of the tax id to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return TaxId
      */
     public static function retrieveTaxId($id, $taxIdId, $params = null, $opts = null)
     {
@@ -178,14 +181,14 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the tax id belongs.
-     * @param string|null $taxIdId The ID of the tax id to delete.
+     * @param string $id The ID of the customer to which the tax id belongs.
+     * @param string $taxIdId The ID of the tax id to delete.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return TaxId
      */
     public static function deleteTaxId($id, $taxIdId, $params = null, $opts = null)
     {
@@ -193,7 +196,7 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to retrieve the tax ids.
+     * @param string $id The ID of the customer on which to retrieve the tax ids.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -207,11 +210,13 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to create the balance transaction.
+     * @param string $id The ID of the customer on which to create the balance transaction.
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @return ApiResource
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BalanceTransaction
      */
     public static function createBalanceTransaction($id, $params = null, $opts = null)
     {
@@ -219,14 +224,14 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer to which the balance transaction belongs.
-     * @param string|null $balanceTransactionId The ID of the balance transaction to retrieve.
+     * @param string $id The ID of the customer to which the balance transaction belongs.
+     * @param string $balanceTransactionId The ID of the balance transaction to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return BalanceTransaction
      */
     public static function retrieveBalanceTransaction($id, $balanceTransactionId, $params = null, $opts = null)
     {
@@ -234,14 +239,14 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to update the balance transaction.
-     * @param string|null $balanceTransactionId The ID of the balance transaction to update.
+     * @param string $id The ID of the customer to which the balance transaction belongs.
+     * @param string $balanceTransactionId The ID of the balance transaction to update.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return BalanceTransaction
      */
     public static function updateBalanceTransaction($id, $balanceTransactionId, $params = null, $opts = null)
     {
@@ -249,13 +254,13 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the customer on which to retrieve the customer balance transactions.
+     * @param string $id The ID of the customer on which to retrieve the balance transactions.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Collection The list of customer balance transactions.
+     * @return Collection The list of balance transactions.
      */
     public static function allBalanceTransactions($id, $params = null, $opts = null)
     {

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -17,6 +17,7 @@ namespace Stripe;
  * @property bool $is_charge_refundable
  * @property bool $livemode
  * @property StripeObject $metadata
+ * @property string $network_reason_code
  * @property string $reason
  * @property string $status
  *
@@ -63,16 +64,17 @@ class Dispute extends ApiResource
     const STATUS_WON                    = 'won';
 
     /**
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Dispute The closed dispute.
      */
-    public function close($options = null)
+    // TODO: add $params to standardize signature
+    public function close($opts = null)
     {
         $url = $this->instanceUrl() . '/close';
-        list($response, $opts) = $this->_request('post', $url, null, $options);
+        list($response, $opts) = $this->_request('post', $url, null, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -9,11 +9,11 @@ namespace Stripe;
  * @property string $object
  * @property string $account
  * @property string $api_version
- * @property int    $created
- * @property mixed  $data
- * @property bool   $livemode
- * @property int    $pending_webhooks
- * @property mixed  $request
+ * @property int $created
+ * @property mixed $data
+ * @property bool $livemode
+ * @property int $pending_webhooks
+ * @property mixed $request
  * @property string $type
  *
  * @package Stripe
@@ -21,6 +21,9 @@ namespace Stripe;
 class Event extends ApiResource
 {
     const OBJECT_NAME = "event";
+
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
 
     /**
      * Possible string representations of event types.
@@ -166,7 +169,4 @@ class Event extends ApiResource
     const TRANSFER_CREATED                          = 'transfer.created';
     const TRANSFER_REVERSED                         = 'transfer.reversed';
     const TRANSFER_UPDATED                          = 'transfer.updated';
-
-    use ApiOperations\All;
-    use ApiOperations\Retrieve;
 }

--- a/lib/ExchangeRate.php
+++ b/lib/ExchangeRate.php
@@ -5,6 +5,10 @@ namespace Stripe;
 /**
  * Class ExchangeRate
  *
+ * @property string $id
+ * @property string $object
+ * @property mixed $rates
+ *
  * @package Stripe
  */
 class ExchangeRate extends ApiResource

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -16,7 +16,6 @@ namespace Stripe;
  * @property int $attempt_count
  * @property bool $attempted
  * @property bool $auto_advance
- * @property string $billing
  * @property string $billing_reason
  * @property string $charge
  * @property string $collection_method

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -24,6 +24,7 @@ namespace Stripe;
  * @property string $subscription_item
  * @property array $tax_rates
  * @property int $unit_amount
+ * @property string $unit_amount_decimal
  *
  * @package Stripe
  */

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -13,7 +13,7 @@ namespace Stripe\Issuing;
  * @property string $authorized_currency
  * @property \Stripe\Collection $balance_transactions
  * @property Card $card
- * @property Cardholder $cardholder
+ * @property string $cardholder
  * @property int $created
  * @property int $held_amount
  * @property string $held_currency
@@ -25,7 +25,7 @@ namespace Stripe\Issuing;
  * @property int $pending_held_amount
  * @property mixed $request_history
  * @property string $status
- * @property \Stripe\Collection $transactions
+ * @property array $transactions
  * @property mixed $verification_data
  *
  * @package Stripe\Issuing
@@ -40,32 +40,32 @@ class Authorization extends \Stripe\ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Authorization The approved authorization.
      */
-    public function approve($params = null, $options = null)
+    public function approve($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/approve';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Authorization The declined authorization.
      */
-    public function decline($params = null, $options = null)
+    public function decline($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/decline';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Issuing/Card.php
+++ b/lib/Issuing/Card.php
@@ -8,7 +8,6 @@ namespace Stripe\Issuing;
  * @property string $id
  * @property string $object
  * @property mixed $authorization_controls
- * @property mixed $billing
  * @property string $brand
  * @property Cardholder $cardholder
  * @property int $created
@@ -19,6 +18,9 @@ namespace Stripe\Issuing;
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
+ * @property mixed $pin
+ * @property string $replacement_for
+ * @property string $replacement_reason
  * @property mixed $shipping
  * @property string $status
  * @property string $type
@@ -36,16 +38,16 @@ class Card extends \Stripe\ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return CardDetails The card details associated with that issuing card.
      */
-    public function details($params = null, $options = null)
+    public function details($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/details';
-        list($response, $opts) = $this->_request('get', $url, $params, $options);
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
         $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;

--- a/lib/Issuing/Cardholder.php
+++ b/lib/Issuing/Cardholder.php
@@ -7,13 +7,16 @@ namespace Stripe\Issuing;
  *
  * @property string $id
  * @property string $object
+ * @property mixed $authorization_controls
  * @property mixed $billing
  * @property int $created
  * @property string $email
+ * @property bool $is_default
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
  * @property string $phone_number
+ * @property mixed $requirements
  * @property string $status
  * @property string $type
  *

--- a/lib/Issuing/Dispute.php
+++ b/lib/Issuing/Dispute.php
@@ -10,12 +10,12 @@ namespace Stripe\Issuing;
  * @property int $amount
  * @property int $created
  * @property string $currency
+ * @property string $disputed_transaction
  * @property mixed $evidence
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $reason
  * @property string $status
- * @property Transaction $transaction
  *
  * @package Stripe\Issuing
  */

--- a/lib/Issuing/Transaction.php
+++ b/lib/Issuing/Transaction.php
@@ -16,9 +16,9 @@ namespace Stripe\Issuing;
  * @property string $currency
  * @property string $dispute
  * @property bool $livemode
- * @property mixed $merchant_data
  * @property int $merchant_amount
  * @property string $merchant_currency
+ * @property mixed $merchant_data
  * @property \Stripe\StripeObject $metadata
  * @property string $type
  *
@@ -29,7 +29,6 @@ class Transaction extends \Stripe\ApiResource
     const OBJECT_NAME = "issuing.transaction";
 
     use \Stripe\ApiOperations\All;
-    use \Stripe\ApiOperations\Create;
     use \Stripe\ApiOperations\Retrieve;
     use \Stripe\ApiOperations\Update;
 }

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -41,6 +41,9 @@ class Order extends ApiResource
     use ApiOperations\Update;
 
     /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Order The paid order.
@@ -54,6 +57,9 @@ class Order extends ApiResource
     }
 
     /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return OrderReturn The newly created return.

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -29,12 +29,15 @@ namespace Stripe;
  * @property mixed $next_action
  * @property string $on_behalf_of
  * @property string $payment_method
+ * @property mixed $payment_method_options
  * @property string[] $payment_method_types
  * @property string $receipt_email
  * @property string $review
+ * @property string $setup_future_usage
  * @property mixed $shipping
  * @property string $source
  * @property string $statement_descriptor
+ * @property string $statement_descriptor_suffix
  * @property string $status
  * @property mixed $transfer_data
  * @property string $transfer_group
@@ -65,48 +68,48 @@ class PaymentIntent extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return PaymentIntent The canceled payment intent.
      */
-    public function cancel($params = null, $options = null)
+    public function cancel($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/cancel';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return PaymentIntent The captured payment intent.
      */
-    public function capture($params = null, $options = null)
+    public function capture($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/capture';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return PaymentIntent The confirmed payment intent.
      */
-    public function confirm($params = null, $options = null)
+    public function confirm($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/confirm';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -80,14 +80,17 @@ class Payout extends ApiResource
     const TYPE_CARD         = 'card';
 
     /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Payout The canceled payout.
      */
-    public function cancel()
+    public function cancel($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/cancel';
-        list($response, $opts) = $this->_request('post', $url);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -5,13 +5,12 @@ namespace Stripe;
 /**
  * Class Plan
  *
- * @package Stripe
- *
  * @property string $id
  * @property string $object
  * @property bool $active
  * @property string $aggregate_usage
  * @property int $amount
+ * @property string $amount_decimal
  * @property string $billing_scheme
  * @property int $created
  * @property string $currency
@@ -26,6 +25,8 @@ namespace Stripe;
  * @property mixed $transform_usage
  * @property int $trial_period_days
  * @property string $usage_type
+ *
+ * @package Stripe
  */
 class Plan extends ApiResource
 {

--- a/lib/Radar/ValueList.php
+++ b/lib/Radar/ValueList.php
@@ -11,12 +11,10 @@ namespace Stripe\Radar;
  * @property int $created
  * @property string $created_by
  * @property string $item_type
- * @property Collection $list_items
+ * @property \Stripe\Collection $list_items
  * @property bool $livemode
  * @property StripeObject $metadata
- * @property mixed $name
- * @property int $updated
- * @property string $updated_by
+ * @property string $name
  *
  * @package Stripe\Radar
  */

--- a/lib/Radar/ValueListItem.php
+++ b/lib/Radar/ValueListItem.php
@@ -9,9 +9,9 @@ namespace Stripe\Radar;
  * @property string $object
  * @property int $created
  * @property string $created_by
- * @property string $list
  * @property bool $livemode
  * @property string $value
+ * @property string $value_list
  *
  * @package Stripe\Radar
  */

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -5,8 +5,6 @@ namespace Stripe;
 /**
  * Class Recipient
  *
- * @package Stripe
- *
  * @property string $id
  * @property string $object
  * @property mixed $active_account
@@ -21,6 +19,9 @@ namespace Stripe;
  * @property string $name
  * @property string $rolled_back_from
  * @property string $type
+ * @property bool $verified
+ *
+ * @package Stripe
  */
 class Recipient extends ApiResource
 {

--- a/lib/Reporting/ReportType.php
+++ b/lib/Reporting/ReportType.php
@@ -9,9 +9,10 @@ namespace Stripe\Reporting;
  * @property string $object
  * @property int $data_available_end
  * @property int $data_available_start
+ * @property string[] $default_columns
  * @property string $name
  * @property int $updated
- * @property string $version
+ * @property int $version
  *
  * @package Stripe\Reporting
  */

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -43,16 +43,17 @@ class Review extends ApiResource
     const REASON_RULE              = 'rule';
 
     /**
-     * @param array|string|null $options
+     * @param array|null $params
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Review The approved review.
      */
-    public function approve($params = null, $options = null)
+    public function approve($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/approve';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -8,6 +8,7 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property string $application
+ * @property string $cancellation_reason
  * @property string $client_secret
  * @property int $created
  * @property string $customer
@@ -18,8 +19,10 @@ namespace Stripe;
  * @property mixed $next_action
  * @property string $on_behalf_of
  * @property string $payment_method
+ * @property mixed $payment_method_options
  * @property string[] $payment_method_types
  * @property string $status
+ * @property string $usage
  *
  * @package Stripe
  */
@@ -46,32 +49,32 @@ class SetupIntent extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return SetupIntent The canceled setup intent.
      */
-    public function cancel($params = null, $options = null)
+    public function cancel($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/cancel';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return SetupIntent The confirmed setup intent.
      */
-    public function confirm($params = null, $options = null)
+    public function confirm($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/confirm';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Sigma/ScheduledQueryRun.php
+++ b/lib/Sigma/ScheduledQueryRun.php
@@ -3,13 +3,13 @@
 namespace Stripe\Sigma;
 
 /**
- * Class Authorization
+ * Class ScheduledQueryRun
  *
  * @property string $id
  * @property string $object
  * @property int $created
  * @property int $data_load_time
- * @property string $error
+ * @property mixed $error
  * @property \Stripe\File $file
  * @property bool $livemode
  * @property int $result_available_until

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -9,8 +9,10 @@ namespace Stripe;
  * @property string $object
  * @property mixed $ach_credit_transfer
  * @property mixed $ach_debit
+ * @property mixed $acss_debit
  * @property mixed $alipay
  * @property int $amount
+ * @property mixed $au_becs_debit
  * @property mixed $bancontact
  * @property mixed $card
  * @property mixed $card_present
@@ -23,6 +25,7 @@ namespace Stripe;
  * @property string $flow
  * @property mixed $giropay
  * @property mixed $ideal
+ * @property mixed $klarna
  * @property bool $livemode
  * @property StripeObject $metadata
  * @property mixed $multibanco
@@ -30,15 +33,17 @@ namespace Stripe;
  * @property mixed $p24
  * @property mixed $receiver
  * @property mixed $redirect
+ * @property mixed $sepa_credit_transfer
  * @property mixed $sepa_debit
  * @property mixed $sofort
+ * @property mixed $source_order
  * @property string $statement_descriptor
  * @property string $status
  * @property mixed $three_d_secure
  * @property string $type
  * @property string $usage
  * @property mixed $wechat
-
+ *
  * @package Stripe
  */
 class Source extends ApiResource
@@ -77,14 +82,14 @@ class Source extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\UnexpectedValueException if the source is not attached to a customer
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Source The detached source.
      */
-    public function detach($params = null, $options = null)
+    public function detach($params = null, $opts = null)
     {
         self::_validateParams($params);
 
@@ -102,7 +107,7 @@ class Source extends ApiResource
             $extn = urlencode(Util\Util::utf8($id));
             $url = "$base/$parentExtn/sources/$extn";
 
-            list($response, $opts) = $this->_request('delete', $url, $params, $options);
+            list($response, $opts) = $this->_request('delete', $url, $params, $opts);
             $this->refreshFrom($response, $opts);
             return $this;
         } else {
@@ -114,33 +119,33 @@ class Source extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Collection The list of source transactions.
      */
-    public function sourceTransactions($params = null, $options = null)
+    public function sourceTransactions($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/source_transactions';
-        list($response, $opts) = $this->_request('get', $url, $params, $options);
-        $obj = Util\Util::convertToStripeObject($response, $opts);
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
     }
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Source The verified source.
      */
-    public function verify($params = null, $options = null)
+    public function verify($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/verify';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -8,9 +8,9 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property float $application_fee_percent
- * @property string $billing
  * @property int $billing_cycle_anchor
  * @property mixed $billing_thresholds
+ * @property int $cancel_at
  * @property bool $cancel_at_period_end
  * @property int $canceled_at
  * @property string $collection_method
@@ -26,13 +26,14 @@ namespace Stripe;
  * @property int $ended_at
  * @property Collection $items
  * @property string $latest_invoice
- * @property boolean $livemode
+ * @property bool $livemode
  * @property StripeObject $metadata
+ * @property int $next_pending_invoice_item_invoice
+ * @property mixed $pending_invoice_item_interval
  * @property string $pending_setup_intent
  * @property Plan $plan
  * @property int $quantity
- * @property SubscriptionSchedule $schedule
- * @property int $start
+ * @property string $schedule
  * @property int $start_date
  * @property string $status
  * @property float $tax_percent
@@ -79,6 +80,7 @@ class Subscription extends ApiResource
 
     /**
      * @param array|null $params
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
@@ -90,14 +92,17 @@ class Subscription extends ApiResource
     }
 
     /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Subscription The updated subscription.
      */
-    public function deleteDiscount()
+    public function deleteDiscount($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/discount';
-        list($response, $opts) = $this->_request('delete', $url);
+        list($response, $opts) = $this->_request('delete', $url, $params, $opts);
         $this->refreshFrom(['discount' => null], $opts, true);
     }
 }

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -21,14 +21,14 @@ class SubscriptionItem extends ApiResource
 {
     const OBJECT_NAME = "subscription_item";
 
-    const PATH_USAGE_RECORDS = '/usage_records';
-
     use ApiOperations\All;
     use ApiOperations\Create;
     use ApiOperations\Delete;
     use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
+
+    const PATH_USAGE_RECORDS = "/usage_records";
 
     /**
      * @param string|null $id The ID of the subscription item on which to create the usage record.
@@ -46,17 +46,17 @@ class SubscriptionItem extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Collection The list of usage record summaries.
      */
-    public function usageRecordSummaries($params = null, $options = null)
+    public function usageRecordSummaries($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/usage_record_summaries';
-        list($response, $opts) = $this->_request('get', $url, $params, $options);
-        $obj = Util\Util::convertToStripeObject($response, $opts);
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
     }

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -7,22 +7,22 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $billing
  * @property mixed $billing_thresholds
  * @property int $canceled_at
+ * @property string $collection_method
  * @property int $completed_at
  * @property int $created
  * @property mixed $current_phase
  * @property string $customer
+ * @property string $default_payment_method
+ * @property string $end_behavior
  * @property mixed $invoice_settings
- * @property boolean $livemode
+ * @property bool $livemode
  * @property StripeObject $metadata
  * @property mixed $phases
  * @property int $released_at
  * @property string $released_subscription
- * @property string $renewal_behavior
  * @property mixed $renewal_interval
- * @property string $revision
  * @property string $status
  * @property string $subscription
  *
@@ -36,7 +36,6 @@ class SubscriptionSchedule extends ApiResource
     use ApiOperations\Create;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
-    use ApiOperations\NestedResource;
 
     /**
      * @param array|null $params

--- a/lib/Terminal/ConnectionToken.php
+++ b/lib/Terminal/ConnectionToken.php
@@ -5,6 +5,8 @@ namespace Stripe\Terminal;
 /**
  * Class ConnectionToken
  *
+ * @property string $object
+ * @property string $location
  * @property string $secret
  *
  * @package Stripe\Terminal

--- a/lib/Terminal/Location.php
+++ b/lib/Terminal/Location.php
@@ -8,7 +8,6 @@ namespace Stripe\Terminal;
  * @property string $id
  * @property string $object
  * @property mixed $address
- * @property bool $deleted
  * @property string $display_name
  *
  * @package Stripe\Terminal

--- a/lib/Terminal/Reader.php
+++ b/lib/Terminal/Reader.php
@@ -7,7 +7,6 @@ namespace Stripe\Terminal;
  *
  * @property string $id
  * @property string $object
- * @property bool $deleted
  * @property string $device_sw_version
  * @property string $device_type
  * @property string $ip_address

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -2,6 +2,22 @@
 
 namespace Stripe;
 
+/**
+ * Class ThreeDSecure
+ *
+ * @property string $id
+ * @property string $object
+ * @property int $amount
+ * @property bool $authenticated
+ * @property mixed $card
+ * @property int $created
+ * @property string $currency
+ * @property bool $livemode
+ * @property string $redirect_url
+ * @property string $status
+ *
+ * @package Stripe
+ */
 class ThreeDSecure extends ApiResource
 {
     const OBJECT_NAME = "three_d_secure";

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -45,16 +45,16 @@ class Topup extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Topup The canceled topup.
      */
-    public function cancel($params = null, $options = null)
+    public function cancel($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/cancel';
-        list($response, $opts) = $this->_request('post', $url, $params, $options);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -47,18 +47,23 @@ class Transfer extends ApiResource
     const SOURCE_TYPE_FINANCING      = 'financing';
 
     /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
      * @return Transfer The canceled transfer.
      */
-    public function cancel()
+    public function cancel($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/cancel';
-        list($response, $opts) = $this->_request('post', $url);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }
 
     /**
-     * @param string|null $id The ID of the transfer on which to create the reversal.
+     * @param string $id The ID of the transfer on which to create the transfer reversal.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -72,8 +77,8 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the transfer to which the reversal belongs.
-     * @param array|null $reversalId The ID of the reversal to retrieve.
+     * @param string $id The ID of the transfer to which the transfer reversal belongs.
+     * @param string $reversalId The ID of the transfer reversal to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -87,8 +92,8 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the transfer to which the reversal belongs.
-     * @param array|null $reversalId The ID of the reversal to update.
+     * @param string $id The ID of the transfer to which the transfer reversal belongs.
+     * @param string $reversalId The ID of the transfer reversal to update.
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -102,13 +107,13 @@ class Transfer extends ApiResource
     }
 
     /**
-     * @param string|null $id The ID of the transfer on which to retrieve the reversals.
+     * @param string $id The ID of the transfer on which to retrieve the transfer reversals.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Collection The list of reversals.
+     * @return Collection The list of transfer reversals.
      */
     public static function allReversals($id, $params = null, $opts = null)
     {

--- a/lib/WebhookEndpoint.php
+++ b/lib/WebhookEndpoint.php
@@ -7,6 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
+ * @property string $api_version
+ * @property string $application
  * @property int $created
  * @property string[] $enabled_events
  * @property bool $livemode


### PR DESCRIPTION
r? @remi-stripe @marko-stripe
cc @stripe/api-libraries 

A bunch of fixes I pulled from @marko-stripe's almost-ready codegen branch:
- fix a lot of PHPDoc blocks
- use `$opts` instead of `$options` everywhere
- standardize all but one methods to accept `$params` and `$opts`
    - the only exception is `Dispute.close()` which already accepts `$opts`, so adding `$params` first would be a breaking change. I left a TODO so we can fix in the next major version
