### PR TITLE
Convert `filters` of `Collection` to array

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -45,7 +45,7 @@ class Collection extends StripeObject implements \IteratorAggregate
      */
     public function setFilters($filters)
     {
-        $this->filters = $filters;
+        $this->filters = (array) $filters;
         unset($this->filters['starting_after']);
         unset($this->filters['ending_before']);
     }


### PR DESCRIPTION
The default value of `filters` is `null`, An error is thrown when executing the `array_merge` function.

https://github.com/stripe/stripe-php/blob/e4da443d8f0df7d7a3a07b77edcaa6292d050b4b/lib/Collection.php#L180-L184

