### PR TITLE
Use custom PHP-CS-Fixer config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ clover.xml
 # Ignore IDE's configuration files
 .idea
 
-# Ignore PHP CS Fixer cache
+# Ignore PHP CS Fixer local config and cache
+.php_cs
 .php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_after_opening_tag' => true,
+        'class_attributes_separation' => [
+            'elements' => ['method'],
+        ],
+        'linebreak_after_opening_tag' => true,
+    ])
+;

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -53,11 +53,11 @@ class ApiRequestor
      */
     private static function _telemetryJson($requestTelemetry)
     {
-        $payload = array(
-            'last_request_metrics' => array(
+        $payload = [
+            'last_request_metrics' => [
                 'request_id' => $requestTelemetry->requestId,
                 'request_duration_ms' => $requestTelemetry->requestDuration,
-        ));
+        ]];
 
         $result = json_encode($payload);
         if ($result != false) {

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -334,7 +334,6 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         return $updateParams;
     }
 
-
     public function serializeParamsValue($value, $original, $unsaved, $force, $key = null)
     {
         // The logic here is that essentially any object embedded in another

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -125,15 +125,15 @@ class ApiRequestorTest extends TestCase
         $this->stubRequest(
             'POST',
             '/v1/charges',
-            array(),
+            [],
             null,
             false,
-            array(
-                'error' => array(
+            [
+                'error' => [
                     'type' => 'idempotency_error',
                     'message' => "Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.",
-                ),
-            ),
+                ],
+            ],
             400
         );
 

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -170,7 +170,6 @@ class CurlClientTest extends \Stripe\TestCase
         $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0));
     }
 
-
     public function testShouldNotRetryOn429()
     {
         \Stripe\Stripe::setMaxNetworkRetries(2);

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -29,7 +29,7 @@ class StripeTelemetryTest extends TestCase
 
         $stub = $this
             ->getMockBuilder("HttpClient\ClientInterface")
-            ->setMethods(array('request'))
+            ->setMethods(['request'])
             ->getMock();
 
         $stub->expects($this->any())
@@ -48,7 +48,7 @@ class StripeTelemetryTest extends TestCase
                 }),
                 $this->anything(),
                 $this->anything()
-            )->willReturn(array(self::FAKE_VALID_RESPONSE, 200, ["request-id" => "123"]));
+            )->willReturn([self::FAKE_VALID_RESPONSE, 200, ["request-id" => "123"]]);
 
         ApiRequestor::setHttpClient($stub);
 
@@ -71,7 +71,7 @@ class StripeTelemetryTest extends TestCase
 
         $stub = $this
             ->getMockBuilder("HttpClient\ClientInterface")
-            ->setMethods(array('request'))
+            ->setMethods(['request'])
             ->getMock();
 
         $stub->expects($this->any())
@@ -90,7 +90,7 @@ class StripeTelemetryTest extends TestCase
                 }),
                 $this->anything(),
                 $this->anything()
-            )->willReturn(array(self::FAKE_VALID_RESPONSE, 200, ["request-id" => ["req_123"]]));
+            )->willReturn([self::FAKE_VALID_RESPONSE, 200, ["request-id" => ["req_123"]]]);
 
         ApiRequestor::setHttpClient($stub);
 

--- a/update_certs.php
+++ b/update_certs.php
@@ -6,11 +6,11 @@ set_time_limit(0); // unlimited max execution time
 
 $fp = fopen(dirname(__FILE__) . '/data/ca-certificates.crt', 'w+');
 
-$options = array(
+$options = [
   CURLOPT_FILE    => $fp,
   CURLOPT_TIMEOUT =>  3600,
   CURLOPT_URL     => 'https://curl.haxx.se/ca/cacert.pem',
-);
+];
 
 $ch = curl_init();
 curl_setopt_array($ch, $options);


### PR DESCRIPTION
r? @cjavilla-stripe @remi-stripe 

Add a custom configuration for PHP-CS-Fixer (our code formatting tool).

The main motivation is to include this:
```
        'class_attributes_separation' => [
            'elements' => ['method'],
        ],
```
which will ensure that all methods in classes are separated by one line and will help with codegen.

I also threw in a couple of other useful options, such as forcing the usage of `[]` instead of `array()` and enforcing some line breaks.
