### PR TITLE
Use single quotes for OBJECT_NAME constants

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -30,7 +30,7 @@ namespace Stripe;
  */
 class Account extends ApiResource
 {
-    const OBJECT_NAME = "account";
+    const OBJECT_NAME = 'account';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/AccountLink.php
+++ b/lib/AccountLink.php
@@ -14,7 +14,7 @@ namespace Stripe;
  */
 class AccountLink extends ApiResource
 {
-    const OBJECT_NAME = "account_link";
+    const OBJECT_NAME = 'account_link';
 
     use ApiOperations\Create;
 }

--- a/lib/AlipayAccount.php
+++ b/lib/AlipayAccount.php
@@ -12,7 +12,7 @@ namespace Stripe;
  */
 class AlipayAccount extends ApiResource
 {
-    const OBJECT_NAME = "alipay_account";
+    const OBJECT_NAME = 'alipay_account';
 
     use ApiOperations\Delete;
     use ApiOperations\Update;

--- a/lib/ApplePayDomain.php
+++ b/lib/ApplePayDomain.php
@@ -15,7 +15,7 @@ namespace Stripe;
  */
 class ApplePayDomain extends ApiResource
 {
-    const OBJECT_NAME = "apple_pay_domain";
+    const OBJECT_NAME = 'apple_pay_domain';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -24,7 +24,7 @@ namespace Stripe;
  */
 class ApplicationFee extends ApiResource
 {
-    const OBJECT_NAME = "application_fee";
+    const OBJECT_NAME = 'application_fee';
 
     use ApiOperations\All;
     use ApiOperations\NestedResource;

--- a/lib/ApplicationFeeRefund.php
+++ b/lib/ApplicationFeeRefund.php
@@ -18,7 +18,7 @@ namespace Stripe;
  */
 class ApplicationFeeRefund extends ApiResource
 {
-    const OBJECT_NAME = "fee_refund";
+    const OBJECT_NAME = 'fee_refund';
 
     use ApiOperations\Update {
         save as protected _save;

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -15,7 +15,7 @@ namespace Stripe;
  */
 class Balance extends SingletonApiResource
 {
-    const OBJECT_NAME = "balance";
+    const OBJECT_NAME = 'balance';
 
     /**
      * @param array|string|null $opts

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -24,7 +24,7 @@ namespace Stripe;
  */
 class BalanceTransaction extends ApiResource
 {
-    const OBJECT_NAME = "balance_transaction";
+    const OBJECT_NAME = 'balance_transaction';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -25,7 +25,7 @@ namespace Stripe;
  */
 class BankAccount extends ApiResource
 {
-    const OBJECT_NAME = "bank_account";
+    const OBJECT_NAME = 'bank_account';
 
     use ApiOperations\Delete;
     use ApiOperations\Update;

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -35,7 +35,7 @@ namespace Stripe;
  */
 class BitcoinReceiver extends ApiResource
 {
-    const OBJECT_NAME = "bitcoin_receiver";
+    const OBJECT_NAME = 'bitcoin_receiver';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/BitcoinTransaction.php
+++ b/lib/BitcoinTransaction.php
@@ -9,5 +9,5 @@ namespace Stripe;
  */
 class BitcoinTransaction extends ApiResource
 {
-    const OBJECT_NAME = "bitcoin_transaction";
+    const OBJECT_NAME = 'bitcoin_transaction';
 }

--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -17,7 +17,7 @@ namespace Stripe;
  */
 class Capability extends ApiResource
 {
-    const OBJECT_NAME = "capability";
+    const OBJECT_NAME = 'capability';
 
     use ApiOperations\Update;
 

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -38,7 +38,7 @@ namespace Stripe;
  */
 class Card extends ApiResource
 {
-    const OBJECT_NAME = "card";
+    const OBJECT_NAME = 'card';
 
     use ApiOperations\Delete;
     use ApiOperations\Update;

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -54,7 +54,7 @@ namespace Stripe;
  */
 class Charge extends ApiResource
 {
-    const OBJECT_NAME = "charge";
+    const OBJECT_NAME = 'charge';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -25,7 +25,7 @@ namespace Stripe\Checkout;
  */
 class Session extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "checkout.session";
+    const OBJECT_NAME = 'checkout.session';
 
     use \Stripe\ApiOperations\Create;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -14,7 +14,7 @@ namespace Stripe;
  */
 class Collection extends StripeObject implements \IteratorAggregate
 {
-    const OBJECT_NAME = "list";
+    const OBJECT_NAME = 'list';
 
     use ApiOperations\Request;
 

--- a/lib/CountrySpec.php
+++ b/lib/CountrySpec.php
@@ -18,7 +18,7 @@ namespace Stripe;
  */
 class CountrySpec extends ApiResource
 {
-    const OBJECT_NAME = "country_spec";
+    const OBJECT_NAME = 'country_spec';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -25,7 +25,7 @@ namespace Stripe;
  */
 class Coupon extends ApiResource
 {
-    const OBJECT_NAME = "coupon";
+    const OBJECT_NAME = 'coupon';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -28,7 +28,7 @@ namespace Stripe;
  */
 class CreditNote extends ApiResource
 {
-    const OBJECT_NAME = "credit_note";
+    const OBJECT_NAME = 'credit_note';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -33,7 +33,7 @@ namespace Stripe;
  */
 class Customer extends ApiResource
 {
-    const OBJECT_NAME = "customer";
+    const OBJECT_NAME = 'customer';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -23,7 +23,7 @@ namespace Stripe;
  */
 class CustomerBalanceTransaction extends ApiResource
 {
-    const OBJECT_NAME = "customer_balance_transaction";
+    const OBJECT_NAME = 'customer_balance_transaction';
 
     /**
      * Possible string representations of a balance transaction's type.

--- a/lib/Discount.php
+++ b/lib/Discount.php
@@ -16,5 +16,5 @@ namespace Stripe;
  */
 class Discount extends StripeObject
 {
-    const OBJECT_NAME = "discount";
+    const OBJECT_NAME = 'discount';
 }

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -25,7 +25,7 @@ namespace Stripe;
  */
 class Dispute extends ApiResource
 {
-    const OBJECT_NAME = "dispute";
+    const OBJECT_NAME = 'dispute';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -17,7 +17,7 @@ namespace Stripe;
  */
 class EphemeralKey extends ApiResource
 {
-    const OBJECT_NAME = "ephemeral_key";
+    const OBJECT_NAME = 'ephemeral_key';
 
     use ApiOperations\Create {
         create as protected _create;

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -20,7 +20,7 @@ namespace Stripe;
  */
 class Event extends ApiResource
 {
-    const OBJECT_NAME = "event";
+    const OBJECT_NAME = 'event';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/ExchangeRate.php
+++ b/lib/ExchangeRate.php
@@ -13,7 +13,7 @@ namespace Stripe;
  */
 class ExchangeRate extends ApiResource
 {
-    const OBJECT_NAME = "exchange_rate";
+    const OBJECT_NAME = 'exchange_rate';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/File.php
+++ b/lib/File.php
@@ -24,7 +24,7 @@ class File extends ApiResource
     // versions, only `file` is used, but since stripe-php may be used with
     // any API version, we need to support deserializing the older
     // `file_upload` object into the same class.
-    const OBJECT_NAME = "file";
+    const OBJECT_NAME = 'file';
     const OBJECT_NAME_ALT = "file_upload";
 
     use ApiOperations\All;

--- a/lib/FileLink.php
+++ b/lib/FileLink.php
@@ -19,7 +19,7 @@ namespace Stripe;
  */
 class FileLink extends ApiResource
 {
-    const OBJECT_NAME = "file_link";
+    const OBJECT_NAME = 'file_link';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -69,7 +69,7 @@ namespace Stripe;
  */
 class Invoice extends ApiResource
 {
-    const OBJECT_NAME = "invoice";
+    const OBJECT_NAME = 'invoice';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -30,7 +30,7 @@ namespace Stripe;
  */
 class InvoiceItem extends ApiResource
 {
-    const OBJECT_NAME = "invoiceitem";
+    const OBJECT_NAME = 'invoiceitem';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/InvoiceLineItem.php
+++ b/lib/InvoiceLineItem.php
@@ -28,5 +28,5 @@ namespace Stripe;
  */
 class InvoiceLineItem extends ApiResource
 {
-    const OBJECT_NAME = "line_item";
+    const OBJECT_NAME = 'line_item';
 }

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -32,7 +32,7 @@ namespace Stripe\Issuing;
  */
 class Authorization extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.authorization";
+    const OBJECT_NAME = 'issuing.authorization';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/Issuing/Card.php
+++ b/lib/Issuing/Card.php
@@ -29,7 +29,7 @@ namespace Stripe\Issuing;
  */
 class Card extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.card";
+    const OBJECT_NAME = 'issuing.card';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Issuing/CardDetails.php
+++ b/lib/Issuing/CardDetails.php
@@ -17,5 +17,5 @@ namespace Stripe\Issuing;
  */
 class CardDetails extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.card_details";
+    const OBJECT_NAME = 'issuing.card_details';
 }

--- a/lib/Issuing/Cardholder.php
+++ b/lib/Issuing/Cardholder.php
@@ -24,7 +24,7 @@ namespace Stripe\Issuing;
  */
 class Cardholder extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.cardholder";
+    const OBJECT_NAME = 'issuing.cardholder';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Issuing/Dispute.php
+++ b/lib/Issuing/Dispute.php
@@ -21,7 +21,7 @@ namespace Stripe\Issuing;
  */
 class Dispute extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.dispute";
+    const OBJECT_NAME = 'issuing.dispute';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Issuing/Transaction.php
+++ b/lib/Issuing/Transaction.php
@@ -26,7 +26,7 @@ namespace Stripe\Issuing;
  */
 class Transaction extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "issuing.transaction";
+    const OBJECT_NAME = 'issuing.transaction';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/LoginLink.php
+++ b/lib/LoginLink.php
@@ -13,5 +13,5 @@ namespace Stripe;
  */
 class LoginLink extends ApiResource
 {
-    const OBJECT_NAME = "login_link";
+    const OBJECT_NAME = 'login_link';
 }

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -33,7 +33,7 @@ namespace Stripe;
  */
 class Order extends ApiResource
 {
-    const OBJECT_NAME = "order";
+    const OBJECT_NAME = 'order';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/OrderItem.php
+++ b/lib/OrderItem.php
@@ -17,5 +17,5 @@ namespace Stripe;
  */
 class OrderItem extends StripeObject
 {
-    const OBJECT_NAME = "order_item";
+    const OBJECT_NAME = 'order_item';
 }

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -19,7 +19,7 @@ namespace Stripe;
  */
 class OrderReturn extends ApiResource
 {
-    const OBJECT_NAME = "order_return";
+    const OBJECT_NAME = 'order_return';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -46,7 +46,7 @@ namespace Stripe;
  */
 class PaymentIntent extends ApiResource
 {
-    const OBJECT_NAME = "payment_intent";
+    const OBJECT_NAME = 'payment_intent';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/PaymentMethod.php
+++ b/lib/PaymentMethod.php
@@ -22,7 +22,7 @@ namespace Stripe;
  */
 class PaymentMethod extends ApiResource
 {
-    const OBJECT_NAME = "payment_method";
+    const OBJECT_NAME = 'payment_method';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -30,7 +30,7 @@ namespace Stripe;
  */
 class Payout extends ApiResource
 {
-    const OBJECT_NAME = "payout";
+    const OBJECT_NAME = 'payout';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Person.php
+++ b/lib/Person.php
@@ -35,7 +35,7 @@ namespace Stripe;
  */
 class Person extends ApiResource
 {
-    const OBJECT_NAME = "person";
+    const OBJECT_NAME = 'person';
 
     use ApiOperations\Delete;
     use ApiOperations\Update;

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -30,7 +30,7 @@ namespace Stripe;
  */
 class Plan extends ApiResource
 {
-    const OBJECT_NAME = "plan";
+    const OBJECT_NAME = 'plan';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -29,7 +29,7 @@ namespace Stripe;
  */
 class Product extends ApiResource
 {
-    const OBJECT_NAME = "product";
+    const OBJECT_NAME = 'product';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Radar/EarlyFraudWarning.php
+++ b/lib/Radar/EarlyFraudWarning.php
@@ -17,7 +17,7 @@ namespace Stripe\Radar;
  */
 class EarlyFraudWarning extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "radar.early_fraud_warning";
+    const OBJECT_NAME = 'radar.early_fraud_warning';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/Radar/ValueList.php
+++ b/lib/Radar/ValueList.php
@@ -20,7 +20,7 @@ namespace Stripe\Radar;
  */
 class ValueList extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "radar.value_list";
+    const OBJECT_NAME = 'radar.value_list';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Radar/ValueListItem.php
+++ b/lib/Radar/ValueListItem.php
@@ -17,7 +17,7 @@ namespace Stripe\Radar;
  */
 class ValueListItem extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "radar.value_list_item";
+    const OBJECT_NAME = 'radar.value_list_item';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -25,7 +25,7 @@ namespace Stripe;
  */
 class Recipient extends ApiResource
 {
-    const OBJECT_NAME = "recipient";
+    const OBJECT_NAME = 'recipient';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/RecipientTransfer.php
+++ b/lib/RecipientTransfer.php
@@ -34,5 +34,5 @@ namespace Stripe;
  */
 class RecipientTransfer extends ApiResource
 {
-    const OBJECT_NAME = "recipient_transfer";
+    const OBJECT_NAME = 'recipient_transfer';
 }

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -26,7 +26,7 @@ namespace Stripe;
  */
 class Refund extends ApiResource
 {
-    const OBJECT_NAME = "refund";
+    const OBJECT_NAME = 'refund';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Reporting/ReportRun.php
+++ b/lib/Reporting/ReportRun.php
@@ -20,7 +20,7 @@ namespace Stripe\Reporting;
  */
 class ReportRun extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "reporting.report_run";
+    const OBJECT_NAME = 'reporting.report_run';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Reporting/ReportType.php
+++ b/lib/Reporting/ReportType.php
@@ -18,7 +18,7 @@ namespace Stripe\Reporting;
  */
 class ReportType extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "reporting.report_type";
+    const OBJECT_NAME = 'reporting.report_type';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -24,7 +24,7 @@ namespace Stripe;
  */
 class Review extends ApiResource
 {
-    const OBJECT_NAME = "review";
+    const OBJECT_NAME = 'review';
 
     use ApiOperations\All;
     use ApiOperations\Retrieve;

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -24,7 +24,7 @@ namespace Stripe;
  */
 class SKU extends ApiResource
 {
-    const OBJECT_NAME = "sku";
+    const OBJECT_NAME = 'sku';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -28,7 +28,7 @@ namespace Stripe;
  */
 class SetupIntent extends ApiResource
 {
-    const OBJECT_NAME = "setup_intent";
+    const OBJECT_NAME = 'setup_intent';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Sigma/ScheduledQueryRun.php
+++ b/lib/Sigma/ScheduledQueryRun.php
@@ -21,7 +21,7 @@ namespace Stripe\Sigma;
  */
 class ScheduledQueryRun extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "scheduled_query_run";
+    const OBJECT_NAME = 'scheduled_query_run';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -48,7 +48,7 @@ namespace Stripe;
  */
 class Source extends ApiResource
 {
-    const OBJECT_NAME = "source";
+    const OBJECT_NAME = 'source';
 
     use ApiOperations\Create;
     use ApiOperations\Retrieve;

--- a/lib/SourceTransaction.php
+++ b/lib/SourceTransaction.php
@@ -18,5 +18,5 @@ namespace Stripe;
  */
 class SourceTransaction extends ApiResource
 {
-    const OBJECT_NAME = "source_transaction";
+    const OBJECT_NAME = 'source_transaction';
 }

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -47,7 +47,7 @@ namespace Stripe;
  */
 class Subscription extends ApiResource
 {
-    const OBJECT_NAME = "subscription";
+    const OBJECT_NAME = 'subscription';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -19,7 +19,7 @@ namespace Stripe;
  */
 class SubscriptionItem extends ApiResource
 {
-    const OBJECT_NAME = "subscription_item";
+    const OBJECT_NAME = 'subscription_item';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -30,7 +30,7 @@ namespace Stripe;
  */
 class SubscriptionSchedule extends ApiResource
 {
-    const OBJECT_NAME = "subscription_schedule";
+    const OBJECT_NAME = 'subscription_schedule';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -19,7 +19,7 @@ namespace Stripe;
  */
 class TaxId extends ApiResource
 {
-    const OBJECT_NAME = "tax_id";
+    const OBJECT_NAME = 'tax_id';
 
     use ApiOperations\Delete;
 

--- a/lib/TaxRate.php
+++ b/lib/TaxRate.php
@@ -21,7 +21,7 @@ namespace Stripe;
  */
 class TaxRate extends ApiResource
 {
-    const OBJECT_NAME = "tax_rate";
+    const OBJECT_NAME = 'tax_rate';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Terminal/ConnectionToken.php
+++ b/lib/Terminal/ConnectionToken.php
@@ -13,7 +13,7 @@ namespace Stripe\Terminal;
  */
 class ConnectionToken extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "terminal.connection_token";
+    const OBJECT_NAME = 'terminal.connection_token';
 
     use \Stripe\ApiOperations\Create;
 }

--- a/lib/Terminal/Location.php
+++ b/lib/Terminal/Location.php
@@ -14,7 +14,7 @@ namespace Stripe\Terminal;
  */
 class Location extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "terminal.location";
+    const OBJECT_NAME = 'terminal.location';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/Terminal/Reader.php
+++ b/lib/Terminal/Reader.php
@@ -19,7 +19,7 @@ namespace Stripe\Terminal;
  */
 class Reader extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = "terminal.reader";
+    const OBJECT_NAME = 'terminal.reader';
 
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Create;

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -20,7 +20,7 @@ namespace Stripe;
  */
 class ThreeDSecure extends ApiResource
 {
-    const OBJECT_NAME = "three_d_secure";
+    const OBJECT_NAME = 'three_d_secure';
 
     use ApiOperations\Create;
     use ApiOperations\Retrieve;

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -19,7 +19,7 @@ namespace Stripe;
  */
 class Token extends ApiResource
 {
-    const OBJECT_NAME = "token";
+    const OBJECT_NAME = 'token';
 
     use ApiOperations\Create;
     use ApiOperations\Retrieve;

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -26,7 +26,7 @@ namespace Stripe;
  */
 class Topup extends ApiResource
 {
-    const OBJECT_NAME = "topup";
+    const OBJECT_NAME = 'topup';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -27,7 +27,7 @@ namespace Stripe;
  */
 class Transfer extends ApiResource
 {
-    const OBJECT_NAME = "transfer";
+    const OBJECT_NAME = 'transfer';
 
     use ApiOperations\All;
     use ApiOperations\Create;

--- a/lib/TransferReversal.php
+++ b/lib/TransferReversal.php
@@ -20,7 +20,7 @@ namespace Stripe;
  */
 class TransferReversal extends ApiResource
 {
-    const OBJECT_NAME = "transfer_reversal";
+    const OBJECT_NAME = 'transfer_reversal';
 
     use ApiOperations\Update {
         save as protected _save;

--- a/lib/UsageRecord.php
+++ b/lib/UsageRecord.php
@@ -16,5 +16,5 @@ namespace Stripe;
  */
 class UsageRecord extends ApiResource
 {
-    const OBJECT_NAME = "usage_record";
+    const OBJECT_NAME = 'usage_record';
 }

--- a/lib/UsageRecordSummary.php
+++ b/lib/UsageRecordSummary.php
@@ -17,5 +17,5 @@ namespace Stripe;
  */
 class UsageRecordSummary extends ApiResource
 {
-    const OBJECT_NAME = "usage_record_summary";
+    const OBJECT_NAME = 'usage_record_summary';
 }

--- a/lib/WebhookEndpoint.php
+++ b/lib/WebhookEndpoint.php
@@ -20,7 +20,7 @@ namespace Stripe;
  */
 class WebhookEndpoint extends ApiResource
 {
-    const OBJECT_NAME = "webhook_endpoint";
+    const OBJECT_NAME = 'webhook_endpoint';
 
     use ApiOperations\All;
     use ApiOperations\Create;


### PR DESCRIPTION
r? @remi-stripe @brandur-stripe 

Use single quotes for `OBJECT_NAME` constants. This is more consistent with the rest of the code (we use single quotes for most strings that don't need interpolation) and will minimize the codegen diff.