### PR TITLE
Don't call php_uname function if disabled by php.ini

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -260,7 +260,8 @@ class ApiRequestor
         $uaString = 'Stripe/v1 PhpBindings/' . Stripe::VERSION;
 
         $langVersion = phpversion();
-        $uname = php_uname();
+        $uname_disabled = in_array('php_uname', explode(',', ini_get('disable_functions')));
+        $uname = $uname_disabled ? '(disabled)' : php_uname();
 
         $appInfo = Stripe::getAppInfo();
         $ua = [


### PR DESCRIPTION
Addresses #828. Some hosting providers disable the php_uname function, presumably by adding it to 'disable_functions' in php.ini. This PR retrieves the value of 'disable_functions', parses the comma-separated list it to see if 'php_uname' is contained. In that case, we hardcode uname to "(disabled)" to avoid calling php_uname.

r? @ob-stripe 
cc @remi-stripe 