### PR TITLE
PHP-CS-Fixer @PHP56Migration changes

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -448,7 +448,7 @@ class CurlClient implements ClientInterface
         // number of $numRetries so far as inputs. Do not allow the number to exceed
         // $maxNetworkRetryDelay.
         $sleepSeconds = min(
-            Stripe::getInitialNetworkRetryDelay() * 1.0 * pow(2, $numRetries - 1),
+            Stripe::getInitialNetworkRetryDelay() * 1.0 * 2 ** ($numRetries - 1),
             Stripe::getMaxNetworkRetryDelay()
         );
 


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 

PHP-CS-Fixer actually has a ton of features I only learned about yesterday. One of these is "risky" rulesets that you can use when upgrading PHP or PHPUnit versions to automatically upgrade to newer syntaxes.

In this case I ran `./vendor/bin/php-cs-fixer fix --allow-risky=yes --rules=@PHP56Migration:risky .`. The only change is replacing the use of the `pow()` function with the `**` operator introduced in PHP 5.6 (https://www.php.net/manual/en/language.operators.arithmetic.php).

(This is "risky" because the `pow()` function might have been overridden, but that's not the case for us.)
