### PR TITLE
Add support for listing lines on an Invoice directly

### DIFF
--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -76,6 +76,7 @@ class Invoice extends ApiResource
     use ApiOperations\Delete;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
+    use ApiOperations\NestedResource;
 
     /**
      * Possible string representations of the billing reason.
@@ -113,6 +114,8 @@ class Invoice extends ApiResource
      */
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const BILLING_SEND_INVOICE         = 'send_invoice';
+
+    const PATH_LINES = '/lines';
 
     /**
      * @param array|null $params
@@ -209,5 +212,19 @@ class Invoice extends ApiResource
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
+    }
+
+    /**
+     * @param string $id The ID of the invoice on which to retrieve the lins.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of lines (InvoiceLineItem).
+     */
+    public static function allLines($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_LINES, $params, $opts);
     }
 }

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -5,6 +5,7 @@ namespace Stripe;
 class InvoiceTest extends TestCase
 {
     const TEST_RESOURCE_ID = 'in_123';
+    const TEST_LINE_ID = 'ii_123';
 
     public function testIsListable()
     {
@@ -142,5 +143,15 @@ class InvoiceTest extends TestCase
         $resource = $invoice->voidInvoice();
         $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
         $this->assertSame($resource, $invoice);
+    }
+
+    public function testCanListLines()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/invoices/' . self::TEST_RESOURCE_ID . '/lines'
+        );
+        $resources = Invoice::allLines(self::TEST_RESOURCE_ID);
+        $this->assertTrue(is_array($resources->data));
     }
 }


### PR DESCRIPTION
Today, if you want to list the lines on an Invoice, you have to fetch the Invoice first and then paginate. This adds a static method to list line items through the invoice class.

r? @ob-stripe 
cc @stripe/api-libraries 