### PR TITLE
Fix UnexpectedValueException

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -422,7 +422,7 @@ class ApiRequestor
         if ($resp === null && $jsonError !== JSON_ERROR_NONE) {
             $msg = "Invalid response body from API: $rbody "
               . "(HTTP response code was $rcode, json_last_error() was $jsonError)";
-            throw new Exception\UnexpectedValueException($msg, $rcode, $rbody);
+            throw new Exception\UnexpectedValueException($msg, $rcode);
         }
 
         if ($rcode < 200 || $rcode >= 300) {


### PR DESCRIPTION
Here is the error:

Fatal error:  Uncaught Error: Wrong parameters for Stripe\Exception\UnexpectedValueException([string $message [, long $code [, Throwable $previous = NULL]]]) in vendor/stripe/stripe-php/lib/ApiRequestor.php:424