### PR TITLE
Disable autoloader when checking for `Throwable`

### DIFF
--- a/lib/Exception/ExceptionInterface.php
+++ b/lib/Exception/ExceptionInterface.php
@@ -3,7 +3,7 @@
 namespace Stripe\Exception;
 
 // TODO: remove this check once we drop support for PHP 5
-if (interface_exists(\Throwable::class)) {
+if (interface_exists(\Throwable::class, false)) {
     /**
      * The base interface for all Stripe exceptions.
      *


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The [`\Throwable`](https://www.php.net/manual/en/class.throwable.php) interface was added in PHP 7, so we use `interface_exists` to check that it exists. However by default this will attempt to autoload the interface from a `Throwable.php` file, which can throw a warning in certain environments.

In this case the interface should be provided by PHP itself, so it's safe to disable autoloading by passing `false` as a second argument to [`interface_exists`](https://www.php.net/manual/en/function.interface-exists.php).

Fixes #813.
