### PR TITLE
Test PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,9 @@ matrix:
       env: AUTOLOAD=1
     - php: 7.3
       env: AUTOLOAD=0
-    - php: 7.4snapshot
+    - php: 7.4
       env: AUTOLOAD=1
-    - php: 7.4snapshot
-      env: AUTOLOAD=0
-  allow_failures:
-    - php: 7.4snapshot
-      env: AUTOLOAD=1
-    - php: 7.4snapshot
+    - php: 7.4
       env: AUTOLOAD=0
 
 env:


### PR DESCRIPTION
r? @ob-stripe 

PHP 7.4.0 has been released, so move it out of `allow_failures`.