### PR TITLE
Diffs from codegen

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -7,8 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $business_profile
- * @property string|null $business_type
+ * @property mixed $business_profile
+ * @property string $business_type
  * @property mixed $capabilities
  * @property bool $charges_enabled
  * @property mixed $company
@@ -16,13 +16,13 @@ namespace Stripe;
  * @property int $created
  * @property string $default_currency
  * @property bool $details_submitted
- * @property string|null $email
- * @property \Stripe\Collection $external_accounts
+ * @property string $email
+ * @property mixed $external_accounts
  * @property mixed $individual
  * @property \Stripe\StripeObject $metadata
  * @property bool $payouts_enabled
  * @property mixed $requirements
- * @property mixed|null $settings
+ * @property mixed $settings
  * @property mixed $tos_acceptance
  * @property string $type
  *
@@ -35,11 +35,11 @@ class Account extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Create;
     use ApiOperations\Delete;
-    use ApiOperations\NestedResource;
+    use ApiOperations\Update;
+
     use ApiOperations\Retrieve {
         retrieve as protected _retrieve;
     }
-    use ApiOperations\Update;
 
     /**
      * Possible string representations of an account's business type.
@@ -85,11 +85,6 @@ class Account extends ApiResource
         return $savedNestedResources;
     }
 
-    const PATH_CAPABILITIES = '/capabilities';
-    const PATH_EXTERNAL_ACCOUNTS = '/external_accounts';
-    const PATH_LOGIN_LINKS = '/login_links';
-    const PATH_PERSONS = '/persons';
-
     public function instanceUrl()
     {
         if ($this['id'] === null) {
@@ -97,285 +92,6 @@ class Account extends ApiResource
         } else {
             return parent::instanceUrl();
         }
-    }
-
-    /**
-     * @param array|string|null $id The ID of the account to retrieve, or an
-     *     options array containing an `id` key.
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Account
-     */
-    public static function retrieve($id = null, $opts = null)
-    {
-        if (!$opts && is_string($id) && substr($id, 0, 3) === 'sk_') {
-            $opts = $id;
-            $id = null;
-        }
-        return self::_retrieve($id, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Account The rejected account.
-     */
-    public function reject($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/reject';
-        list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
-    }
-
-    /**
-     * @param array|null $clientId
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return StripeObject Object containing the response from the API.
-     */
-    public function deauthorize($clientId = null, $opts = null)
-    {
-        $params = [
-            'client_id' => $clientId,
-            'stripe_user_id' => $this->id,
-        ];
-        return OAuth::deauthorize($params, $opts);
-    }
-
-    /*
-     * Capabilities methods
-     * We can not add the capabilities() method today as the Account object already has a
-     * capabilities property which is a hash and not the sub-list of capabilities.
-     */
-
-
-    /**
-     * @param string $id The ID of the account to which the capability belongs.
-     * @param string $capabilityId The ID of the capability to retrieve.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Capability
-     */
-    public static function retrieveCapability($id, $capabilityId, $params = null, $opts = null)
-    {
-        return self::_retrieveNestedResource($id, static::PATH_CAPABILITIES, $capabilityId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the capability belongs.
-     * @param string $capabilityId The ID of the capability to update.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Capability
-     */
-    public static function updateCapability($id, $capabilityId, $params = null, $opts = null)
-    {
-        return self::_updateNestedResource($id, static::PATH_CAPABILITIES, $capabilityId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account on which to retrieve the capabilities.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of capabilities.
-     */
-    public static function allCapabilities($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_CAPABILITIES, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account on which to create the external account.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BankAccount|Card
-     */
-    public static function createExternalAccount($id, $params = null, $opts = null)
-    {
-        return self::_createNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the external account belongs.
-     * @param string $externalAccountId The ID of the external account to retrieve.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BankAccount|Card
-     */
-    public static function retrieveExternalAccount($id, $externalAccountId, $params = null, $opts = null)
-    {
-        return self::_retrieveNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the external account belongs.
-     * @param string $externalAccountId The ID of the external account to update.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BankAccount|Card
-     */
-    public static function updateExternalAccount($id, $externalAccountId, $params = null, $opts = null)
-    {
-        return self::_updateNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the external account belongs.
-     * @param string $externalAccountId The ID of the external account to delete.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BankAccount|Card
-     */
-    public static function deleteExternalAccount($id, $externalAccountId, $params = null, $opts = null)
-    {
-        return self::_deleteNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account on which to retrieve the external accounts.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of external accounts (BankAccount or Card).
-     */
-    public static function allExternalAccounts($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_EXTERNAL_ACCOUNTS, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account on which to create the login link.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return LoginLink
-     */
-    public static function createLoginLink($id, $params = null, $opts = null)
-    {
-        return self::_createNestedResource($id, static::PATH_LOGIN_LINKS, $params, $opts);
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of persons.
-     */
-    public function persons($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/persons';
-        list($response, $opts) = $this->_request('get', $url, $params, $opts);
-        $obj = Util\Util::convertToStripeObject($response, $opts);
-        $obj->setLastResponse($response);
-        return $obj;
-    }
-
-    /**
-     * @param string $id The ID of the account on which to create the person.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Person
-     */
-    public static function createPerson($id, $params = null, $opts = null)
-    {
-        return self::_createNestedResource($id, static::PATH_PERSONS, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the person belongs.
-     * @param string $personId The ID of the person to retrieve.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Person
-     */
-    public static function retrievePerson($id, $personId, $params = null, $opts = null)
-    {
-        return self::_retrieveNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the person belongs.
-     * @param string $personId The ID of the person to update.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Person
-     */
-    public static function updatePerson($id, $personId, $params = null, $opts = null)
-    {
-        return self::_updateNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account to which the person belongs.
-     * @param string $personId The ID of the person to delete.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Person
-     */
-    public static function deletePerson($id, $personId, $params = null, $opts = null)
-    {
-        return self::_deleteNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the account on which to retrieve the persons.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of persons.
-     */
-    public static function allPersons($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_PERSONS, $params, $opts);
     }
 
     public function serializeParameters($force = false)
@@ -425,5 +141,332 @@ class Account extends ApiResource
             }
         }
         return $updateArr;
+    }
+
+    /**
+     * @param array|string|null $id The ID of the account to retrieve, or an
+     *     options array containing an `id` key.
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Account
+     */
+    public static function retrieve($id = null, $opts = null)
+    {
+        if (!$opts && is_string($id) && substr($id, 0, 3) === 'sk_') {
+            $opts = $id;
+            $id = null;
+        }
+        return self::_retrieve($id, $opts);
+    }
+
+    /**
+     * @param array|null $clientId
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return StripeObject Object containing the response from the API.
+     */
+    public function deauthorize($clientId = null, $opts = null)
+    {
+        $params = [
+            'client_id' => $clientId,
+            'stripe_user_id' => $this->id,
+        ];
+        return OAuth::deauthorize($params, $opts);
+    }
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Account The rejected account.
+     */
+    public function reject($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/reject';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+    use ApiOperations\NestedResource;
+    
+    /*
+     * Capabilities methods
+     * We can not add the capabilities() method today as the Account object already has a
+     * capabilities property which is a hash and not the sub-list of capabilities.
+     */
+
+
+    const PATH_CAPABILITIES = '/capabilities';
+
+    /**
+     * @param string $id The ID of the account to which the capability belongs.
+     * @param string $capabilityId The ID of the capability to retrieve.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Capability
+     */
+    public static function retrieveCapability(
+        $id,
+        $capabilityId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_retrieveNestedResource($id, static::PATH_CAPABILITIES, $capabilityId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the capability belongs.
+     * @param string $capabilityId The ID of the capability to update.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Capability
+     */
+    public static function updateCapability(
+        $id,
+        $capabilityId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_updateNestedResource($id, static::PATH_CAPABILITIES, $capabilityId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account on which to retrieve the capabilities.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of capabilities.
+     */
+    public static function allCapabilities($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_CAPABILITIES, $params, $opts);
+    }
+
+    const PATH_EXTERNAL_ACCOUNTS = '/external_accounts';
+
+    /**
+     * @param string $id The ID of the account on which to create the external account.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BankAccount|Card
+     */
+    public static function createExternalAccount(
+        $id,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_createNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the external account belongs.
+     * @param string $externalAccountId The ID of the external account to retrieve.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BankAccount|Card
+     */
+    public static function retrieveExternalAccount(
+        $id,
+        $externalAccountId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_retrieveNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the external account belongs.
+     * @param string $externalAccountId The ID of the external account to update.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BankAccount|Card
+     */
+    public static function updateExternalAccount(
+        $id,
+        $externalAccountId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_updateNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the external account belongs.
+     * @param string $externalAccountId The ID of the external account to delete.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BankAccount|Card
+     */
+    public static function deleteExternalAccount(
+        $id,
+        $externalAccountId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_deleteNestedResource($id, static::PATH_EXTERNAL_ACCOUNTS, $externalAccountId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account on which to retrieve the external accounts.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of external accounts (BankAccount or Card).
+     */
+    public static function allExternalAccounts(
+        $id,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_allNestedResources($id, static::PATH_EXTERNAL_ACCOUNTS, $params, $opts);
+    }
+
+    const PATH_LOGIN_LINKS = '/login_links';
+
+    /**
+     * @param string $id The ID of the account on which to create the login link.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return LoginLink
+     */
+    public static function createLoginLink($id, $params = null, $opts = null)
+    {
+        return self::_createNestedResource($id, static::PATH_LOGIN_LINKS, $params, $opts);
+    }
+
+    const PATH_PERSONS = '/persons';
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of persons.
+     */
+    public function persons($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/persons';
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
+        $obj = Util\Util::convertToStripeObject($response, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+
+    /**
+     * @param string $id The ID of the account on which to create the person.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Person
+     */
+    public static function createPerson($id, $params = null, $opts = null)
+    {
+        return self::_createNestedResource($id, static::PATH_PERSONS, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the person belongs.
+     * @param string $personId The ID of the person to retrieve.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Person
+     */
+    public static function retrievePerson(
+        $id,
+        $personId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_retrieveNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the person belongs.
+     * @param string $personId The ID of the person to update.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Person
+     */
+    public static function updatePerson(
+        $id,
+        $personId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_updateNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account to which the person belongs.
+     * @param string $personId The ID of the person to delete.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Person
+     */
+    public static function deletePerson(
+        $id,
+        $personId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_deleteNestedResource($id, static::PATH_PERSONS, $personId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the account on which to retrieve the persons.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of persons.
+     */
+    public static function allPersons($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_PERSONS, $params, $opts);
     }
 }

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -11,14 +11,14 @@ namespace Stripe;
  * @property int $amount
  * @property int $amount_refunded
  * @property string $application
- * @property string|null $balance_transaction
+ * @property string $balance_transaction
  * @property string $charge
  * @property int $created
  * @property string $currency
  * @property bool $livemode
- * @property string|null $originating_transaction
+ * @property string $originating_transaction
  * @property bool $refunded
- * @property \Stripe\Collection $refunds
+ * @property mixed $refunds
  *
  * @package Stripe
  */
@@ -27,8 +27,9 @@ class ApplicationFee extends ApiResource
     const OBJECT_NAME = 'application_fee';
 
     use ApiOperations\All;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
+
+    use ApiOperations\NestedResource;
 
     const PATH_REFUNDS = '/refunds';
 
@@ -56,8 +57,12 @@ class ApplicationFee extends ApiResource
      *
      * @return ApplicationFeeRefund
      */
-    public static function retrieveRefund($id, $refundId, $params = null, $opts = null)
-    {
+    public static function retrieveRefund(
+        $id,
+        $refundId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_retrieveNestedResource($id, static::PATH_REFUNDS, $refundId, $params, $opts);
     }
 
@@ -71,8 +76,12 @@ class ApplicationFee extends ApiResource
      *
      * @return ApplicationFeeRefund
      */
-    public static function updateRefund($id, $refundId, $params = null, $opts = null)
-    {
+    public static function updateRefund(
+        $id,
+        $refundId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_updateNestedResource($id, static::PATH_REFUNDS, $refundId, $params, $opts);
     }
 

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -6,16 +6,17 @@ namespace Stripe;
  * Class Balance
  *
  * @property string $object
- * @property array $available
- * @property array $connect_reserved
+ * @property mixed $available
+ * @property mixed $connect_reserved
  * @property bool $livemode
- * @property array $pending
+ * @property mixed $pending
  *
  * @package Stripe
  */
 class Balance extends SingletonApiResource
 {
     const OBJECT_NAME = 'balance';
+
 
     /**
      * @param array|string|null $opts

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -11,12 +11,12 @@ namespace Stripe;
  * @property int $available_on
  * @property int $created
  * @property string $currency
- * @property string|null $description
- * @property float|null $exchange_rate
+ * @property string $description
+ * @property float $exchange_rate
  * @property int $fee
  * @property mixed $fee_details
  * @property int $net
- * @property string|null $source
+ * @property string $source
  * @property string $status
  * @property string $type
  *

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -7,18 +7,18 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $account
- * @property string|null $account_holder_name
- * @property string|null $account_holder_type
- * @property string|null $bank_name
+ * @property string $account
+ * @property string $account_holder_name
+ * @property string $account_holder_type
+ * @property string $bank_name
  * @property string $country
- * @property string|null $currency
- * @property string|null $customer
- * @property bool|null $default_for_currency
- * @property string|null $fingerprint
+ * @property string $currency
+ * @property string $customer
+ * @property bool $default_for_currency
+ * @property string $fingerprint
  * @property string $last4
- * @property \Stripe\StripeObject|null $metadata
- * @property string|null $routing_number
+ * @property \Stripe\StripeObject $metadata
+ * @property string $routing_number
  * @property string $status
  *
  * @package Stripe

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -5,9 +5,6 @@ namespace Stripe;
 /**
  * Class BitcoinReceiver
  *
- * @deprecated Bitcoin receivers are deprecated. Please use the sources API instead.
- * @link https://stripe.com/docs/sources/bitcoin
- *
  * @property string $id
  * @property string $object
  * @property bool $active
@@ -18,18 +15,18 @@ namespace Stripe;
  * @property string $bitcoin_uri
  * @property int $created
  * @property string $currency
- * @property string|null $customer
- * @property string|null $description
- * @property string|null $email
+ * @property string $customer
+ * @property string $description
+ * @property string $email
  * @property bool $filled
  * @property string $inbound_address
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $payment
- * @property string|null $refund_address
+ * @property string $payment
+ * @property string $refund_address
  * @property mixed $transactions
  * @property bool $uncaptured_funds
- * @property bool|null $used_for_payment
+ * @property bool $used_for_payment
  *
  * @package Stripe
  */

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -5,6 +5,9 @@ namespace Stripe;
 /**
  * Class BitcoinReceiver
  *
+ * @deprecated Bitcoin receivers are deprecated. Please use the sources API instead.
+ * @link https://stripe.com/docs/sources/bitcoin
+ *
  * @property string $id
  * @property string $object
  * @property bool $active

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -7,32 +7,32 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $account
- * @property string|null $address_city
- * @property string|null $address_country
- * @property string|null $address_line1
- * @property string|null $address_line1_check
- * @property string|null $address_line2
- * @property string|null $address_state
- * @property string|null $address_zip
- * @property string|null $address_zip_check
- * @property string[]|null $available_payout_methods
+ * @property string $account
+ * @property string $address_city
+ * @property string $address_country
+ * @property string $address_line1
+ * @property string $address_line1_check
+ * @property string $address_line2
+ * @property string $address_state
+ * @property string $address_zip
+ * @property string $address_zip_check
+ * @property string[] $available_payout_methods
  * @property string $brand
- * @property string|null $country
- * @property string|null $currency
- * @property string|null $customer
- * @property string|null $cvc_check
- * @property bool|null $default_for_currency
- * @property string|null $dynamic_last4
+ * @property string $country
+ * @property string $currency
+ * @property string $customer
+ * @property string $cvc_check
+ * @property bool $default_for_currency
+ * @property string $dynamic_last4
  * @property int $exp_month
  * @property int $exp_year
- * @property string|null $fingerprint
+ * @property string $fingerprint
  * @property string $funding
  * @property string $last4
  * @property \Stripe\StripeObject $metadata
- * @property string|null $name
- * @property string|null $recipient
- * @property string|null $tokenization_method
+ * @property string $name
+ * @property string $recipient
+ * @property string $tokenization_method
  *
  * @package Stripe
  */

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -9,46 +9,47 @@ namespace Stripe;
  * @property string $object
  * @property int $amount
  * @property int $amount_refunded
- * @property string|null $application
- * @property string|null $application_fee
- * @property int|null $application_fee_amount
- * @property string|null $balance_transaction
+ * @property string $application
+ * @property string $application_fee
+ * @property int $application_fee_amount
+ * @property string $balance_transaction
  * @property mixed $billing_details
  * @property bool $captured
  * @property int $created
  * @property string $currency
- * @property string|null $customer
- * @property string|null $description
- * @property string|null $destination
- * @property string|null $dispute
- * @property string|null $failure_code
- * @property string|null $failure_message
- * @property mixed|null $fraud_details
- * @property string|null $invoice
+ * @property string $customer
+ * @property string $description
+ * @property string $destination
+ * @property string $dispute
+ * @property bool $disputed
+ * @property string $failure_code
+ * @property string $failure_message
+ * @property mixed $fraud_details
+ * @property string $invoice
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $on_behalf_of
- * @property string|null $order
- * @property mixed|null $outcome
+ * @property string $on_behalf_of
+ * @property string $order
+ * @property mixed $outcome
  * @property bool $paid
- * @property string|null $payment_intent
- * @property string|null $payment_method
- * @property mixed|null $payment_method_details
- * @property string|null $receipt_email
- * @property string|null $receipt_number
+ * @property string $payment_intent
+ * @property string $payment_method
+ * @property mixed $payment_method_details
+ * @property string $receipt_email
+ * @property string $receipt_number
  * @property string $receipt_url
  * @property bool $refunded
- * @property \Stripe\Collection $refunds
- * @property string|null $review
- * @property mixed|null $shipping
- * @property mixed|null $source
- * @property string|null $source_transfer
- * @property string|null $statement_descriptor
- * @property string|null $statement_descriptor_suffix
+ * @property mixed $refunds
+ * @property string $review
+ * @property mixed $shipping
+ * @property mixed $source
+ * @property string $source_transfer
+ * @property string $statement_descriptor
+ * @property string $statement_descriptor_suffix
  * @property string $status
  * @property string $transfer
- * @property mixed|null $transfer_data
- * @property string|null $transfer_group
+ * @property mixed $transfer_data
+ * @property string $transfer_group
  *
  * @package Stripe
  */

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -7,18 +7,20 @@ namespace Stripe\Checkout;
  *
  * @property string $id
  * @property string $object
+ * @property string $billing_address_collection
  * @property string $cancel_url
- * @property string|null $client_reference_id
- * @property string|null $customer
- * @property string|null $customer_email
- * @property mixed|null $display_items
+ * @property string $client_reference_id
+ * @property string $customer
+ * @property string $customer_email
+ * @property mixed $display_items
  * @property bool $livemode
- * @property string|null $mode
- * @property string|null $payment_intent
+ * @property string $locale
+ * @property string $mode
+ * @property string $payment_intent
  * @property string[] $payment_method_types
- * @property string|null $setup_intent
- * @property string|null $submit_type
- * @property string|null $subscription
+ * @property string $setup_intent
+ * @property string $submit_type
+ * @property string $subscription
  * @property string $success_url
  *
  * @package Stripe\Checkout

--- a/lib/Coupon.php
+++ b/lib/Coupon.php
@@ -7,17 +7,17 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property int|null $amount_off
+ * @property int $amount_off
  * @property int $created
- * @property string|null $currency
+ * @property string $currency
  * @property string $duration
- * @property int|null $duration_in_months
+ * @property int $duration_in_months
  * @property bool $livemode
- * @property int|null $max_redemptions
+ * @property int $max_redemptions
  * @property \Stripe\StripeObject $metadata
- * @property string|null $name
- * @property float|null $percent_off
- * @property int|null $redeem_by
+ * @property string $name
+ * @property float $percent_off
+ * @property int $redeem_by
  * @property int $times_redeemed
  * @property bool $valid
  *

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -11,18 +11,18 @@ namespace Stripe;
  * @property int $created
  * @property string $currency
  * @property string $customer
- * @property string|null $customer_balance_transaction
+ * @property string $customer_balance_transaction
  * @property string $invoice
  * @property bool $livemode
- * @property string|null $memo
+ * @property string $memo
  * @property \Stripe\StripeObject $metadata
  * @property string $number
  * @property string $pdf
- * @property string|null $reason
- * @property string|null $refund
+ * @property string $reason
+ * @property string $refund
  * @property string $status
  * @property string $type
- * @property int|null $voided_at
+ * @property int $voided_at
  *
  * @package Stripe
  */

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -7,27 +7,29 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $address
+ * @property mixed $address
  * @property int $balance
  * @property int $created
- * @property string|null $currency
- * @property string|null $default_source
- * @property bool|null $delinquent
- * @property string|null $description
- * @property \Stripe\Discount|null $discount
- * @property string|null $email
- * @property string|null $invoice_prefix
+ * @property string $currency
+ * @property string $default_source
+ * @property bool $delinquent
+ * @property string $description
+ * @property mixed $discount
+ * @property string $email
+ * @property string $invoice_prefix
  * @property mixed $invoice_settings
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $name
- * @property string|null $phone
- * @property string[]|null $preferred_locales
- * @property mixed|null $shipping
- * @property \Stripe\Collection $sources
- * @property \Stripe\Collection $subscriptions
- * @property string|null $tax_exempt
- * @property \Stripe\Collection $tax_ids
+ * @property string $name
+ * @property string $phone
+ * @property string[] $preferred_locales
+ * @property mixed $shipping
+ * @property mixed $sources
+ * @property mixed $subscriptions
+ * @property string $tax_exempt
+ * @property mixed $tax_ids
+ * @property mixed $tax_info
+ * @property mixed $tax_info_verification
  *
  * @package Stripe
  */
@@ -38,7 +40,6 @@ class Customer extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Create;
     use ApiOperations\Delete;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
@@ -61,31 +62,105 @@ class Customer extends ApiResource
         return $savedNestedResources;
     }
 
-    const PATH_BALANCE_TRANSACTIONS = '/balance_transactions';
-    const PATH_SOURCES = '/sources';
-    const PATH_TAX_IDS = '/tax_ids';
-
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @return Customer The updated customer.
      */
-    public function deleteDiscount($params = null, $options = null)
+    public function deleteDiscount($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/discount';
-        list($response, $opts) = $this->_request('delete', $url, $params, $options);
+        list($response, $opts) = $this->_request('delete', $url, $params, $opts);
         $this->refreshFrom(['discount' => null], $opts, true);
     }
 
+    use ApiOperations\NestedResource;
+
+    const PATH_BALANCE_TRANSACTIONS = '/balance_transactions';
+
     /**
-     * @param string $id The ID of the customer on which to create the source.
+     * @param string $id The ID of the customer on which to create the customer balance transaction.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return BalanceTransaction
+     */
+    public static function createBalanceTransaction(
+        $id,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_createNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the customer to which the customer balance transaction belongs.
+     * @param string $balanceTransactionId The ID of the customer balance transaction to retrieve.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BalanceTransaction
+     */
+    public static function retrieveBalanceTransaction(
+        $id,
+        $balanceTransactionId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_retrieveNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $balanceTransactionId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the customer to which the customer balance transaction belongs.
+     * @param string $balanceTransactionId The ID of the customer balance transaction to update.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return BalanceTransaction
+     */
+    public static function updateBalanceTransaction(
+        $id,
+        $balanceTransactionId,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_updateNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $balanceTransactionId, $params, $opts);
+    }
+
+    /**
+     * @param string $id The ID of the customer on which to retrieve the customer balance transactions.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Collection The list of customer balance transactions.
+     */
+    public static function allBalanceTransactions(
+        $id,
+        $params = null,
+        $opts = null
+    ) {
+        return self::_allNestedResources($id, static::PATH_BALANCE_TRANSACTIONS, $params, $opts);
+    }
+
+    const PATH_SOURCES = '/sources';
+
+    /**
+     * @param string $id The ID of the customer on which to create the payment source.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return AlipayAccount|BankAccount|BitcoinReceiver|Card|Source
      */
     public static function createSource($id, $params = null, $opts = null)
     {
@@ -93,63 +168,77 @@ class Customer extends ApiResource
     }
 
     /**
-     * @param string $id The ID of the customer to which the source belongs.
-     * @param string $sourceId The ID of the source to retrieve.
+     * @param string $id The ID of the customer to which the payment source belongs.
+     * @param string $sourceId The ID of the payment source to retrieve.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return AlipayAccount|BankAccount|BitcoinReceiver|Card|Source
      */
-    public static function retrieveSource($id, $sourceId, $params = null, $opts = null)
-    {
+    public static function retrieveSource(
+        $id,
+        $sourceId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_retrieveNestedResource($id, static::PATH_SOURCES, $sourceId, $params, $opts);
     }
 
     /**
-     * @param string $id The ID of the customer to which the source belongs.
-     * @param string $sourceId The ID of the source to update.
+     * @param string $id The ID of the customer to which the payment source belongs.
+     * @param string $sourceId The ID of the payment source to update.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return AlipayAccount|BankAccount|BitcoinReceiver|Card|Source
      */
-    public static function updateSource($id, $sourceId, $params = null, $opts = null)
-    {
+    public static function updateSource(
+        $id,
+        $sourceId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_updateNestedResource($id, static::PATH_SOURCES, $sourceId, $params, $opts);
     }
 
     /**
-     * @param string $id The ID of the customer to which the source belongs.
-     * @param string $sourceId The ID of the source to delete.
+     * @param string $id The ID of the customer to which the payment source belongs.
+     * @param string $sourceId The ID of the payment source to delete.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return ApiResource
+     * @return AlipayAccount|BankAccount|BitcoinReceiver|Card|Source
      */
-    public static function deleteSource($id, $sourceId, $params = null, $opts = null)
-    {
+    public static function deleteSource(
+        $id,
+        $sourceId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_deleteNestedResource($id, static::PATH_SOURCES, $sourceId, $params, $opts);
     }
 
     /**
-     * @param string $id The ID of the customer on which to retrieve the sources.
+     * @param string $id The ID of the customer on which to retrieve the payment sources.
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Collection The list of sources.
+     * @return Collection The list of payment sources (AlipayAccount, BankAccount, BitcoinReceiver, Card or Source).
      */
     public static function allSources($id, $params = null, $opts = null)
     {
         return self::_allNestedResources($id, static::PATH_SOURCES, $params, $opts);
     }
+
+    const PATH_TAX_IDS = '/tax_ids';
 
     /**
      * @param string $id The ID of the customer on which to create the tax id.
@@ -175,8 +264,12 @@ class Customer extends ApiResource
      *
      * @return TaxId
      */
-    public static function retrieveTaxId($id, $taxIdId, $params = null, $opts = null)
-    {
+    public static function retrieveTaxId(
+        $id,
+        $taxIdId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_retrieveNestedResource($id, static::PATH_TAX_IDS, $taxIdId, $params, $opts);
     }
 
@@ -190,8 +283,12 @@ class Customer extends ApiResource
      *
      * @return TaxId
      */
-    public static function deleteTaxId($id, $taxIdId, $params = null, $opts = null)
-    {
+    public static function deleteTaxId(
+        $id,
+        $taxIdId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_deleteNestedResource($id, static::PATH_TAX_IDS, $taxIdId, $params, $opts);
     }
 
@@ -207,63 +304,5 @@ class Customer extends ApiResource
     public static function allTaxIds($id, $params = null, $opts = null)
     {
         return self::_allNestedResources($id, static::PATH_TAX_IDS, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the customer on which to create the balance transaction.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BalanceTransaction
-     */
-    public static function createBalanceTransaction($id, $params = null, $opts = null)
-    {
-        return self::_createNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the customer to which the balance transaction belongs.
-     * @param string $balanceTransactionId The ID of the balance transaction to retrieve.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BalanceTransaction
-     */
-    public static function retrieveBalanceTransaction($id, $balanceTransactionId, $params = null, $opts = null)
-    {
-        return self::_retrieveNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $balanceTransactionId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the customer to which the balance transaction belongs.
-     * @param string $balanceTransactionId The ID of the balance transaction to update.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return BalanceTransaction
-     */
-    public static function updateBalanceTransaction($id, $balanceTransactionId, $params = null, $opts = null)
-    {
-        return self::_updateNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $balanceTransactionId, $params, $opts);
-    }
-
-    /**
-     * @param string $id The ID of the customer on which to retrieve the balance transactions.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of balance transactions.
-     */
-    public static function allBalanceTransactions($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_BALANCE_TRANSACTIONS, $params, $opts);
     }
 }

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -8,7 +8,7 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property BalanceTransaction[] $balance_transactions
+ * @property mixed $balance_transactions
  * @property string $charge
  * @property int $created
  * @property string $currency
@@ -17,7 +17,8 @@ namespace Stripe;
  * @property bool $is_charge_refundable
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $network_reason_code
+ * @property string $network_reason_code
+ * @property string $payment_intent
  * @property string $reason
  * @property string $status
  *
@@ -64,17 +65,17 @@ class Dispute extends ApiResource
     const STATUS_WON                    = 'won';
 
     /**
+     * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Dispute The closed dispute.
      */
-    // TODO: add $params to standardize signature
-    public function close($opts = null)
+    public function close($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/close';
-        list($response, $opts) = $this->_request('post', $url, null, $opts);
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
     }

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -11,7 +11,6 @@ namespace Stripe;
  * @property int $expires
  * @property bool $livemode
  * @property string $secret
- * @property array $associated_objects
  *
  * @package Stripe
  */
@@ -19,10 +18,11 @@ class EphemeralKey extends ApiResource
 {
     const OBJECT_NAME = 'ephemeral_key';
 
+    use ApiOperations\Delete;
+
     use ApiOperations\Create {
         create as protected _create;
     }
-    use ApiOperations\Delete;
 
     /**
      * @param array|null $params

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -8,12 +8,12 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property string $account
- * @property string|null $api_version
+ * @property string $api_version
  * @property int $created
  * @property mixed $data
  * @property bool $livemode
  * @property int $pending_webhooks
- * @property mixed|null $request
+ * @property mixed $request
  * @property string $type
  *
  * @package Stripe

--- a/lib/File.php
+++ b/lib/File.php
@@ -8,30 +8,32 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $created
- * @property string|null $filename
- * @property \Stripe\Collection|null $links
+ * @property string $filename
+ * @property mixed $links
  * @property string $purpose
  * @property int $size
- * @property string|null $title
- * @property string|null $type
- * @property string|null $url
+ * @property string $title
+ * @property string $type
+ * @property string $url
  *
  * @package Stripe
  */
 class File extends ApiResource
 {
+    const OBJECT_NAME = 'file';
+
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     // This resource can have two different object names. In latter API
     // versions, only `file` is used, but since stripe-php may be used with
     // any API version, we need to support deserializing the older
     // `file_upload` object into the same class.
-    const OBJECT_NAME = 'file';
-    const OBJECT_NAME_ALT = "file_upload";
+    const OBJECT_NAME_ALT = 'file_upload';
 
-    use ApiOperations\All;
     use ApiOperations\Create {
         create as protected _create;
     }
-    use ApiOperations\Retrieve;
 
     public static function classUrl()
     {
@@ -40,15 +42,15 @@ class File extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\File The created resource.
      */
-    public static function create($params = null, $options = null)
+    public static function create($params = null, $opts = null)
     {
-        $opts = \Stripe\Util\RequestOptions::parse($options);
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
         if (is_null($opts->apiBase)) {
             $opts->apiBase = Stripe::$apiUploadBase;
         }

--- a/lib/FileLink.php
+++ b/lib/FileLink.php
@@ -9,11 +9,11 @@ namespace Stripe;
  * @property string $object
  * @property int $created
  * @property bool $expired
- * @property int|null $expires_at
+ * @property int $expires_at
  * @property string $file
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $url
+ * @property string $url
  *
  * @package Stripe
  */

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -115,6 +115,8 @@ class Invoice extends ApiResource
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const BILLING_SEND_INVOICE         = 'send_invoice';
 
+    const PATH_LINES = '/lines';
+
     /**
      * @param array|null $params
      * @param array|string|null $opts
@@ -130,6 +132,20 @@ class Invoice extends ApiResource
         $obj = Util\Util::convertToStripeObject($response->json, $opts);
         $obj->setLastResponse($response);
         return $obj;
+    }
+
+    /**
+     * @param string $id The ID of the invoice on which to retrieve the lins.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws StripeExceptionApiErrorException if the request fails
+     *
+     * @return Collection The list of lines (InvoiceLineItem).
+     */
+    public static function allLines($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_LINES, $params, $opts);
     }
 
     /**

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -7,63 +7,64 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $account_country
- * @property string|null $account_name
+ * @property string $account_country
+ * @property string $account_name
  * @property int $amount_due
  * @property int $amount_paid
  * @property int $amount_remaining
- * @property int|null $application_fee_amount
+ * @property int $application_fee_amount
  * @property int $attempt_count
  * @property bool $attempted
  * @property bool $auto_advance
- * @property string|null $billing_reason
- * @property string|null $charge
- * @property string|null $collection_method
+ * @property string $billing_reason
+ * @property string $charge
+ * @property string $collection_method
  * @property int $created
  * @property string $currency
- * @property array|null $custom_fields
+ * @property mixed $custom_fields
  * @property string $customer
- * @property mixed|null $customer_address
- * @property string|null $customer_email
- * @property string|null $customer_name
- * @property string|null $customer_phone
- * @property mixed|null $customer_shipping
- * @property string|null $customer_tax_exempt
- * @property array|null $customer_tax_ids
- * @property string|null $default_payment_method
- * @property string|null $default_source
- * @property array|null $default_tax_rates
- * @property string|null $description
- * @property \Stripe\Discount|null $discount
- * @property int|null $due_date
- * @property int|null $ending_balance
- * @property string|null $footer
- * @property string|null $hosted_invoice_url
- * @property string|null $invoice_pdf
- * @property \Stripe\Collection $lines
+ * @property mixed $customer_address
+ * @property string $customer_email
+ * @property string $customer_name
+ * @property string $customer_phone
+ * @property mixed $customer_shipping
+ * @property string $customer_tax_exempt
+ * @property mixed $customer_tax_ids
+ * @property string $default_payment_method
+ * @property string $default_source
+ * @property mixed $default_tax_rates
+ * @property string $description
+ * @property mixed $discount
+ * @property int $due_date
+ * @property int $ending_balance
+ * @property string $footer
+ * @property string $hosted_invoice_url
+ * @property string $invoice_pdf
+ * @property mixed $lines
  * @property bool $livemode
- * @property \Stripe\StripeObject|null $metadata
- * @property int|null $next_payment_attempt
- * @property string|null $number
+ * @property \Stripe\StripeObject $metadata
+ * @property int $next_payment_attempt
+ * @property string $number
  * @property bool $paid
- * @property string|null $payment_intent
+ * @property string $payment_intent
  * @property int $period_end
  * @property int $period_start
  * @property int $post_payment_credit_notes_amount
  * @property int $pre_payment_credit_notes_amount
- * @property string|null $receipt_number
+ * @property string $receipt_number
  * @property int $starting_balance
- * @property string|null $statement_descriptor
- * @property string|null $status
+ * @property string $statement_descriptor
+ * @property string $status
  * @property mixed $status_transitions
- * @property string|null $subscription
+ * @property string $subscription
  * @property int $subscription_proration_date
  * @property int $subtotal
- * @property int|null $tax
+ * @property int $tax
+ * @property float $tax_percent
  * @property mixed $threshold_reason
  * @property int $total
- * @property array|null $total_tax_amounts
- * @property int|null $webhooks_delivered_at
+ * @property mixed $total_tax_amounts
+ * @property int $webhooks_delivered_at
  *
  * @package Stripe
  */
@@ -76,7 +77,6 @@ class Invoice extends ApiResource
     use ApiOperations\Delete;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
-    use ApiOperations\NestedResource;
 
     /**
      * Possible string representations of the billing reason.
@@ -115,72 +115,6 @@ class Invoice extends ApiResource
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const BILLING_SEND_INVOICE         = 'send_invoice';
 
-    const PATH_LINES = '/lines';
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Invoice The finalized invoice.
-     */
-    public function finalizeInvoice($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/finalize';
-        list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Invoice The uncollectible invoice.
-     */
-    public function markUncollectible($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/mark_uncollectible';
-        list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Invoice The paid invoice.
-     */
-    public function pay($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/pay';
-        list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Invoice The sent invoice.
-     */
-    public function sendInvoice($params = null, $opts = null)
-    {
-        $url = $this->instanceUrl() . '/send';
-        list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
-    }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts
@@ -204,6 +138,66 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
+     * @return Invoice The finalized invoice.
+     */
+    public function finalizeInvoice($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/finalize';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Invoice The uncollectible invoice.
+     */
+    public function markUncollectible($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/mark_uncollectible';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Invoice The paid invoice.
+     */
+    public function pay($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/pay';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return Invoice The sent invoice.
+     */
+    public function sendInvoice($params = null, $opts = null)
+    {
+        $url = $this->instanceUrl() . '/send';
+        list($response, $opts) = $this->_request('post', $url, $params, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
+    }
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
      * @return Invoice The voided invoice.
      */
     public function voidInvoice($params = null, $opts = null)
@@ -212,19 +206,5 @@ class Invoice extends ApiResource
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
-    }
-
-    /**
-     * @param string $id The ID of the invoice on which to retrieve the lins.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of lines (InvoiceLineItem).
-     */
-    public static function allLines($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_LINES, $params, $opts);
     }
 }

--- a/lib/InvoiceItem.php
+++ b/lib/InvoiceItem.php
@@ -11,20 +11,21 @@ namespace Stripe;
  * @property string $currency
  * @property string $customer
  * @property int $date
- * @property string|null $description
+ * @property string $description
  * @property bool $discountable
- * @property string|null $invoice
+ * @property string $invoice
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property mixed $period
- * @property \Stripe\Plan|null $plan
+ * @property mixed $plan
  * @property bool $proration
  * @property int $quantity
- * @property string|null $subscription
+ * @property string $subscription
  * @property string $subscription_item
- * @property array|null $tax_rates
- * @property int|null $unit_amount
- * @property string|null $unit_amount_decimal
+ * @property mixed $tax_rates
+ * @property bool $unified_proration
+ * @property int $unit_amount
+ * @property string $unit_amount_decimal
  *
  * @package Stripe
  */

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -11,9 +11,9 @@ namespace Stripe\Issuing;
  * @property string $authorization_method
  * @property int $authorized_amount
  * @property string $authorized_currency
- * @property \Stripe\Collection $balance_transactions
- * @property Card $card
- * @property string|null $cardholder
+ * @property mixed $balance_transactions
+ * @property mixed $card
+ * @property string $cardholder
  * @property int $created
  * @property int $held_amount
  * @property string $held_currency
@@ -25,8 +25,9 @@ namespace Stripe\Issuing;
  * @property int $pending_held_amount
  * @property mixed $request_history
  * @property string $status
- * @property array $transactions
+ * @property mixed $transactions
  * @property mixed $verification_data
+ * @property string $wallet_provider
  *
  * @package Stripe\Issuing
  */
@@ -53,7 +54,6 @@ class Authorization extends \Stripe\ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/Issuing/Card.php
+++ b/lib/Issuing/Card.php
@@ -9,7 +9,7 @@ namespace Stripe\Issuing;
  * @property string $object
  * @property mixed $authorization_controls
  * @property string $brand
- * @property \Stripe\Issuing\Cardholder|null $cardholder
+ * @property mixed $cardholder
  * @property int $created
  * @property string $currency
  * @property int $exp_month
@@ -18,10 +18,10 @@ namespace Stripe\Issuing;
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property mixed|null $pin
- * @property string|null $replacement_for
- * @property string|null $replacement_reason
- * @property mixed|null $shipping
+ * @property mixed $pin
+ * @property string $replacement_for
+ * @property string $replacement_reason
+ * @property mixed $shipping
  * @property string $status
  * @property string $type
  *

--- a/lib/Issuing/Cardholder.php
+++ b/lib/Issuing/Cardholder.php
@@ -7,15 +7,17 @@ namespace Stripe\Issuing;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $authorization_controls
+ * @property mixed $authorization_controls
  * @property mixed $billing
+ * @property mixed $company
  * @property int $created
- * @property string|null $email
+ * @property string $email
+ * @property mixed $individual
  * @property bool $is_default
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property string|null $phone_number
+ * @property string $phone_number
  * @property mixed $requirements
  * @property string $status
  * @property string $type

--- a/lib/Issuing/Transaction.php
+++ b/lib/Issuing/Transaction.php
@@ -8,13 +8,13 @@ namespace Stripe\Issuing;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string|null $authorization
- * @property string|null $balance_transaction
+ * @property string $authorization
+ * @property string $balance_transaction
  * @property string $card
- * @property string|null $cardholder
+ * @property string $cardholder
  * @property int $created
  * @property string $currency
- * @property string|null $dispute
+ * @property string $dispute
  * @property bool $livemode
  * @property int $merchant_amount
  * @property string $merchant_currency

--- a/lib/Mandate.php
+++ b/lib/Mandate.php
@@ -9,10 +9,10 @@ namespace Stripe;
  * @property string $object
  * @property mixed $customer_acceptance
  * @property bool $livemode
- * @property mixed|null $multi_use
+ * @property mixed $multi_use
  * @property string $payment_method
  * @property mixed $payment_method_details
- * @property mixed|null $single_use
+ * @property mixed $single_use
  * @property string $status
  * @property string $type
  *

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -8,25 +8,25 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property int|null $amount_returned
- * @property string|null $application
- * @property int|null $application_fee
- * @property string|null $charge
+ * @property int $amount_returned
+ * @property string $application
+ * @property int $application_fee
+ * @property string $charge
  * @property int $created
  * @property string $currency
- * @property string|null $customer
- * @property string|null $email
+ * @property string $customer
+ * @property string $email
  * @property string $external_coupon_code
- * @property OrderItem[] $items
+ * @property mixed $items
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property \Stripe\Collection|null $returns
- * @property string|null $selected_shipping_method
- * @property mixed|null $shipping
- * @property array|null $shipping_methods
+ * @property mixed $returns
+ * @property string $selected_shipping_method
+ * @property mixed $shipping
+ * @property mixed $shipping_methods
  * @property string $status
- * @property mixed|null $status_transitions
- * @property int|null $updated
+ * @property mixed $status_transitions
+ * @property int $updated
  * @property string $upstream_id
  *
  * @package Stripe
@@ -46,14 +46,13 @@ class Order extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Order The paid order.
+     * @return OrderReturn The newly created return.
      */
-    public function pay($params = null, $opts = null)
+    public function returnOrder($params = null, $opts = null)
     {
-        $url = $this->instanceUrl() . '/pay';
+        $url = $this->instanceUrl() . '/returns';
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
+        return Util\Util::convertToStripeObject($response, $opts);
     }
 
     /**
@@ -62,12 +61,13 @@ class Order extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return OrderReturn The newly created return.
+     * @return Order The paid order.
      */
-    public function returnOrder($params = null, $opts = null)
+    public function pay($params = null, $opts = null)
     {
-        $url = $this->instanceUrl() . '/returns';
+        $url = $this->instanceUrl() . '/pay';
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        return Util\Util::convertToStripeObject($response, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
     }
 }

--- a/lib/OrderReturn.php
+++ b/lib/OrderReturn.php
@@ -10,10 +10,10 @@ namespace Stripe;
  * @property int $amount
  * @property int $created
  * @property string $currency
- * @property OrderItem[] $items
+ * @property mixed $items
  * @property bool $livemode
- * @property string|null $order
- * @property string|null $refund
+ * @property string $order
+ * @property string $refund
  *
  * @package Stripe
  */

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -10,37 +10,37 @@ namespace Stripe;
  * @property int $amount
  * @property int $amount_capturable
  * @property int $amount_received
- * @property string|null $application
- * @property int|null $application_fee_amount
- * @property int|null $canceled_at
- * @property string|null $cancellation_reason
+ * @property string $application
+ * @property int $application_fee_amount
+ * @property int $canceled_at
+ * @property string $cancellation_reason
  * @property string $capture_method
- * @property \Stripe\Collection $charges
- * @property string|null $client_secret
+ * @property mixed $charges
+ * @property string $client_secret
  * @property string $confirmation_method
  * @property int $created
  * @property string $currency
- * @property string|null $customer
- * @property string|null $description
- * @property string|null $invoice
- * @property mixed|null $last_payment_error
+ * @property string $customer
+ * @property string $description
+ * @property string $invoice
+ * @property mixed $last_payment_error
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property mixed|null $next_action
- * @property string|null $on_behalf_of
- * @property string|null $payment_method
- * @property mixed|null $payment_method_options
+ * @property mixed $next_action
+ * @property string $on_behalf_of
+ * @property string $payment_method
+ * @property mixed $payment_method_options
  * @property string[] $payment_method_types
- * @property string|null $receipt_email
- * @property string|null $review
- * @property string|null $setup_future_usage
- * @property mixed|null $shipping
- * @property string|null $source
- * @property string|null $statement_descriptor
- * @property string|null $statement_descriptor_suffix
+ * @property string $receipt_email
+ * @property string $review
+ * @property string $setup_future_usage
+ * @property mixed $shipping
+ * @property string $source
+ * @property string $statement_descriptor
+ * @property string $statement_descriptor_suffix
  * @property string $status
- * @property mixed|null $transfer_data
- * @property string|null $transfer_group
+ * @property mixed $transfer_data
+ * @property string $transfer_group
  *
  * @package Stripe
  */
@@ -81,7 +81,6 @@ class PaymentIntent extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts
@@ -97,7 +96,6 @@ class PaymentIntent extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/PaymentMethod.php
+++ b/lib/PaymentMethod.php
@@ -11,11 +11,11 @@ namespace Stripe;
  * @property mixed $card
  * @property mixed $card_present
  * @property int $created
- * @property string|null $customer
- * @property mixed|null $ideal
+ * @property string $customer
+ * @property mixed $ideal
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property mixed|null $sepa_debit
+ * @property mixed $sepa_debit
  * @property string $type
  *
  * @package Stripe
@@ -44,7 +44,6 @@ class PaymentMethod extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -10,19 +10,19 @@ namespace Stripe;
  * @property int $amount
  * @property int $arrival_date
  * @property bool $automatic
- * @property string|null $balance_transaction
+ * @property string $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string|null $description
- * @property string|null $destination
- * @property string|null $failure_balance_transaction
- * @property string|null $failure_code
- * @property string|null $failure_message
+ * @property string $description
+ * @property string $destination
+ * @property string $failure_balance_transaction
+ * @property string $failure_code
+ * @property string $failure_message
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $method
  * @property string $source_type
- * @property string|null $statement_descriptor
+ * @property string $statement_descriptor
  * @property string $status
  * @property string $type
  *

--- a/lib/Plan.php
+++ b/lib/Plan.php
@@ -8,22 +8,22 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property bool $active
- * @property string|null $aggregate_usage
- * @property int|null $amount
- * @property string|null $amount_decimal
- * @property string|null $billing_scheme
+ * @property string $aggregate_usage
+ * @property int $amount
+ * @property string $amount_decimal
+ * @property string $billing_scheme
  * @property int $created
  * @property string $currency
  * @property string $interval
  * @property int $interval_count
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $nickname
- * @property string|null $product
- * @property mixed|null $tiers
- * @property string|null $tiers_mode
- * @property mixed|null $transform_usage
- * @property int|null $trial_period_days
+ * @property string $nickname
+ * @property string $product
+ * @property mixed $tiers
+ * @property string $tiers_mode
+ * @property mixed $transform_usage
+ * @property int $trial_period_days
  * @property string $usage_type
  *
  * @package Stripe

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -7,23 +7,23 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property bool|null $active
- * @property string[]|null $attributes
- * @property string|null $caption
+ * @property bool $active
+ * @property string[] $attributes
+ * @property string $caption
  * @property int $created
  * @property string[] $deactivate_on
- * @property string|null $description
+ * @property string $description
  * @property string[] $images
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name
- * @property mixed|null $package_dimensions
- * @property bool|null $shippable
- * @property string|null $statement_descriptor
+ * @property mixed $package_dimensions
+ * @property bool $shippable
+ * @property string $statement_descriptor
  * @property string $type
- * @property string|null $unit_label
+ * @property string $unit_label
  * @property int $updated
- * @property string|null $url
+ * @property string $url
  *
  * @package Stripe
  */

--- a/lib/Radar/ValueList.php
+++ b/lib/Radar/ValueList.php
@@ -11,7 +11,7 @@ namespace Stripe\Radar;
  * @property int $created
  * @property string $created_by
  * @property string $item_type
- * @property \Stripe\Collection $list_items
+ * @property mixed $list_items
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property string $name

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -7,16 +7,16 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $active_account
- * @property \Stripe\Collection|null $cards
+ * @property mixed $active_account
+ * @property mixed $cards
  * @property int $created
- * @property string|null $default_card
- * @property string|null $description
- * @property string|null $email
+ * @property string $default_card
+ * @property string $description
+ * @property string $email
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property string|null $migrated_to
- * @property string|null $name
+ * @property string $migrated_to
+ * @property string $name
  * @property string $rolled_back_from
  * @property string $type
  * @property bool $verified

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -8,19 +8,20 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string|null $balance_transaction
- * @property string|null $charge
+ * @property string $balance_transaction
+ * @property string $charge
  * @property int $created
  * @property string $currency
  * @property string $description
  * @property string $failure_balance_transaction
  * @property string $failure_reason
  * @property \Stripe\StripeObject $metadata
- * @property string|null $reason
- * @property string|null $receipt_number
- * @property string|null $source_transfer_reversal
- * @property string|null $status
- * @property string|null $transfer_reversal
+ * @property string $payment_intent
+ * @property string $reason
+ * @property string $receipt_number
+ * @property string $source_transfer_reversal
+ * @property string $status
+ * @property string $transfer_reversal
  *
  * @package Stripe
  */

--- a/lib/Reporting/ReportRun.php
+++ b/lib/Reporting/ReportRun.php
@@ -8,13 +8,13 @@ namespace Stripe\Reporting;
  * @property string $id
  * @property string $object
  * @property int $created
- * @property string|null $error
+ * @property string $error
  * @property bool $livemode
  * @property mixed $parameters
  * @property string $report_type
- * @property mixed|null $result
+ * @property mixed $result
  * @property string $status
- * @property int|null $succeeded_at
+ * @property int $succeeded_at
  *
  * @package Stripe\Reporting
  */

--- a/lib/Reporting/ReportType.php
+++ b/lib/Reporting/ReportType.php
@@ -9,7 +9,7 @@ namespace Stripe\Reporting;
  * @property string $object
  * @property int $data_available_end
  * @property int $data_available_start
- * @property string[]|null $default_columns
+ * @property string[] $default_columns
  * @property string $name
  * @property int $updated
  * @property int $version

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -7,18 +7,18 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $billing_zip
- * @property string|null $charge
- * @property string|null $closed_reason
+ * @property string $billing_zip
+ * @property string $charge
+ * @property string $closed_reason
  * @property int $created
- * @property string|null $ip_address
- * @property mixed|null $ip_address_location
+ * @property string $ip_address
+ * @property mixed $ip_address_location
  * @property bool $livemode
  * @property bool $open
  * @property string $opened_reason
  * @property string $payment_intent
  * @property string $reason
- * @property mixed|null $session
+ * @property mixed $session
  *
  * @package Stripe
  */

--- a/lib/SKU.php
+++ b/lib/SKU.php
@@ -11,11 +11,11 @@ namespace Stripe;
  * @property mixed $attributes
  * @property int $created
  * @property string $currency
- * @property string|null $image
+ * @property string $image
  * @property mixed $inventory
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property mixed|null $package_dimensions
+ * @property mixed $package_dimensions
  * @property int $price
  * @property string $product
  * @property int $updated

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -7,22 +7,22 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $application
- * @property string|null $cancellation_reason
- * @property string|null $client_secret
+ * @property string $application
+ * @property string $cancellation_reason
+ * @property string $client_secret
  * @property int $created
- * @property string|null $customer
- * @property string|null $description
- * @property mixed|null $last_setup_error
+ * @property string $customer
+ * @property string $description
+ * @property mixed $last_setup_error
  * @property bool $livemode
- * @property string|null $mandate
+ * @property string $mandate
  * @property \Stripe\StripeObject $metadata
- * @property mixed|null $next_action
- * @property string|null $on_behalf_of
- * @property string|null $payment_method
- * @property mixed|null $payment_method_options
+ * @property mixed $next_action
+ * @property string $on_behalf_of
+ * @property string $payment_method
+ * @property mixed $payment_method_options
  * @property string[] $payment_method_types
- * @property string|null $single_use_mandate
+ * @property string $single_use_mandate
  * @property string $status
  * @property string $usage
  *
@@ -64,7 +64,6 @@ class SetupIntent extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/Sigma/ScheduledQueryRun.php
+++ b/lib/Sigma/ScheduledQueryRun.php
@@ -10,7 +10,7 @@ namespace Stripe\Sigma;
  * @property int $created
  * @property int $data_load_time
  * @property mixed $error
- * @property \Stripe\File|null $file
+ * @property mixed $file
  * @property bool $livemode
  * @property int $result_available_until
  * @property string $sql

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -118,6 +118,8 @@ class Source extends ApiResource
     }
 
     /**
+     * @deprecated sourceTransactions is deprecated. Please use Source::allSourceTransactions instead.
+     *
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -132,6 +134,20 @@ class Source extends ApiResource
         $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
+    }
+
+    /**
+     * @param string $id
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws StripeExceptionApiErrorException if the request fails
+     *
+     * @return Collection The list of source transactions.
+     */
+    public static function allSourceTransactions($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, '/source_transactions', $params, $opts);
     }
 
     /**

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -11,7 +11,7 @@ namespace Stripe;
  * @property mixed $ach_debit
  * @property mixed $acss_debit
  * @property mixed $alipay
- * @property int|null $amount
+ * @property int $amount
  * @property mixed $au_becs_debit
  * @property mixed $bancontact
  * @property mixed $card
@@ -19,7 +19,7 @@ namespace Stripe;
  * @property string $client_secret
  * @property mixed $code_verification
  * @property int $created
- * @property string|null $currency
+ * @property string $currency
  * @property string $customer
  * @property mixed $eps
  * @property string $flow
@@ -27,9 +27,9 @@ namespace Stripe;
  * @property mixed $ideal
  * @property mixed $klarna
  * @property bool $livemode
- * @property \Stripe\StripeObject|null $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property mixed $multibanco
- * @property mixed|null $owner
+ * @property mixed $owner
  * @property mixed $p24
  * @property mixed $receiver
  * @property mixed $redirect
@@ -37,11 +37,11 @@ namespace Stripe;
  * @property mixed $sepa_debit
  * @property mixed $sofort
  * @property mixed $source_order
- * @property string|null $statement_descriptor
+ * @property string $statement_descriptor
  * @property string $status
  * @property mixed $three_d_secure
  * @property string $type
- * @property string|null $usage
+ * @property string $usage
  * @property mixed $wechat
  *
  * @package Stripe
@@ -51,7 +51,6 @@ class Source extends ApiResource
     const OBJECT_NAME = 'source';
 
     use ApiOperations\Create;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
@@ -98,7 +97,7 @@ class Source extends ApiResource
         if (!$id) {
             $class = get_class($this);
             $msg = "Could not determine which URL to request: $class instance "
-             . "has invalid ID: $id";
+               . "has invalid ID: $id";
             throw new Exception\UnexpectedValueException($msg, null);
         }
 
@@ -113,14 +112,12 @@ class Source extends ApiResource
             return $this;
         } else {
             $message = "This source object does not appear to be currently attached "
-               . "to a customer object.";
+                 . "to a customer object.";
             throw new Exception\UnexpectedValueException($message);
         }
     }
 
     /**
-     * @deprecated sourceTransactions is deprecated. Please use Source::allSourceTransactions instead.
-     *
      * @param array|null $params
      * @param array|string|null $opts
      *
@@ -135,20 +132,6 @@ class Source extends ApiResource
         $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
-    }
-
-    /**
-     * @param string $id
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of source transactions.
-     */
-    public static function allSourceTransactions($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, '/source_transactions', $params, $opts);
     }
 
     /**

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -7,41 +7,39 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property float|null $application_fee_percent
+ * @property float $application_fee_percent
  * @property int $billing_cycle_anchor
- * @property mixed|null $billing_thresholds
- * @property int|null $cancel_at
+ * @property mixed $billing_thresholds
+ * @property int $cancel_at
  * @property bool $cancel_at_period_end
- * @property int|null $canceled_at
- * @property string|null $collection_method
+ * @property int $canceled_at
+ * @property string $collection_method
  * @property int $created
  * @property int $current_period_end
  * @property int $current_period_start
  * @property string $customer
- * @property int|null $days_until_due
- * @property string|null $default_payment_method
- * @property string|null $default_source
- * @property array|null $default_tax_rates
- * @property \Stripe\Discount|null $discount
- * @property int|null $ended_at
+ * @property int $days_until_due
+ * @property string $default_payment_method
+ * @property string $default_source
+ * @property mixed $default_tax_rates
+ * @property mixed $discount
+ * @property int $ended_at
  * @property mixed $invoice_customer_balance_settings
- * @property \Stripe\Collection $items
- * @property string|null $latest_invoice
+ * @property mixed $items
+ * @property string $latest_invoice
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property int|null $next_pending_invoice_item_invoice
- * @property mixed|null $pending_invoice_item_interval
- * @property string|null $pending_setup_intent
- * @property \Stripe\Plan|null $plan
- * @property int|null $quantity
- * @property string|null $schedule
+ * @property int $next_pending_invoice_item_invoice
+ * @property mixed $pending_invoice_item_interval
+ * @property string $pending_setup_intent
+ * @property mixed $plan
+ * @property int $quantity
+ * @property string $schedule
  * @property int $start_date
  * @property string $status
- * @property float|null $tax_percent
- * @property int|null $trial_end
- * @property int|null $trial_start
- * @property string $pending_setup_intent
- * @property \Stripe\SubscriptionSchedule $schedule
+ * @property float $tax_percent
+ * @property int $trial_end
+ * @property int $trial_start
  *
  * @package Stripe
  */
@@ -51,9 +49,6 @@ class Subscription extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Create;
-    use ApiOperations\Delete {
-        delete as protected _delete;
-    }
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
@@ -70,6 +65,10 @@ class Subscription extends ApiResource
     const STATUS_INCOMPLETE         = 'incomplete';
     const STATUS_INCOMPLETE_EXPIRED = 'incomplete_expired';
 
+    use ApiOperations\Delete {
+        delete as protected _delete;
+      }
+
     public static function getSavedNestedResources()
     {
         static $savedNestedResources = null;
@@ -84,7 +83,7 @@ class Subscription extends ApiResource
     /**
      * @param array|null $params
      * @param array|string|null $opts
-     *
+           *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return Subscription The deleted subscription.

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -7,13 +7,13 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $billing_thresholds
+ * @property mixed $billing_thresholds
  * @property int $created
  * @property \Stripe\StripeObject $metadata
- * @property \Stripe\Plan $plan
+ * @property mixed $plan
  * @property int $quantity
  * @property string $subscription
- * @property array|null $tax_rates
+ * @property mixed $tax_rates
  *
  * @package Stripe
  */
@@ -24,11 +24,12 @@ class SubscriptionItem extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Create;
     use ApiOperations\Delete;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    const PATH_USAGE_RECORDS = "/usage_records";
+    use ApiOperations\NestedResource;
+
+    const PATH_USAGE_RECORDS = '/usage_records';
 
     /**
      * @param string|null $id The ID of the subscription item on which to create the usage record.
@@ -45,14 +46,12 @@ class SubscriptionItem extends ApiResource
     }
 
     /**
-     * @deprecated usageRecordSummaries is deprecated. Please use SubscriptionItem::allUsageRecordSummaries instead.
-     *
      * @param array|null $params
      * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Collection The list of usage record summaries.
+     * @return SubscriptionItem The list of subscription item.
      */
     public function usageRecordSummaries($params = null, $opts = null)
     {
@@ -61,19 +60,5 @@ class SubscriptionItem extends ApiResource
         $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
-    }
-
-    /**
-     * @param string $id
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return Collection The list of usage record summaries.
-     */
-    public static function allUsageRecordSummaries($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, '/usage_record_summaries', $params, $opts);
     }
 }

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -46,19 +46,35 @@ class SubscriptionItem extends ApiResource
     }
 
     /**
+     * @deprecated usageRecordSummaries is deprecated. Please use SubscriptionItem::allUsageRecordSummaries instead.
+     *
      * @param array|null $params
      * @param array|string|null $opts
      *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     * @throws StripeExceptionApiErrorException if the request fails
      *
-     * @return SubscriptionItem The list of subscription item.
+     * @return Collection The list of usage record summaries.
      */
     public function usageRecordSummaries($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/usage_record_summaries';
         list($response, $opts) = $this->_request('get', $url, $params, $opts);
-        $obj = \Stripe\Util\Util::convertToStripeObject($response, $opts);
+        $obj = StripeUtilUtil::convertToStripeObject($response, $opts);
         $obj->setLastResponse($response);
         return $obj;
+    }
+
+    /**
+     * @param string $id
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws StripeExceptionApiErrorException if the request fails
+     *
+     * @return Collection The list of usage record summaries.
+     */
+    public static function allUsageRecordSummaries($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, '/usage_record_summaries', $params, $opts);
     }
 }

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -7,24 +7,21 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property mixed|null $billing_thresholds
- * @property int|null $canceled_at
- * @property string|null $collection_method
- * @property int|null $completed_at
+ * @property int $canceled_at
+ * @property int $completed_at
  * @property int $created
- * @property mixed|null $current_phase
+ * @property mixed $current_phase
  * @property string $customer
- * @property string|null $default_payment_method
+ * @property mixed $default_settings
  * @property string $end_behavior
- * @property mixed|null $invoice_settings
  * @property bool $livemode
- * @property \Stripe\StripeObject|null $metadata
+ * @property \Stripe\StripeObject $metadata
  * @property mixed $phases
- * @property int|null $released_at
- * @property string|null $released_subscription
- * @property mixed|null $renewal_interval
+ * @property int $released_at
+ * @property string $released_subscription
+ * @property mixed $renewal_interval
  * @property string $status
- * @property string|null $subscription
+ * @property string $subscription
  *
  * @package Stripe
  */
@@ -52,7 +49,6 @@ class SubscriptionSchedule extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-
     /**
      * @param array|null $params
      * @param array|string|null $opts

--- a/lib/TaxRate.php
+++ b/lib/TaxRate.php
@@ -9,10 +9,10 @@ namespace Stripe;
  * @property string $object
  * @property bool $active
  * @property int $created
- * @property string|null $description
+ * @property string $description
  * @property string $display_name
  * @property bool $inclusive
- * @property string|null $jurisdiction
+ * @property string $jurisdiction
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property float $percentage

--- a/lib/Terminal/Reader.php
+++ b/lib/Terminal/Reader.php
@@ -7,13 +7,13 @@ namespace Stripe\Terminal;
  *
  * @property string $id
  * @property string $object
- * @property string|null $device_sw_version
+ * @property string $device_sw_version
  * @property string $device_type
- * @property string|null $ip_address
+ * @property string $ip_address
  * @property string $label
- * @property string|null $location
+ * @property string $location
  * @property string $serial_number
- * @property string|null $status
+ * @property string $status
  *
  * @package Stripe\Terminal
  */

--- a/lib/ThreeDSecure.php
+++ b/lib/ThreeDSecure.php
@@ -13,7 +13,7 @@ namespace Stripe;
  * @property int $created
  * @property string $currency
  * @property bool $livemode
- * @property string|null $redirect_url
+ * @property string $redirect_url
  * @property string $status
  *
  * @package Stripe

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -7,9 +7,9 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property \Stripe\BankAccount $bank_account
- * @property \Stripe\Card $card
- * @property string|null $client_ip
+ * @property mixed $bank_account
+ * @property mixed $card
+ * @property string $client_ip
  * @property int $created
  * @property bool $livemode
  * @property string $type

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -8,19 +8,19 @@ namespace Stripe;
  * @property string $id
  * @property string $object
  * @property int $amount
- * @property string|null $balance_transaction
+ * @property string $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string|null $description
- * @property int|null $expected_availability_date
- * @property string|null $failure_code
- * @property string|null $failure_message
+ * @property string $description
+ * @property int $expected_availability_date
+ * @property string $failure_code
+ * @property string $failure_message
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property mixed $source
- * @property string|null $statement_descriptor
+ * @property string $statement_descriptor
  * @property string $status
- * @property string|null $transfer_group
+ * @property string $transfer_group
  *
  * @package Stripe
  */

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -9,19 +9,19 @@ namespace Stripe;
  * @property string $object
  * @property int $amount
  * @property int $amount_reversed
- * @property string|null $balance_transaction
+ * @property string $balance_transaction
  * @property int $created
  * @property string $currency
- * @property string|null $description
- * @property string|null $destination
+ * @property string $description
+ * @property string $destination
  * @property string $destination_payment
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
- * @property \Stripe\Collection $reversals
+ * @property mixed $reversals
  * @property bool $reversed
- * @property string|null $source_transaction
- * @property string|null $source_type
- * @property string|null $transfer_group
+ * @property string $source_transaction
+ * @property string $source_type
+ * @property string $transfer_group
  *
  * @package Stripe
  */
@@ -31,11 +31,8 @@ class Transfer extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Create;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
-
-    const PATH_REVERSALS = '/reversals';
 
     /**
      * Possible string representations of the source type of the transfer.
@@ -61,6 +58,9 @@ class Transfer extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
+    use ApiOperations\NestedResource;
+
+    const PATH_REVERSALS = '/reversals';
 
     /**
      * @param string $id The ID of the transfer on which to create the transfer reversal.
@@ -86,8 +86,12 @@ class Transfer extends ApiResource
      *
      * @return TransferReversal
      */
-    public static function retrieveReversal($id, $reversalId, $params = null, $opts = null)
-    {
+    public static function retrieveReversal(
+        $id,
+        $reversalId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_retrieveNestedResource($id, static::PATH_REVERSALS, $reversalId, $params, $opts);
     }
 
@@ -101,8 +105,12 @@ class Transfer extends ApiResource
      *
      * @return TransferReversal
      */
-    public static function updateReversal($id, $reversalId, $params = null, $opts = null)
-    {
+    public static function updateReversal(
+        $id,
+        $reversalId,
+        $params = null,
+        $opts = null
+    ) {
         return self::_updateNestedResource($id, static::PATH_REVERSALS, $reversalId, $params, $opts);
     }
 

--- a/lib/WebhookEndpoint.php
+++ b/lib/WebhookEndpoint.php
@@ -7,8 +7,8 @@ namespace Stripe;
  *
  * @property string $id
  * @property string $object
- * @property string|null $api_version
- * @property string|null $application
+ * @property string $api_version
+ * @property string $application
  * @property int $created
  * @property string[] $enabled_events
  * @property bool $livemode


### PR DESCRIPTION
r? @ob-stripe 
cc @marko-stripe @remi-stripe 
cc @stripe/api-libraries 

The biggest difference I can find is that we no longer output `|null` for optional fields in comments. Should we? I don't think it should be too hard.

There are a few other comment regressions, like
```diff
- * @property \Stripe\Collection $reversals
+ * @property mixed $reversals
```
Feels on how important those are to fix? Should be doable.