### PR TITLE
Mark nullable fields in PHPDoc

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -7,8 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed $business_profile
- * @property string $business_type
+ * @property mixed|null $business_profile
+ * @property string|null $business_type
  * @property mixed $capabilities
  * @property bool $charges_enabled
  * @property mixed $company
@@ -16,13 +16,13 @@ namespace Stripe;
  * @property int $created
  * @property string $default_currency
  * @property bool $details_submitted
- * @property string $email
- * @property Collection $external_accounts
+ * @property string|null $email
+ * @property \Stripe\Collection $external_accounts
  * @property mixed $individual
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property bool $payouts_enabled
  * @property mixed $requirements
- * @property mixed $settings
+ * @property mixed|null $settings
  * @property mixed $tos_acceptance
  * @property string $type
  *

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -11,14 +11,14 @@ namespace Stripe;
  * @property int $amount
  * @property int $amount_refunded
  * @property string $application
- * @property string $balance_transaction
+ * @property string|null $balance_transaction
  * @property string $charge
  * @property int $created
  * @property string $currency
  * @property bool $livemode
- * @property string $originating_transaction
+ * @property string|null $originating_transaction
  * @property bool $refunded
- * @property Collection $refunds
+ * @property \Stripe\Collection $refunds
  *
  * @package Stripe
  */

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -11,12 +11,12 @@ namespace Stripe;
  * @property int $available_on
  * @property int $created
  * @property string $currency
- * @property string $description
- * @property float $exchange_rate
+ * @property string|null $description
+ * @property float|null $exchange_rate
  * @property int $fee
  * @property mixed $fee_details
  * @property int $net
- * @property string $source
+ * @property string|null $source
  * @property string $status
  * @property string $type
  *

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -7,18 +7,18 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $account
- * @property string $account_holder_name
- * @property string $account_holder_type
- * @property string $bank_name
+ * @property string|null $account
+ * @property string|null $account_holder_name
+ * @property string|null $account_holder_type
+ * @property string|null $bank_name
  * @property string $country
- * @property string $currency
- * @property string $customer
- * @property bool $default_for_currency
- * @property string $fingerprint
+ * @property string|null $currency
+ * @property string|null $customer
+ * @property bool|null $default_for_currency
+ * @property string|null $fingerprint
  * @property string $last4
- * @property StripeObject $metadata
- * @property string $routing_number
+ * @property \Stripe\StripeObject|null $metadata
+ * @property string|null $routing_number
  * @property string $status
  *
  * @package Stripe

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -18,18 +18,18 @@ namespace Stripe;
  * @property string $bitcoin_uri
  * @property int $created
  * @property string $currency
- * @property string $customer
- * @property string $description
- * @property string $email
+ * @property string|null $customer
+ * @property string|null $description
+ * @property string|null $email
  * @property bool $filled
  * @property string $inbound_address
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $payment
- * @property string $refund_address
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $payment
+ * @property string|null $refund_address
  * @property mixed $transactions
  * @property bool $uncaptured_funds
- * @property bool $used_for_payment
+ * @property bool|null $used_for_payment
  *
  * @package Stripe
  */

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -7,32 +7,32 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $account
- * @property string $address_city
- * @property string $address_country
- * @property string $address_line1
- * @property string $address_line1_check
- * @property string $address_line2
- * @property string $address_state
- * @property string $address_zip
- * @property string $address_zip_check
- * @property string[] $available_payout_methods
+ * @property string|null $account
+ * @property string|null $address_city
+ * @property string|null $address_country
+ * @property string|null $address_line1
+ * @property string|null $address_line1_check
+ * @property string|null $address_line2
+ * @property string|null $address_state
+ * @property string|null $address_zip
+ * @property string|null $address_zip_check
+ * @property string[]|null $available_payout_methods
  * @property string $brand
- * @property string $country
- * @property string $currency
- * @property string $customer
- * @property string $cvc_check
- * @property bool $default_for_currency
- * @property string $dynamic_last4
+ * @property string|null $country
+ * @property string|null $currency
+ * @property string|null $customer
+ * @property string|null $cvc_check
+ * @property bool|null $default_for_currency
+ * @property string|null $dynamic_last4
  * @property int $exp_month
  * @property int $exp_year
- * @property string $fingerprint
+ * @property string|null $fingerprint
  * @property string $funding
  * @property string $last4
- * @property StripeObject $metadata
- * @property string $name
- * @property string $recipient
- * @property string $tokenization_method
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $name
+ * @property string|null $recipient
+ * @property string|null $tokenization_method
  *
  * @package Stripe
  */

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -9,46 +9,46 @@ namespace Stripe;
  * @property string $object
  * @property int $amount
  * @property int $amount_refunded
- * @property string $application
- * @property string $application_fee
- * @property int $application_fee_amount
- * @property string $balance_transaction
+ * @property string|null $application
+ * @property string|null $application_fee
+ * @property int|null $application_fee_amount
+ * @property string|null $balance_transaction
  * @property mixed $billing_details
  * @property bool $captured
  * @property int $created
  * @property string $currency
- * @property string $customer
- * @property string $description
- * @property string $destination
- * @property string $dispute
- * @property string $failure_code
- * @property string $failure_message
- * @property mixed $fraud_details
- * @property string $invoice
+ * @property string|null $customer
+ * @property string|null $description
+ * @property string|null $destination
+ * @property string|null $dispute
+ * @property string|null $failure_code
+ * @property string|null $failure_message
+ * @property mixed|null $fraud_details
+ * @property string|null $invoice
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $on_behalf_of
- * @property string $order
- * @property mixed $outcome
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $on_behalf_of
+ * @property string|null $order
+ * @property mixed|null $outcome
  * @property bool $paid
- * @property string $payment_intent
- * @property string $payment_method
- * @property mixed $payment_method_details
- * @property string $receipt_email
- * @property string $receipt_number
+ * @property string|null $payment_intent
+ * @property string|null $payment_method
+ * @property mixed|null $payment_method_details
+ * @property string|null $receipt_email
+ * @property string|null $receipt_number
  * @property string $receipt_url
  * @property bool $refunded
- * @property Collection $refunds
- * @property string $review
- * @property mixed $shipping
- * @property mixed $source
- * @property string $source_transfer
- * @property string $statement_descriptor
- * @property string $statement_descriptor_suffix
+ * @property \Stripe\Collection $refunds
+ * @property string|null $review
+ * @property mixed|null $shipping
+ * @property mixed|null $source
+ * @property string|null $source_transfer
+ * @property string|null $statement_descriptor
+ * @property string|null $statement_descriptor_suffix
  * @property string $status
  * @property string $transfer
- * @property mixed $transfer_data
- * @property string $transfer_group
+ * @property mixed|null $transfer_data
+ * @property string|null $transfer_group
  *
  * @package Stripe
  */

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -8,17 +8,17 @@ namespace Stripe\Checkout;
  * @property string $id
  * @property string $object
  * @property string $cancel_url
- * @property string $client_reference_id
- * @property string $customer
- * @property string $customer_email
- * @property mixed $display_items
+ * @property string|null $client_reference_id
+ * @property string|null $customer
+ * @property string|null $customer_email
+ * @property mixed|null $display_items
  * @property bool $livemode
- * @property string $mode
- * @property string $payment_intent
+ * @property string|null $mode
+ * @property string|null $payment_intent
  * @property string[] $payment_method_types
- * @property string $setup_intent
- * @property string $submit_type
- * @property string $subscription
+ * @property string|null $setup_intent
+ * @property string|null $submit_type
+ * @property string|null $subscription
  * @property string $success_url
  *
  * @package Stripe\Checkout

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -7,17 +7,17 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property int $amount_off
+ * @property int|null $amount_off
  * @property int $created
- * @property string $currency
+ * @property string|null $currency
  * @property string $duration
- * @property int $duration_in_months
+ * @property int|null $duration_in_months
  * @property bool $livemode
- * @property int $max_redemptions
- * @property StripeObject $metadata
- * @property string $name
- * @property float $percent_off
- * @property int $redeem_by
+ * @property int|null $max_redemptions
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $name
+ * @property float|null $percent_off
+ * @property int|null $redeem_by
  * @property int $times_redeemed
  * @property bool $valid
  *

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -11,18 +11,18 @@ namespace Stripe;
  * @property int $created
  * @property string $currency
  * @property string $customer
- * @property string $customer_balance_transaction
+ * @property string|null $customer_balance_transaction
  * @property string $invoice
  * @property bool $livemode
- * @property string $memo
- * @property StripeObject $metadata
+ * @property string|null $memo
+ * @property \Stripe\StripeObject $metadata
  * @property string $number
  * @property string $pdf
- * @property string $reason
- * @property string $refund
+ * @property string|null $reason
+ * @property string|null $refund
  * @property string $status
  * @property string $type
- * @property int $voided_at
+ * @property int|null $voided_at
  *
  * @package Stripe
  */

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -7,27 +7,27 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed $address
+ * @property mixed|null $address
  * @property int $balance
  * @property int $created
- * @property string $currency
- * @property string $default_source
- * @property bool $delinquent
- * @property string $description
- * @property Discount $discount
- * @property string $email
- * @property string $invoice_prefix
+ * @property string|null $currency
+ * @property string|null $default_source
+ * @property bool|null $delinquent
+ * @property string|null $description
+ * @property \Stripe\Discount|null $discount
+ * @property string|null $email
+ * @property string|null $invoice_prefix
  * @property mixed $invoice_settings
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $name
- * @property string $phone
- * @property string[] $preferred_locales
- * @property mixed $shipping
- * @property Collection $sources
- * @property Collection $subscriptions
- * @property string $tax_exempt
- * @property Collection $tax_ids
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $name
+ * @property string|null $phone
+ * @property string[]|null $preferred_locales
+ * @property mixed|null $shipping
+ * @property \Stripe\Collection $sources
+ * @property \Stripe\Collection $subscriptions
+ * @property string|null $tax_exempt
+ * @property \Stripe\Collection $tax_ids
  *
  * @package Stripe
  */

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -16,8 +16,8 @@ namespace Stripe;
  * @property mixed $evidence_details
  * @property bool $is_charge_refundable
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $network_reason_code
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $network_reason_code
  * @property string $reason
  * @property string $status
  *

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -8,12 +8,12 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property string $account
- * @property string $api_version
+ * @property string|null $api_version
  * @property int $created
  * @property mixed $data
  * @property bool $livemode
  * @property int $pending_webhooks
- * @property mixed $request
+ * @property mixed|null $request
  * @property string $type
  *
  * @package Stripe

--- a/lib/File.php
+++ b/lib/File.php
@@ -8,13 +8,13 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $created
- * @property string $filename
- * @property Collection $links
+ * @property string|null $filename
+ * @property \Stripe\Collection|null $links
  * @property string $purpose
  * @property int $size
- * @property string $title
- * @property string $type
- * @property string $url
+ * @property string|null $title
+ * @property string|null $type
+ * @property string|null $url
  *
  * @package Stripe
  */

--- a/lib/FileLink.php
+++ b/lib/FileLink.php
@@ -9,11 +9,11 @@ namespace Stripe;
  * @property string $object
  * @property int $created
  * @property bool $expired
- * @property int $expires_at
+ * @property int|null $expires_at
  * @property string $file
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $url
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $url
  *
  * @package Stripe
  */

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -7,63 +7,63 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $account_country
- * @property string $account_name
+ * @property string|null $account_country
+ * @property string|null $account_name
  * @property int $amount_due
  * @property int $amount_paid
  * @property int $amount_remaining
- * @property int $application_fee_amount
+ * @property int|null $application_fee_amount
  * @property int $attempt_count
  * @property bool $attempted
  * @property bool $auto_advance
- * @property string $billing_reason
- * @property string $charge
- * @property string $collection_method
+ * @property string|null $billing_reason
+ * @property string|null $charge
+ * @property string|null $collection_method
  * @property int $created
  * @property string $currency
- * @property array $custom_fields
+ * @property array|null $custom_fields
  * @property string $customer
- * @property mixed $customer_address
- * @property string $customer_email
- * @property string $customer_name
- * @property string $customer_phone
- * @property mixed $customer_shipping
- * @property string $customer_tax_exempt
- * @property array $customer_tax_ids
- * @property string $default_payment_method
- * @property string $default_source
- * @property array $default_tax_rates
- * @property string $description
- * @property Discount $discount
- * @property int $due_date
- * @property int $ending_balance
- * @property string $footer
- * @property string $hosted_invoice_url
- * @property string $invoice_pdf
- * @property Collection $lines
+ * @property mixed|null $customer_address
+ * @property string|null $customer_email
+ * @property string|null $customer_name
+ * @property string|null $customer_phone
+ * @property mixed|null $customer_shipping
+ * @property string|null $customer_tax_exempt
+ * @property array|null $customer_tax_ids
+ * @property string|null $default_payment_method
+ * @property string|null $default_source
+ * @property array|null $default_tax_rates
+ * @property string|null $description
+ * @property \Stripe\Discount|null $discount
+ * @property int|null $due_date
+ * @property int|null $ending_balance
+ * @property string|null $footer
+ * @property string|null $hosted_invoice_url
+ * @property string|null $invoice_pdf
+ * @property \Stripe\Collection $lines
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property int $next_payment_attempt
- * @property string $number
+ * @property \Stripe\StripeObject|null $metadata
+ * @property int|null $next_payment_attempt
+ * @property string|null $number
  * @property bool $paid
- * @property string $payment_intent
+ * @property string|null $payment_intent
  * @property int $period_end
  * @property int $period_start
  * @property int $post_payment_credit_notes_amount
  * @property int $pre_payment_credit_notes_amount
- * @property string $receipt_number
+ * @property string|null $receipt_number
  * @property int $starting_balance
- * @property string $statement_descriptor
- * @property string $status
+ * @property string|null $statement_descriptor
+ * @property string|null $status
  * @property mixed $status_transitions
- * @property string $subscription
+ * @property string|null $subscription
  * @property int $subscription_proration_date
  * @property int $subtotal
- * @property int $tax
+ * @property int|null $tax
  * @property mixed $threshold_reason
  * @property int $total
- * @property array $total_tax_amounts
- * @property int $webhooks_delivered_at
+ * @property array|null $total_tax_amounts
+ * @property int|null $webhooks_delivered_at
  *
  * @package Stripe
  */

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -11,20 +11,20 @@ namespace Stripe;
  * @property string $currency
  * @property string $customer
  * @property int $date
- * @property string $description
+ * @property string|null $description
  * @property bool $discountable
- * @property string $invoice
+ * @property string|null $invoice
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property mixed $period
- * @property Plan $plan
+ * @property \Stripe\Plan|null $plan
  * @property bool $proration
  * @property int $quantity
- * @property string $subscription
+ * @property string|null $subscription
  * @property string $subscription_item
- * @property array $tax_rates
- * @property int $unit_amount
- * @property string $unit_amount_decimal
+ * @property array|null $tax_rates
+ * @property int|null $unit_amount
+ * @property string|null $unit_amount_decimal
  *
  * @package Stripe
  */

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -13,7 +13,7 @@ namespace Stripe\Issuing;
  * @property string $authorized_currency
  * @property \Stripe\Collection $balance_transactions
  * @property Card $card
- * @property string $cardholder
+ * @property string|null $cardholder
  * @property int $created
  * @property int $held_amount
  * @property string $held_currency

--- a/lib/Issuing/Card.php
+++ b/lib/Issuing/Card.php
@@ -9,7 +9,7 @@ namespace Stripe\Issuing;
  * @property string $object
  * @property mixed $authorization_controls
  * @property string $brand
- * @property Cardholder $cardholder
+ * @property \Stripe\Issuing\Cardholder|null $cardholder
  * @property int $created
  * @property string $currency
  * @property int $exp_month
@@ -18,10 +18,10 @@ namespace Stripe\Issuing;
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property mixed $pin
- * @property string $replacement_for
- * @property string $replacement_reason
- * @property mixed $shipping
+ * @property mixed|null $pin
+ * @property string|null $replacement_for
+ * @property string|null $replacement_reason
+ * @property mixed|null $shipping
  * @property string $status
  * @property string $type
  *

--- a/lib/Issuing/Cardholder.php
+++ b/lib/Issuing/Cardholder.php
@@ -7,15 +7,15 @@ namespace Stripe\Issuing;
  *
  * @property string $id
  * @property string $object
- * @property mixed $authorization_controls
+ * @property mixed|null $authorization_controls
  * @property mixed $billing
  * @property int $created
- * @property string $email
+ * @property string|null $email
  * @property bool $is_default
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property string $phone_number
+ * @property string|null $phone_number
  * @property mixed $requirements
  * @property string $status
  * @property string $type

--- a/lib/Issuing/Transaction.php
+++ b/lib/Issuing/Transaction.php
@@ -8,13 +8,13 @@ namespace Stripe\Issuing;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string $authorization
- * @property string $balance_transaction
+ * @property string|null $authorization
+ * @property string|null $balance_transaction
  * @property string $card
- * @property string $cardholder
+ * @property string|null $cardholder
  * @property int $created
  * @property string $currency
- * @property string $dispute
+ * @property string|null $dispute
  * @property bool $livemode
  * @property int $merchant_amount
  * @property string $merchant_currency

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -8,25 +8,25 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property int $amount_returned
- * @property string $application
- * @property int $application_fee
- * @property string $charge
+ * @property int|null $amount_returned
+ * @property string|null $application
+ * @property int|null $application_fee
+ * @property string|null $charge
  * @property int $created
  * @property string $currency
- * @property string $customer
- * @property string $email
+ * @property string|null $customer
+ * @property string|null $email
  * @property string $external_coupon_code
  * @property OrderItem[] $items
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property Collection $returns
- * @property string $selected_shipping_method
- * @property mixed $shipping
- * @property array $shipping_methods
+ * @property \Stripe\StripeObject $metadata
+ * @property \Stripe\Collection|null $returns
+ * @property string|null $selected_shipping_method
+ * @property mixed|null $shipping
+ * @property array|null $shipping_methods
  * @property string $status
- * @property mixed $status_transitions
- * @property int $updated
+ * @property mixed|null $status_transitions
+ * @property int|null $updated
  * @property string $upstream_id
  *
  * @package Stripe

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -12,8 +12,8 @@ namespace Stripe;
  * @property string $currency
  * @property OrderItem[] $items
  * @property bool $livemode
- * @property string $order
- * @property string $refund
+ * @property string|null $order
+ * @property string|null $refund
  *
  * @package Stripe
  */

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -10,37 +10,37 @@ namespace Stripe;
  * @property int $amount
  * @property int $amount_capturable
  * @property int $amount_received
- * @property string $application
- * @property int $application_fee_amount
- * @property int $canceled_at
- * @property string $cancellation_reason
+ * @property string|null $application
+ * @property int|null $application_fee_amount
+ * @property int|null $canceled_at
+ * @property string|null $cancellation_reason
  * @property string $capture_method
- * @property Collection $charges
- * @property string $client_secret
+ * @property \Stripe\Collection $charges
+ * @property string|null $client_secret
  * @property string $confirmation_method
  * @property int $created
  * @property string $currency
- * @property string $customer
- * @property string $description
- * @property string $invoice
- * @property mixed $last_payment_error
+ * @property string|null $customer
+ * @property string|null $description
+ * @property string|null $invoice
+ * @property mixed|null $last_payment_error
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property mixed $next_action
- * @property string $on_behalf_of
- * @property string $payment_method
- * @property mixed $payment_method_options
+ * @property \Stripe\StripeObject $metadata
+ * @property mixed|null $next_action
+ * @property string|null $on_behalf_of
+ * @property string|null $payment_method
+ * @property mixed|null $payment_method_options
  * @property string[] $payment_method_types
- * @property string $receipt_email
- * @property string $review
- * @property string $setup_future_usage
- * @property mixed $shipping
- * @property string $source
- * @property string $statement_descriptor
- * @property string $statement_descriptor_suffix
+ * @property string|null $receipt_email
+ * @property string|null $review
+ * @property string|null $setup_future_usage
+ * @property mixed|null $shipping
+ * @property string|null $source
+ * @property string|null $statement_descriptor
+ * @property string|null $statement_descriptor_suffix
  * @property string $status
- * @property mixed $transfer_data
- * @property string $transfer_group
+ * @property mixed|null $transfer_data
+ * @property string|null $transfer_group
  *
  * @package Stripe
  */

--- a/lib/PaymentMethod.php
+++ b/lib/PaymentMethod.php
@@ -11,11 +11,11 @@ namespace Stripe;
  * @property mixed $card
  * @property mixed $card_present
  * @property int $created
- * @property string $customer
- * @property mixed $ideal
+ * @property string|null $customer
+ * @property mixed|null $ideal
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property mixed $sepa_debit
+ * @property \Stripe\StripeObject $metadata
+ * @property mixed|null $sepa_debit
  * @property string $type
  *
  * @package Stripe

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -10,19 +10,19 @@ namespace Stripe;
  * @property int $amount
  * @property int $arrival_date
  * @property bool $automatic
- * @property string $balance_transaction
+ * @property string|null $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string $description
- * @property string $destination
- * @property string $failure_balance_transaction
- * @property string $failure_code
- * @property string $failure_message
+ * @property string|null $description
+ * @property string|null $destination
+ * @property string|null $failure_balance_transaction
+ * @property string|null $failure_code
+ * @property string|null $failure_message
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property string $method
  * @property string $source_type
- * @property string $statement_descriptor
+ * @property string|null $statement_descriptor
  * @property string $status
  * @property string $type
  *

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -8,22 +8,22 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property bool $active
- * @property string $aggregate_usage
- * @property int $amount
- * @property string $amount_decimal
- * @property string $billing_scheme
+ * @property string|null $aggregate_usage
+ * @property int|null $amount
+ * @property string|null $amount_decimal
+ * @property string|null $billing_scheme
  * @property int $created
  * @property string $currency
  * @property string $interval
  * @property int $interval_count
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $nickname
- * @property string $product
- * @property mixed $tiers
- * @property string $tiers_mode
- * @property mixed $transform_usage
- * @property int $trial_period_days
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $nickname
+ * @property string|null $product
+ * @property mixed|null $tiers
+ * @property string|null $tiers_mode
+ * @property mixed|null $transform_usage
+ * @property int|null $trial_period_days
  * @property string $usage_type
  *
  * @package Stripe

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -7,23 +7,23 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property bool $active
- * @property string[] $attributes
- * @property string $caption
+ * @property bool|null $active
+ * @property string[]|null $attributes
+ * @property string|null $caption
  * @property int $created
  * @property string[] $deactivate_on
- * @property string $description
+ * @property string|null $description
  * @property string[] $images
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property mixed $package_dimensions
- * @property bool $shippable
- * @property string $statement_descriptor
+ * @property mixed|null $package_dimensions
+ * @property bool|null $shippable
+ * @property string|null $statement_descriptor
  * @property string $type
- * @property string $unit_label
+ * @property string|null $unit_label
  * @property int $updated
- * @property string $url
+ * @property string|null $url
  *
  * @package Stripe
  */

--- a/lib/Radar/ValueList.php
+++ b/lib/Radar/ValueList.php
@@ -13,7 +13,7 @@ namespace Stripe\Radar;
  * @property string $item_type
  * @property \Stripe\Collection $list_items
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property string $name
  *
  * @package Stripe\Radar

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -7,16 +7,16 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed $active_account
- * @property Collection $cards
+ * @property mixed|null $active_account
+ * @property \Stripe\Collection|null $cards
  * @property int $created
- * @property string $default_card
- * @property string $description
- * @property string $email
+ * @property string|null $default_card
+ * @property string|null $description
+ * @property string|null $email
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property string $migrated_to
- * @property string $name
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $migrated_to
+ * @property string|null $name
  * @property string $rolled_back_from
  * @property string $type
  * @property bool $verified

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -8,19 +8,19 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string $balance_transaction
- * @property string $charge
+ * @property string|null $balance_transaction
+ * @property string|null $charge
  * @property int $created
  * @property string $currency
  * @property string $description
  * @property string $failure_balance_transaction
  * @property string $failure_reason
- * @property StripeObject $metadata
- * @property string $reason
- * @property string $receipt_number
- * @property string $source_transfer_reversal
- * @property string $status
- * @property string $transfer_reversal
+ * @property \Stripe\StripeObject $metadata
+ * @property string|null $reason
+ * @property string|null $receipt_number
+ * @property string|null $source_transfer_reversal
+ * @property string|null $status
+ * @property string|null $transfer_reversal
  *
  * @package Stripe
  */

--- a/lib/Reporting/ReportRun.php
+++ b/lib/Reporting/ReportRun.php
@@ -8,13 +8,13 @@ namespace Stripe\Reporting;
  * @property string $id
  * @property string $object
  * @property int $created
- * @property string $error
+ * @property string|null $error
  * @property bool $livemode
  * @property mixed $parameters
  * @property string $report_type
- * @property mixed $result
+ * @property mixed|null $result
  * @property string $status
- * @property int $succeeded_at
+ * @property int|null $succeeded_at
  *
  * @package Stripe\Reporting
  */

--- a/lib/Reporting/ReportType.php
+++ b/lib/Reporting/ReportType.php
@@ -9,7 +9,7 @@ namespace Stripe\Reporting;
  * @property string $object
  * @property int $data_available_end
  * @property int $data_available_start
- * @property string[] $default_columns
+ * @property string[]|null $default_columns
  * @property string $name
  * @property int $updated
  * @property int $version

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -7,18 +7,18 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $billing_zip
- * @property string $charge
- * @property string $closed_reason
+ * @property string|null $billing_zip
+ * @property string|null $charge
+ * @property string|null $closed_reason
  * @property int $created
- * @property string $ip_address
- * @property mixed $ip_address_location
+ * @property string|null $ip_address
+ * @property mixed|null $ip_address_location
  * @property bool $livemode
  * @property bool $open
  * @property string $opened_reason
  * @property string $payment_intent
  * @property string $reason
- * @property mixed $session
+ * @property mixed|null $session
  *
  * @package Stripe
  */

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -11,11 +11,11 @@ namespace Stripe;
  * @property mixed $attributes
  * @property int $created
  * @property string $currency
- * @property string $image
+ * @property string|null $image
  * @property mixed $inventory
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property mixed $package_dimensions
+ * @property \Stripe\StripeObject $metadata
+ * @property mixed|null $package_dimensions
  * @property int $price
  * @property string $product
  * @property int $updated

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -7,19 +7,19 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $application
- * @property string $cancellation_reason
- * @property string $client_secret
+ * @property string|null $application
+ * @property string|null $cancellation_reason
+ * @property string|null $client_secret
  * @property int $created
- * @property string $customer
- * @property string $description
- * @property mixed $last_setup_error
+ * @property string|null $customer
+ * @property string|null $description
+ * @property mixed|null $last_setup_error
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property mixed $next_action
- * @property string $on_behalf_of
- * @property string $payment_method
- * @property mixed $payment_method_options
+ * @property \Stripe\StripeObject $metadata
+ * @property mixed|null $next_action
+ * @property string|null $on_behalf_of
+ * @property string|null $payment_method
+ * @property mixed|null $payment_method_options
  * @property string[] $payment_method_types
  * @property string $status
  * @property string $usage

--- a/lib/Sigma/ScheduledQueryRun.php
+++ b/lib/Sigma/ScheduledQueryRun.php
@@ -10,7 +10,7 @@ namespace Stripe\Sigma;
  * @property int $created
  * @property int $data_load_time
  * @property mixed $error
- * @property \Stripe\File $file
+ * @property \Stripe\File|null $file
  * @property bool $livemode
  * @property int $result_available_until
  * @property string $sql

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -11,7 +11,7 @@ namespace Stripe;
  * @property mixed $ach_debit
  * @property mixed $acss_debit
  * @property mixed $alipay
- * @property int $amount
+ * @property int|null $amount
  * @property mixed $au_becs_debit
  * @property mixed $bancontact
  * @property mixed $card
@@ -19,7 +19,7 @@ namespace Stripe;
  * @property string $client_secret
  * @property mixed $code_verification
  * @property int $created
- * @property string $currency
+ * @property string|null $currency
  * @property string $customer
  * @property mixed $eps
  * @property string $flow
@@ -27,9 +27,9 @@ namespace Stripe;
  * @property mixed $ideal
  * @property mixed $klarna
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject|null $metadata
  * @property mixed $multibanco
- * @property mixed $owner
+ * @property mixed|null $owner
  * @property mixed $p24
  * @property mixed $receiver
  * @property mixed $redirect
@@ -37,11 +37,11 @@ namespace Stripe;
  * @property mixed $sepa_debit
  * @property mixed $sofort
  * @property mixed $source_order
- * @property string $statement_descriptor
+ * @property string|null $statement_descriptor
  * @property string $status
  * @property mixed $three_d_secure
  * @property string $type
- * @property string $usage
+ * @property string|null $usage
  * @property mixed $wechat
  *
  * @package Stripe

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -7,38 +7,41 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property float $application_fee_percent
+ * @property float|null $application_fee_percent
  * @property int $billing_cycle_anchor
- * @property mixed $billing_thresholds
- * @property int $cancel_at
+ * @property mixed|null $billing_thresholds
+ * @property int|null $cancel_at
  * @property bool $cancel_at_period_end
- * @property int $canceled_at
- * @property string $collection_method
+ * @property int|null $canceled_at
+ * @property string|null $collection_method
  * @property int $created
  * @property int $current_period_end
  * @property int $current_period_start
  * @property string $customer
- * @property int $days_until_due
- * @property string $default_payment_method
- * @property string $default_source
- * @property array $default_tax_rates
- * @property Discount $discount
- * @property int $ended_at
- * @property Collection $items
- * @property string $latest_invoice
+ * @property int|null $days_until_due
+ * @property string|null $default_payment_method
+ * @property string|null $default_source
+ * @property array|null $default_tax_rates
+ * @property \Stripe\Discount|null $discount
+ * @property int|null $ended_at
+ * @property mixed $invoice_customer_balance_settings
+ * @property \Stripe\Collection $items
+ * @property string|null $latest_invoice
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property int $next_pending_invoice_item_invoice
- * @property mixed $pending_invoice_item_interval
- * @property string $pending_setup_intent
- * @property Plan $plan
- * @property int $quantity
- * @property string $schedule
+ * @property \Stripe\StripeObject $metadata
+ * @property int|null $next_pending_invoice_item_invoice
+ * @property mixed|null $pending_invoice_item_interval
+ * @property string|null $pending_setup_intent
+ * @property \Stripe\Plan|null $plan
+ * @property int|null $quantity
+ * @property string|null $schedule
  * @property int $start_date
  * @property string $status
- * @property float $tax_percent
- * @property int $trial_end
- * @property int $trial_start
+ * @property float|null $tax_percent
+ * @property int|null $trial_end
+ * @property int|null $trial_start
+ * @property string $pending_setup_intent
+ * @property \Stripe\SubscriptionSchedule $schedule
  *
  * @package Stripe
  */

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -7,13 +7,13 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed $billing_thresholds
+ * @property mixed|null $billing_thresholds
  * @property int $created
- * @property StripeObject $metadata
- * @property Plan $plan
+ * @property \Stripe\StripeObject $metadata
+ * @property \Stripe\Plan $plan
  * @property int $quantity
  * @property string $subscription
- * @property array $tax_rates
+ * @property array|null $tax_rates
  *
  * @package Stripe
  */

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -7,24 +7,24 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed $billing_thresholds
- * @property int $canceled_at
- * @property string $collection_method
- * @property int $completed_at
+ * @property mixed|null $billing_thresholds
+ * @property int|null $canceled_at
+ * @property string|null $collection_method
+ * @property int|null $completed_at
  * @property int $created
- * @property mixed $current_phase
+ * @property mixed|null $current_phase
  * @property string $customer
- * @property string $default_payment_method
+ * @property string|null $default_payment_method
  * @property string $end_behavior
- * @property mixed $invoice_settings
+ * @property mixed|null $invoice_settings
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject|null $metadata
  * @property mixed $phases
- * @property int $released_at
- * @property string $released_subscription
- * @property mixed $renewal_interval
+ * @property int|null $released_at
+ * @property string|null $released_subscription
+ * @property mixed|null $renewal_interval
  * @property string $status
- * @property string $subscription
+ * @property string|null $subscription
  *
  * @package Stripe
  */

--- a/lib/TaxRate.php
+++ b/lib/TaxRate.php
@@ -9,12 +9,12 @@ namespace Stripe;
  * @property string $object
  * @property bool $active
  * @property int $created
- * @property string $description
+ * @property string|null $description
  * @property string $display_name
  * @property bool $inclusive
- * @property string $jurisdiction
+ * @property string|null $jurisdiction
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property float $percentage
  *
  * @package Stripe

--- a/lib/Terminal/Reader.php
+++ b/lib/Terminal/Reader.php
@@ -7,13 +7,13 @@ namespace Stripe\Terminal;
  *
  * @property string $id
  * @property string $object
- * @property string $device_sw_version
+ * @property string|null $device_sw_version
  * @property string $device_type
- * @property string $ip_address
+ * @property string|null $ip_address
  * @property string $label
- * @property string $location
+ * @property string|null $location
  * @property string $serial_number
- * @property string $status
+ * @property string|null $status
  *
  * @package Stripe\Terminal
  */

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -13,7 +13,7 @@ namespace Stripe;
  * @property int $created
  * @property string $currency
  * @property bool $livemode
- * @property string $redirect_url
+ * @property string|null $redirect_url
  * @property string $status
  *
  * @package Stripe

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -7,9 +7,9 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property BankAccount $bank_account
- * @property Card $card
- * @property string $client_ip
+ * @property \Stripe\BankAccount $bank_account
+ * @property \Stripe\Card $card
+ * @property string|null $client_ip
  * @property int $created
  * @property bool $livemode
  * @property string $type

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -8,19 +8,19 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string $balance_transaction
+ * @property string|null $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string $description
- * @property int $expected_availability_date
- * @property string $failure_code
- * @property string $failure_message
+ * @property string|null $description
+ * @property int|null $expected_availability_date
+ * @property string|null $failure_code
+ * @property string|null $failure_message
  * @property bool $livemode
- * @property StripeObject $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property mixed $source
- * @property string $statement_descriptor
+ * @property string|null $statement_descriptor
  * @property string $status
- * @property string $transfer_group
+ * @property string|null $transfer_group
  *
  * @package Stripe
  */

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -9,19 +9,19 @@ namespace Stripe;
  * @property string $object
  * @property int $amount
  * @property int $amount_reversed
- * @property string $balance_transaction
+ * @property string|null $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string $description
- * @property string $destination
+ * @property string|null $description
+ * @property string|null $destination
  * @property string $destination_payment
  * @property bool $livemode
- * @property StripeObject $metadata
- * @property Collection $reversals
+ * @property \Stripe\StripeObject $metadata
+ * @property \Stripe\Collection $reversals
  * @property bool $reversed
- * @property string $source_transaction
- * @property string $source_type
- * @property string $transfer_group
+ * @property string|null $source_transaction
+ * @property string|null $source_type
+ * @property string|null $transfer_group
  *
  * @package Stripe
  */

--- a/lib/WebhookEndpoint.php
+++ b/lib/WebhookEndpoint.php
@@ -7,8 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string $api_version
- * @property string $application
+ * @property string|null $api_version
+ * @property string|null $application
  * @property int $created
  * @property string[] $enabled_events
  * @property bool $livemode


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

- Mark nullable fields in PHPDoc
- Use fully qualified names everywhere for `\Stripe\Collection`, `\Stripe\StripeObject`, etc.
