### PR TITLE
Add `array<string, mixed>` as return type for `getJsonBody`

### DIFF
--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -135,7 +135,7 @@ abstract class ApiErrorException extends \Exception implements ExceptionInterfac
     /**
      * Gets the JSON deserialized body.
      *
-     * @return array|null
+     * @return array<string, mixed>|null
      */
     public function getJsonBody()
     {
@@ -145,7 +145,7 @@ abstract class ApiErrorException extends \Exception implements ExceptionInterfac
     /**
      * Sets the JSON deserialized body.
      *
-     * @param array|null $jsonBody
+     * @param array<string, mixed>|null $jsonBody
      */
     public function setJsonBody($jsonBody)
     {


### PR DESCRIPTION
This makes it easier for PHPStan et all to understand that the array will be mixed.