### PR TITLE
PHPDoc fixes, CreditNote.previewLines, and autogen prep

### DIFF
--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -30,6 +30,7 @@ class ApplicationFee extends ApiResource
     use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
 
+
     const PATH_REFUNDS = '/refunds';
 
     /**

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -38,9 +38,9 @@ class CreditNote extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Create;
+    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
-    use ApiOperations\NestedResource;
 
     /**
      * Possible string representations of the credit note reason.
@@ -64,8 +64,6 @@ class CreditNote extends ApiResource
      */
     const TYPE_POST_PAYMENT = 'post_payment';
     const TYPE_PRE_PAYMENT  = 'pre_payment';
-
-    const PATH_LINES = '/lines';
 
     /**
      * @param array|null $params
@@ -99,6 +97,8 @@ class CreditNote extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
+
+    const PATH_LINES = '/lines';
 
     /**
      * @param string $id The ID of the credit note on which to retrieve the credit note line items.

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -61,10 +61,6 @@ class Customer extends ApiResource
         return $savedNestedResources;
     }
 
-    const PATH_BALANCE_TRANSACTIONS = '/balance_transactions';
-    const PATH_SOURCES = '/sources';
-    const PATH_TAX_IDS = '/tax_ids';
-
     /**
      * @param array|null $params
      * @param array|string|null $opts
@@ -77,6 +73,8 @@ class Customer extends ApiResource
         list($response, $opts) = $this->_request('delete', $url, $params, $opts);
         $this->refreshFrom(['discount' => null], $opts, true);
     }
+
+    const PATH_BALANCE_TRANSACTIONS = '/balance_transactions';
 
     /**
      * @param string $id The ID of the customer on which to retrieve the customer balance transactions.
@@ -135,6 +133,8 @@ class Customer extends ApiResource
     {
         return self::_updateNestedResource($id, static::PATH_BALANCE_TRANSACTIONS, $balanceTransactionId, $params, $opts);
     }
+
+    const PATH_SOURCES = '/sources';
 
     /**
      * @param string $id The ID of the customer on which to retrieve the payment sources.
@@ -208,6 +208,8 @@ class Customer extends ApiResource
     {
         return self::_updateNestedResource($id, static::PATH_SOURCES, $sourceId, $params, $opts);
     }
+
+    const PATH_TAX_IDS = '/tax_ids';
 
     /**
      * @param string $id The ID of the customer on which to retrieve the tax ids.

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -19,10 +19,11 @@ class EphemeralKey extends ApiResource
 {
     const OBJECT_NAME = 'ephemeral_key';
 
+    use ApiOperations\Delete;
+
     use ApiOperations\Create {
         create as protected _create;
     }
-    use ApiOperations\Delete;
 
     /**
      * @param array|null $params

--- a/lib/File.php
+++ b/lib/File.php
@@ -20,18 +20,20 @@ namespace Stripe;
  */
 class File extends ApiResource
 {
+    const OBJECT_NAME = 'file';
+
+    use ApiOperations\All;
+    use ApiOperations\Retrieve;
+
     // This resource can have two different object names. In latter API
     // versions, only `file` is used, but since stripe-php may be used with
     // any API version, we need to support deserializing the older
     // `file_upload` object into the same class.
-    const OBJECT_NAME = 'file';
-    const OBJECT_NAME_ALT = "file_upload";
+    const OBJECT_NAME_ALT = 'file_upload';
 
-    use ApiOperations\All;
     use ApiOperations\Create {
         create as protected _create;
     }
-    use ApiOperations\Retrieve;
 
     public static function classUrl()
     {

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -77,6 +77,7 @@ class Invoice extends ApiResource
     use ApiOperations\Delete;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
+
     use ApiOperations\NestedResource;
 
     /**
@@ -117,6 +118,37 @@ class Invoice extends ApiResource
     const BILLING_SEND_INVOICE         = 'send_invoice';
 
     const PATH_LINES = '/lines';
+
+    /**
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice The upcoming invoice.
+     */
+    public static function upcoming($params = null, $opts = null)
+    {
+        $url = static::classUrl() . '/upcoming';
+        list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
+        $obj = Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+        return $obj;
+    }
+
+    /**
+     * @param string $id The ID of the invoice on which to retrieve the lines.
+     * @param array|null $params
+     * @param array|string|null $opts
+     *
+     * @throws StripeExceptionApiErrorException if the request fails
+     *
+     * @return \Stripe\Collection The list of lines (InvoiceLineItem).
+     */
+    public static function allLines($id, $params = null, $opts = null)
+    {
+        return self::_allNestedResources($id, static::PATH_LINES, $params, $opts);
+    }
 
     /**
      * @param array|null $params
@@ -188,23 +220,6 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Invoice The upcoming invoice.
-     */
-    public static function upcoming($params = null, $opts = null)
-    {
-        $url = static::classUrl() . '/upcoming';
-        list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
-        $obj = Util\Util::convertToStripeObject($response->json, $opts);
-        $obj->setLastResponse($response);
-        return $obj;
-    }
-
-    /**
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
      * @return Invoice The voided invoice.
      */
     public function voidInvoice($params = null, $opts = null)
@@ -213,19 +228,5 @@ class Invoice extends ApiResource
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
         $this->refreshFrom($response, $opts);
         return $this;
-    }
-
-    /**
-     * @param string $id The ID of the invoice on which to retrieve the lines.
-     * @param array|null $params
-     * @param array|string|null $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return \Stripe\Collection The list of lines (InvoiceLineItem).
-     */
-    public static function allLines($id, $params = null, $opts = null)
-    {
-        return self::_allNestedResources($id, static::PATH_LINES, $params, $opts);
     }
 }

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -46,14 +46,13 @@ class Order extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Order The paid order.
+     * @return \Stripe\OrderReturn The newly created return.
      */
-    public function pay($params = null, $opts = null)
+    public function returnOrder($params = null, $opts = null)
     {
-        $url = $this->instanceUrl() . '/pay';
+        $url = $this->instanceUrl() . '/returns';
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        $this->refreshFrom($response, $opts);
-        return $this;
+        return Util\Util::convertToStripeObject($response, $opts);
     }
 
     /**
@@ -62,12 +61,13 @@ class Order extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\OrderReturn The newly created return.
+     * @return Order The paid order.
      */
-    public function returnOrder($params = null, $opts = null)
+    public function pay($params = null, $opts = null)
     {
-        $url = $this->instanceUrl() . '/returns';
+        $url = $this->instanceUrl() . '/pay';
         list($response, $opts) = $this->_request('post', $url, $params, $opts);
-        return Util\Util::convertToStripeObject($response, $opts);
+        $this->refreshFrom($response, $opts);
+        return $this;
     }
 }

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -51,9 +51,10 @@ class Source extends ApiResource
     const OBJECT_NAME = 'source';
 
     use ApiOperations\Create;
-    use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
+
+    use ApiOperations\NestedResource;
 
     /**
      * Possible string representations of source flows.

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -49,9 +49,6 @@ class Subscription extends ApiResource
 
     use ApiOperations\All;
     use ApiOperations\Create;
-    use ApiOperations\Delete {
-        delete as protected _delete;
-    }
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
@@ -67,6 +64,10 @@ class Subscription extends ApiResource
     const STATUS_UNPAID             = 'unpaid';
     const STATUS_INCOMPLETE         = 'incomplete';
     const STATUS_INCOMPLETE_EXPIRED = 'incomplete_expired';
+
+    use ApiOperations\Delete {
+        delete as protected _delete;
+      }
 
     public static function getSavedNestedResources()
     {

--- a/lib/SubscriptionItem.php
+++ b/lib/SubscriptionItem.php
@@ -29,7 +29,6 @@ class SubscriptionItem extends ApiResource
     use ApiOperations\Update;
 
     const PATH_USAGE_RECORDS = '/usage_records';
-    const PATH_USAGE_RECORD_SUMMARIES = '/usage_record_summaries';
 
     /**
      * @param string|null $id The ID of the subscription item on which to create the usage record.
@@ -63,6 +62,8 @@ class SubscriptionItem extends ApiResource
         $obj->setLastResponse($response);
         return $obj;
     }
+
+    const PATH_USAGE_RECORD_SUMMARIES = '/usage_record_summaries';
 
     /**
      * @param string $id The ID of the subscription item on which to retrieve the usage record summaries.

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -35,8 +35,6 @@ class Transfer extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    const PATH_REVERSALS = '/reversals';
-
     /**
      * Possible string representations of the source type of the transfer.
      * @link https://stripe.com/docs/api/transfers/object#transfer_object-source_type
@@ -61,6 +59,8 @@ class Transfer extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
+
+    const PATH_REVERSALS = '/reversals';
 
     /**
      * @param string $id The ID of the transfer on which to retrieve the transfer reversals.


### PR DESCRIPTION
r? @ob
cc @stripe/api-libraries @remi-stripe @cjavilla-stripe @marko-stripe 
Changes:
  * Document missing properties on `Session`, `CreditNote`, `Invoice`, `InvoiceItem`, `Subscription`, and `SubscriptionSchedule`.
  * Undocument properties on `SubscriptionSchedule` that were removed in the latest API versions.
  * Add '.previewLines' method to CreditNote.
  * Adds more specific types for many docstrings. A full list of the PHPDoc changes is [here](https://gist.github.com/richardm-stripe/2c335c99b08f819b66e9c649695c9b8c).
  * Several formatting changes/reordering of methods. This is an artifact of autogeneration.
