### PR TITLE
Remove php_codesniffer

### DIFF
--- a/build.php
+++ b/build.php
@@ -9,24 +9,13 @@ if (!$autoload) {
     // Modify composer to not autoload Stripe
     $composer = json_decode(file_get_contents('composer.json'), true);
     unset($composer['autoload']);
-    unset($composer['require-dev']['squizlabs/php_codesniffer']);
+    unset($composer['autoload-dev']);
     file_put_contents('composer.json', json_encode($composer, JSON_PRETTY_PRINT));
 }
 
 passthru('composer update', $returnStatus);
 if ($returnStatus !== 0) {
     exit(1);
-}
-
-if ($autoload) {
-    // Only run CS on 1 of the 2 environments
-    passthru(
-        './vendor/bin/phpcs --standard=PSR2 -n lib tests *.php',
-        $returnStatus
-    );
-    if ($returnStatus !== 0) {
-        exit(1);
-    }
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';


### PR DESCRIPTION
r? @ob-stripe 

Remove the call to `phpcs` in `build.php`, since we now have a separate build step (using `php-cs-fixer`) to check that code is correctly formatted.