### PR TITLE
Rename remaining `$options` to `$opts`

### DIFF
--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -67,14 +67,14 @@ class Customer extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @return Customer The updated customer.
      */
-    public function deleteDiscount($params = null, $options = null)
+    public function deleteDiscount($params = null, $opts = null)
     {
         $url = $this->instanceUrl() . '/discount';
-        list($response, $opts) = $this->_request('delete', $url, $params, $options);
+        list($response, $opts) = $this->_request('delete', $url, $params, $opts);
         $this->refreshFrom(['discount' => null], $opts, true);
     }
 

--- a/lib/File.php
+++ b/lib/File.php
@@ -40,15 +40,15 @@ class File extends ApiResource
 
     /**
      * @param array|null $params
-     * @param array|string|null $options
+     * @param array|string|null $opts
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return \Stripe\File The created resource.
      */
-    public static function create($params = null, $options = null)
+    public static function create($params = null, $opts = null)
     {
-        $opts = \Stripe\Util\RequestOptions::parse($options);
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
         if (is_null($opts->apiBase)) {
             $opts->apiBase = Stripe::$apiUploadBase;
         }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Rename a few remaining `$options` arguments to `$opts` to be consistent with other methods.
