### PR TITLE
Remove duplicate property from `Subscription`

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -40,8 +40,6 @@ namespace Stripe;
  * @property float|null $tax_percent
  * @property int|null $trial_end
  * @property int|null $trial_start
- * @property string $pending_setup_intent
- * @property \Stripe\SubscriptionSchedule $schedule
  *
  * @package Stripe
  */


### PR DESCRIPTION
### `$pending_setup_intent` is duplicated.  
1. https://github.com/stripe/stripe-php/blob/ff089fda26dcb1a7f14ffa5bea5f77da3af458fa/lib/Subscription.php#L34  
2. https://github.com/stripe/stripe-php/blob/ff089fda26dcb1a7f14ffa5bea5f77da3af458fa/lib/Subscription.php#L43

### `$schedule` is duplicated and can only be `string` or `null`,  It's not a `SubscriptionSchedule` object.  
1. https://github.com/stripe/stripe-php/blob/ff089fda26dcb1a7f14ffa5bea5f77da3af458fa/lib/Subscription.php#L37  
2. https://github.com/stripe/stripe-php/blob/ff089fda26dcb1a7f14ffa5bea5f77da3af458fa/lib/Subscription.php#L44