### PR TITLE
Add autoload-dev section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,17 @@
     "friendsofphp/php-cs-fixer": "^2.15"
   },
   "autoload": {
-    "psr-4": { "Stripe\\" : "lib/" }
+    "psr-4": {
+      "Stripe\\": "lib/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Stripe\\": [
+        "tests/",
+        "tests/Stripe/"
+      ]
+    }
   },
   "extra": {
     "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,3 @@ includes:
 
 parameters:
 	level: 1
-	bootstrap: tests/bootstrap.php
-	autoload_directories:
-		- tests

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace Stripe;
+namespace Stripe\HttpClient;
 
-use Stripe\HttpClient\CurlClient;
-
-class CurlClientTest extends TestCase
+class CurlClientTest extends \Stripe\TestCase
 {
     /** @var \ReflectionProperty */
     private $initialNetworkRetryDelayProperty;
@@ -32,9 +30,9 @@ class CurlClientTest extends TestCase
      */
     public function saveOriginalNetworkValues()
     {
-        $this->origMaxNetworkRetries = Stripe::getMaxNetworkRetries();
-        $this->origMaxNetworkRetryDelay = Stripe::getMaxNetworkRetryDelay();
-        $this->origInitialNetworkRetryDelay = Stripe::getInitialNetworkRetryDelay();
+        $this->origMaxNetworkRetries = \Stripe\Stripe::getMaxNetworkRetries();
+        $this->origMaxNetworkRetryDelay = \Stripe\Stripe::getMaxNetworkRetryDelay();
+        $this->origInitialNetworkRetryDelay = \Stripe\Stripe::getInitialNetworkRetryDelay();
     }
 
     /**
@@ -50,7 +48,7 @@ class CurlClientTest extends TestCase
         $this->initialNetworkRetryDelayProperty = $stripeReflector->getProperty('initialNetworkRetryDelay');
         $this->initialNetworkRetryDelayProperty->setAccessible(true);
 
-        $curlClientReflector = new \ReflectionClass('Stripe\HttpClient\CurlClient');
+        $curlClientReflector = new \ReflectionClass('\Stripe\HttpClient\CurlClient');
 
         $this->shouldRetryMethod = $curlClientReflector->getMethod('shouldRetry');
         $this->shouldRetryMethod->setAccessible(true);
@@ -64,7 +62,7 @@ class CurlClientTest extends TestCase
      */
     public function restoreOriginalNetworkValues()
     {
-        Stripe::setMaxNetworkRetries($this->origMaxNetworkRetries);
+        \Stripe\Stripe::setMaxNetworkRetries($this->origMaxNetworkRetries);
         $this->setMaxNetworkRetryDelay($this->origMaxNetworkRetryDelay);
         $this->setInitialNetworkRetryDelay($this->origInitialNetworkRetryDelay);
     }
@@ -81,7 +79,7 @@ class CurlClientTest extends TestCase
 
     private function createFakeRandomGenerator($returnValue = 1.0)
     {
-        $fakeRandomGenerator = $this->createMock('Stripe\Util\RandomGenerator');
+        $fakeRandomGenerator = $this->createMock('\Stripe\Util\RandomGenerator');
         $fakeRandomGenerator->method('randFloat')->willReturn($returnValue);
         return $fakeRandomGenerator;
     }
@@ -147,7 +145,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOnTimeout()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -156,7 +154,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOnConnectionFailure()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -165,7 +163,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOnConflict()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -175,7 +173,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldNotRetryOn429()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -184,7 +182,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOn500()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -193,7 +191,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOn503()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -202,7 +200,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldRetryOnStripeShouldRetryTrue()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -212,7 +210,7 @@ class CurlClientTest extends TestCase
 
     public function testShouldNotRetryOnStripeShouldRetryFalse()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -222,16 +220,16 @@ class CurlClientTest extends TestCase
 
     public function testShouldNotRetryAtMaximumCount()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], Stripe::getMaxNetworkRetries()));
+        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries()));
     }
 
     public function testShouldNotRetryOnCertValidationError()
     {
-        Stripe::setMaxNetworkRetries(2);
+        \Stripe\Stripe::setMaxNetworkRetries(2);
 
         $curlClient = new CurlClient();
 
@@ -245,19 +243,19 @@ class CurlClientTest extends TestCase
         $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
 
         $this->assertEquals(
-            Stripe::getInitialNetworkRetryDelay() * 1,
+            \Stripe\Stripe::getInitialNetworkRetryDelay() * 1,
             $this->sleepTimeMethod->invoke($curlClient, 1, [])
         );
         $this->assertEquals(
-            Stripe::getInitialNetworkRetryDelay() * 2,
+            \Stripe\Stripe::getInitialNetworkRetryDelay() * 2,
             $this->sleepTimeMethod->invoke($curlClient, 2, [])
         );
         $this->assertEquals(
-            Stripe::getInitialNetworkRetryDelay() * 4,
+            \Stripe\Stripe::getInitialNetworkRetryDelay() * 4,
             $this->sleepTimeMethod->invoke($curlClient, 3, [])
         );
         $this->assertEquals(
-            Stripe::getInitialNetworkRetryDelay() * 8,
+            \Stripe\Stripe::getInitialNetworkRetryDelay() * 8,
             $this->sleepTimeMethod->invoke($curlClient, 4, [])
         );
     }
@@ -298,11 +296,11 @@ class CurlClientTest extends TestCase
 
         $curlClient = new CurlClient(null, $this->createFakeRandomGenerator($randomValue));
 
-        $baseValue = Stripe::getInitialNetworkRetryDelay() * (0.5 * (1 + $randomValue));
+        $baseValue = \Stripe\Stripe::getInitialNetworkRetryDelay() * (0.5 * (1 + $randomValue));
 
         // the initial value cannot be smaller than the base,
         // so the randomness is ignored
-        $this->assertEquals(Stripe::getInitialNetworkRetryDelay(), $this->sleepTimeMethod->invoke($curlClient, 1, []));
+        $this->assertEquals(\Stripe\Stripe::getInitialNetworkRetryDelay(), $this->sleepTimeMethod->invoke($curlClient, 1, []));
 
         // after the first one, the randomness is applied
         $this->assertEquals($baseValue * 2, $this->sleepTimeMethod->invoke($curlClient, 2, []));
@@ -312,7 +310,7 @@ class CurlClientTest extends TestCase
 
     public function testResponseHeadersCaseInsensitive()
     {
-        $charge = Charge::all();
+        $charge = \Stripe\Charge::all();
 
         $headers = $charge->getLastResponse()->headers;
         $this->assertNotNull($headers['request-id']);
@@ -339,7 +337,7 @@ class CurlClientTest extends TestCase
 
             \Stripe\ApiRequestor::setHttpClient($curl);
 
-            Charge::all();
+            \Stripe\Charge::all();
 
             $this->assertTrue($called);
         } finally {

--- a/tests/Stripe/Sigma/ScheduledQueryRunTest.php
+++ b/tests/Stripe/Sigma/ScheduledQueryRunTest.php
@@ -2,7 +2,7 @@
 
 namespace Stripe\Sigma;
 
-class AuthorizationTest extends \Stripe\TestCase
+class ScheduledQueryRunTest extends \Stripe\TestCase
 {
     const TEST_RESOURCE_ID = 'sqr_123';
 

--- a/tests/Stripe/Util/DefaultLoggerTest.php
+++ b/tests/Stripe/Util/DefaultLoggerTest.php
@@ -4,7 +4,7 @@
 // `error_log` below.
 namespace Stripe\Util;
 
-class UtilLoggerTest extends \Stripe\TestCase
+class DefaultLoggerTest extends \Stripe\TestCase
 {
     public function testDefaultLogger()
     {

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -1,33 +1,33 @@
 <?php
 
-namespace Stripe;
+namespace Stripe\Util;
 
-class RequestOptionsTest extends TestCase
+class RequestOptionsTest extends \Stripe\TestCase
 {
     public function testStringAPIKey()
     {
-        $opts = Util\RequestOptions::parse("foo");
+        $opts = RequestOptions::parse("foo");
         $this->assertSame("foo", $opts->apiKey);
         $this->assertSame([], $opts->headers);
     }
 
     public function testNull()
     {
-        $opts = Util\RequestOptions::parse(null);
+        $opts = RequestOptions::parse(null);
         $this->assertSame(null, $opts->apiKey);
         $this->assertSame([], $opts->headers);
     }
 
     public function testEmptyArray()
     {
-        $opts = Util\RequestOptions::parse([]);
+        $opts = RequestOptions::parse([]);
         $this->assertSame(null, $opts->apiKey);
         $this->assertSame([], $opts->headers);
     }
 
     public function testAPIKeyArray()
     {
-        $opts = Util\RequestOptions::parse(
+        $opts = RequestOptions::parse(
             [
                 'api_key' => 'foo',
             ]
@@ -38,7 +38,7 @@ class RequestOptionsTest extends TestCase
 
     public function testIdempotentKeyArray()
     {
-        $opts = Util\RequestOptions::parse(
+        $opts = RequestOptions::parse(
             [
                 'idempotency_key' => 'foo',
             ]
@@ -49,7 +49,7 @@ class RequestOptionsTest extends TestCase
 
     public function testKeyArray()
     {
-        $opts = Util\RequestOptions::parse(
+        $opts = RequestOptions::parse(
             [
                 'idempotency_key' => 'foo',
                 'api_key' => 'foo'
@@ -64,12 +64,12 @@ class RequestOptionsTest extends TestCase
      */
     public function testWrongType()
     {
-        $opts = Util\RequestOptions::parse(5);
+        $opts = RequestOptions::parse(5);
     }
 
     public function testDiscardNonPersistentHeaders()
     {
-        $opts = Util\RequestOptions::parse(
+        $opts = RequestOptions::parse(
             [
                 'stripe_account' => 'foo',
                 'idempotency_key' => 'foo',
@@ -81,15 +81,15 @@ class RequestOptionsTest extends TestCase
 
     public function testDebugInfo()
     {
-        $opts = Util\RequestOptions::parse(['api_key' => 'sk_test_1234567890abcdefghijklmn']);
+        $opts = RequestOptions::parse(['api_key' => 'sk_test_1234567890abcdefghijklmn']);
         $debugInfo = print_r($opts, true);
         $this->assertContains("[apiKey] => sk_test_********************klmn", $debugInfo);
 
-        $opts = Util\RequestOptions::parse(['api_key' => 'sk_1234567890abcdefghijklmn']);
+        $opts = RequestOptions::parse(['api_key' => 'sk_1234567890abcdefghijklmn']);
         $debugInfo = print_r($opts, true);
         $this->assertContains("[apiKey] => sk_********************klmn", $debugInfo);
 
-        $opts = Util\RequestOptions::parse(['api_key' => '1234567890abcdefghijklmn']);
+        $opts = RequestOptions::parse(['api_key' => '1234567890abcdefghijklmn']);
         $debugInfo = print_r($opts, true);
         $this->assertContains("[apiKey] => ********************klmn", $debugInfo);
     }

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Stripe;
+namespace Stripe\Util;
 
-class UtilTest extends TestCase
+class UtilTest extends \Stripe\TestCase
 {
     public function testIsList()
     {
         $list = [5, 'nstaoush', []];
-        $this->assertTrue(Util\Util::isList($list));
+        $this->assertTrue(Util::isList($list));
 
         $notlist = [5, 'nstaoush', [], 'bar' => 'baz'];
-        $this->assertFalse(Util\Util::isList($notlist));
+        $this->assertFalse(Util::isList($notlist));
     }
 
     public function testThatPHPHasValueSemanticsForArrays()
@@ -24,7 +24,7 @@ class UtilTest extends TestCase
 
     public function testConvertStripeObjectToArrayIncludesId()
     {
-        $customer = Util\Util::convertToStripeObject(
+        $customer = Util::convertToStripeObject(
             [
                 'id' => 'cus_123',
                 'object' => 'customer',
@@ -38,22 +38,22 @@ class UtilTest extends TestCase
     {
         // UTF-8 string
         $x = "\xc3\xa9";
-        $this->assertSame(Util\Util::utf8($x), $x);
+        $this->assertSame(Util::utf8($x), $x);
 
         // Latin-1 string
         $x = "\xe9";
-        $this->assertSame(Util\Util::utf8($x), "\xc3\xa9");
+        $this->assertSame(Util::utf8($x), "\xc3\xa9");
 
         // Not a string
         $x = true;
-        $this->assertSame(Util\Util::utf8($x), $x);
+        $this->assertSame(Util::utf8($x), $x);
     }
 
     public function testObjectsToIds()
     {
         $params = [
             'foo' => 'bar',
-            'customer' => Util\Util::convertToStripeObject(
+            'customer' => Util::convertToStripeObject(
                 [
                     'id' => 'cus_123',
                     'object' => 'customer',
@@ -68,7 +68,7 @@ class UtilTest extends TestCase
                 'foo' => 'bar',
                 'customer' => 'cus_123',
             ],
-            Util\Util::objectsToIds($params)
+            Util::objectsToIds($params)
         );
     }
 
@@ -88,16 +88,16 @@ class UtilTest extends TestCase
 
         $this->assertSame(
             "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[0]=0&e[1]=1&f=",
-            Util\Util::encodeParameters($params)
+            Util::encodeParameters($params)
         );
     }
 
     public function testUrlEncode()
     {
-        $this->assertSame("foo", Util\Util::urlEncode("foo"));
-        $this->assertSame("foo%2B", Util\Util::urlEncode("foo+"));
-        $this->assertSame("foo%26", Util\Util::urlEncode("foo&"));
-        $this->assertSame("foo[bar]", Util\Util::urlEncode("foo[bar]"));
+        $this->assertSame("foo", Util::urlEncode("foo"));
+        $this->assertSame("foo%2B", Util::urlEncode("foo+"));
+        $this->assertSame("foo%26", Util::urlEncode("foo&"));
+        $this->assertSame("foo[bar]", Util::urlEncode("foo[bar]"));
     }
 
     public function testFlattenParams()
@@ -128,7 +128,7 @@ class UtilTest extends TestCase
                 ['f[1][foo]', '3'],
                 ['f[1][bar]', '4'],
             ],
-            Util\Util::flattenParams($params)
+            Util::flattenParams($params)
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,7 +35,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $this->origAccountId = Stripe::getAccountId();
 
         // Set up host and credentials for stripe-mock
-        Stripe::$apiBase = MOCK_URL;
+        Stripe::$apiBase = defined('MOCK_URL') ? MOCK_URL : 'http://localhost:12111';
         Stripe::setApiKey("sk_test_123");
         Stripe::setClientId("ca_123");
         Stripe::setApiVersion(null);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds an [`autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev) section to `composer.json` to enable autoloading for test classes.

The motivation for this is so that PHPStan no longer needs to load `bootstrap.php`, because that file requires stripe-mock to be running and it makes no sense to require stripe-mock to be running for static analysis.

It also makes the code a bit cleaner by forcing us to fix some class/file names mismatches in tests.
