### PR TITLE
PHP-CS-Fixer @PHPUnit57Migration changes

### DIFF
--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -16,7 +16,7 @@ class AccountTest extends TestCase
             '/v1/accounts'
         );
         $resources = Account::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Account::class, $resources->data[0]);
     }
 
@@ -126,7 +126,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $account->id . '/persons'
         );
         $persons = $account->persons();
-        $this->assertTrue(is_array($persons->data));
+        $this->assertInternalType('array', $persons->data);
         $this->assertInstanceOf(\Stripe\Person::class, $persons->data[0]);
     }
 
@@ -159,7 +159,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities'
         );
         $resources = Account::allCapabilities(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateExternalAccount()
@@ -213,7 +213,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
         );
         $resources = Account::allExternalAccounts(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateLoginLink()
@@ -281,7 +281,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons'
         );
         $resources = Account::allPersons(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testSerializeNewAdditionalOwners()
@@ -395,11 +395,10 @@ class AccountTest extends TestCase
         $this->assertSame($expected, $obj->serializeParameters());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSerializeAdditionalOwnersDeletedItem()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $obj = Util\Util::convertToStripeObject([
             'object' => 'account',
             'legal_entity' => [

--- a/tests/Stripe/AlipayAccountTest.php
+++ b/tests/Stripe/AlipayAccountTest.php
@@ -33,11 +33,10 @@ class AlipayAccountTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyRetrievable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         AlipayAccount::retrieve(self::TEST_RESOURCE_ID);
     }
 
@@ -53,11 +52,10 @@ class AlipayAccountTest extends TestCase
         $this->assertSame(\Stripe\AlipayAccount::class, get_class($resource));
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyUpdatable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         AlipayAccount::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -79,12 +79,11 @@ class ApiRequestorTest extends TestCase
         $this->assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\AuthenticationException
-     * @expectedExceptionMessageRegExp #No API key provided#
-     */
     public function testRaisesAuthenticationErrorWhenNoApiKey()
     {
+        $this->expectException(\Stripe\Exception\AuthenticationException::class);
+        $this->expectExceptionMessageRegExp('#No API key provided#');
+
         Stripe::setApiKey(null);
         Charge::create();
     }
@@ -112,7 +111,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\InvalidRequestException $e) {
             $this->assertSame(400, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('Missing id', $e->getMessage());
             $this->assertSame('id', $e->getStripeParam());
         } catch (\Exception $e) {
@@ -142,7 +141,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\IdempotencyException $e) {
             $this->assertSame(400, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame("Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.", $e->getMessage());
         } catch (\Exception $e) {
             $this->fail("Unexpected exception: " . get_class($e));
@@ -171,7 +170,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\AuthenticationException $e) {
             $this->assertSame(401, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('You did not provide an API key.', $e->getMessage());
         } catch (\Exception $e) {
             $this->fail("Unexpected exception: " . get_class($e));
@@ -204,7 +203,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\CardException $e) {
             $this->assertSame(402, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('Your card was declined.', $e->getMessage());
             $this->assertSame('card_declined', $e->getStripeCode());
             $this->assertSame('generic_decline', $e->getDeclineCode());
@@ -236,7 +235,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\PermissionException $e) {
             $this->assertSame(403, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame("The provided key 'sk_test_********************1234' does not have access to account 'foo' (or that account does not exist). Application access may have been revoked.", $e->getMessage());
         } catch (\Exception $e) {
             $this->fail("Unexpected exception: " . get_class($e));
@@ -266,7 +265,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\InvalidRequestException $e) {
             $this->assertSame(404, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('No such charge: foo', $e->getMessage());
             $this->assertSame('id', $e->getStripeParam());
         } catch (\Exception $e) {
@@ -295,7 +294,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\RateLimitException $e) {
             $this->assertSame(429, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('Too many requests', $e->getMessage());
         } catch (\Exception $e) {
             var_dump($e);
@@ -325,7 +324,7 @@ class ApiRequestorTest extends TestCase
             $this->fail("Did not raise error");
         } catch (Exception\RateLimitException $e) {
             $this->assertSame(400, $e->getHttpStatus());
-            $this->assertTrue(is_array($e->getJsonBody()));
+            $this->assertInternalType('array', $e->getJsonBody());
             $this->assertSame('Too many requests', $e->getMessage());
         } catch (\Exception $e) {
             $this->fail("Unexpected exception: " . get_class($e));

--- a/tests/Stripe/ApplePayDomainTest.php
+++ b/tests/Stripe/ApplePayDomainTest.php
@@ -13,7 +13,7 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains'
         );
         $resources = ApplePayDomain::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\ApplePayDomain::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/ApplicationFeeTest.php
+++ b/tests/Stripe/ApplicationFeeTest.php
@@ -14,7 +14,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees'
         );
         $resources = ApplicationFee::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\ApplicationFee::class, $resources->data[0]);
     }
 
@@ -65,7 +65,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
         );
         $resources = ApplicationFee::allRefunds(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/BalanceTransactionTest.php
+++ b/tests/Stripe/BalanceTransactionTest.php
@@ -13,7 +13,7 @@ class BalanceTransactionTest extends TestCase
             '/v1/balance_transactions'
         );
         $resources = BalanceTransaction::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\BalanceTransaction::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -42,11 +42,10 @@ class BankAccountTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyRetrievable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         BankAccount::retrieve(self::TEST_RESOURCE_ID);
     }
 
@@ -62,11 +61,10 @@ class BankAccountTest extends TestCase
         $this->assertSame(\Stripe\BankAccount::class, get_class($resource));
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyUpdatable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         BankAccount::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);

--- a/tests/Stripe/BitcoinReceiverTest.php
+++ b/tests/Stripe/BitcoinReceiverTest.php
@@ -46,7 +46,7 @@ class BitcoinReceiverTest extends TestCase
             '/v1/bitcoin/receivers'
         );
         $resources = BitcoinReceiver::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertSame(\Stripe\BitcoinReceiver::class, get_class($resources->data[0]));
     }
 

--- a/tests/Stripe/CapabilityTest.php
+++ b/tests/Stripe/CapabilityTest.php
@@ -16,11 +16,10 @@ class CapabilityTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyRetrievable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Capability::retrieve(self::TEST_RESOURCE_ID);
     }
 
@@ -36,11 +35,10 @@ class CapabilityTest extends TestCase
         $this->assertInstanceOf(\Stripe\Capability::class, $resource);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyUpdatable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Capability::update(self::TEST_RESOURCE_ID, ["requested" => true]);
     }
 }

--- a/tests/Stripe/CardTest.php
+++ b/tests/Stripe/CardTest.php
@@ -51,11 +51,10 @@ class CardTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyRetrievable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Card::retrieve(self::TEST_RESOURCE_ID);
     }
 
@@ -71,11 +70,10 @@ class CardTest extends TestCase
         $this->assertSame(\Stripe\Card::class, get_class($resource));
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyUpdatable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Card::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -13,7 +13,7 @@ class ChargeTest extends TestCase
             '/v1/charges'
         );
         $resources = Charge::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Charge::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -19,12 +19,11 @@ class CollectionTest extends TestCase
         ]);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp /You tried to access the \d index/
-     */
     public function testOffsetGetNumericIndex()
     {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('/You tried to access the \\d index/');
+
         $this->fixture[0];
     }
 
@@ -45,7 +44,7 @@ class CollectionTest extends TestCase
         );
 
         $resources = $this->fixture->all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testCanRetrieve()

--- a/tests/Stripe/CountrySpecTest.php
+++ b/tests/Stripe/CountrySpecTest.php
@@ -13,7 +13,7 @@ class CountrySpecTest extends TestCase
             '/v1/country_specs'
         );
         $resources = CountrySpec::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\CountrySpec::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/CouponTest.php
+++ b/tests/Stripe/CouponTest.php
@@ -13,7 +13,7 @@ class CouponTest extends TestCase
             '/v1/coupons'
         );
         $resources = Coupon::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/CreditNoteTest.php
+++ b/tests/Stripe/CreditNoteTest.php
@@ -13,7 +13,7 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes'
         );
         $resources = CreditNote::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\CreditNote::class, $resources->data[0]);
     }
 
@@ -97,6 +97,6 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes/' . self::TEST_RESOURCE_ID . '/lines'
         );
         $resources = CreditNote::allLines(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -16,7 +16,7 @@ class CustomerTest extends TestCase
             '/v1/customers'
         );
         $resources = Customer::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Customer::class, $resources->data[0]);
     }
 
@@ -131,7 +131,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
         );
         $resources = Customer::allSources(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testSerializeSourceString()
@@ -207,7 +207,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids'
         );
         $resources = Customer::allTaxIds(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateBalanceTransaction()
@@ -247,6 +247,6 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions'
         );
         $resources = Customer::allBalanceTransactions(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/DisputeTest.php
+++ b/tests/Stripe/DisputeTest.php
@@ -13,7 +13,7 @@ class DisputeTest extends TestCase
             '/v1/disputes'
         );
         $resources = Dispute::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Dispute::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/EphemeralKeyTest.php
+++ b/tests/Stripe/EphemeralKeyTest.php
@@ -18,11 +18,10 @@ class EphemeralKeyTest extends TestCase
         $this->assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testIsNotCreatableWithoutAnExplicitApiVersion()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $resource = EphemeralKey::create([
             "customer" => "cus_123",
         ]);

--- a/tests/Stripe/EventTest.php
+++ b/tests/Stripe/EventTest.php
@@ -13,7 +13,7 @@ class EventTest extends TestCase
             '/v1/events'
         );
         $resources = Event::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Event::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/ExchangeRateTest.php
+++ b/tests/Stripe/ExchangeRateTest.php
@@ -30,7 +30,7 @@ class ExchangeRateTest extends TestCase
         );
 
         $listRates = ExchangeRate::all();
-        $this->assertTrue(is_array($listRates->data));
+        $this->assertInternalType('array', $listRates->data);
         $this->assertEquals('exchange_rate', $listRates->data[0]->object);
     }
 

--- a/tests/Stripe/FileLinkTest.php
+++ b/tests/Stripe/FileLinkTest.php
@@ -13,7 +13,7 @@ class FileLinkTest extends TestCase
             '/v1/file_links'
         );
         $resources = FileLink::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\FileLink::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/FileTest.php
+++ b/tests/Stripe/FileTest.php
@@ -13,7 +13,7 @@ class FileTest extends TestCase
             '/v1/files'
         );
         $resources = File::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\File::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -131,7 +131,8 @@ class CurlClientTest extends \Stripe\TestCase
         $withBadClosure = new CurlClient(function () {
             return 'thisShouldNotWork';
         });
-        $this->setExpectedException('Stripe\Exception\UnexpectedValueException', "Non-array value returned by defaultOptions CurlClient callback");
+        $this->expectException('Stripe\Exception\UnexpectedValueException');
+        $this->expectExceptionMessage("Non-array value returned by defaultOptions CurlClient callback");
         $withBadClosure->request('get', 'https://httpbin.org/status/200', [], [], false);
     }
 
@@ -325,7 +326,7 @@ class CurlClientTest extends \Stripe\TestCase
             $curl->setRequestStatusCallback(function ($rbody, $rcode, $rheaders, $errno, $message, $willBeRetried, $numRetries) use (&$called) {
                 $called = true;
 
-                $this->assertTrue(is_string($rbody));
+                $this->assertInternalType('string', $rbody);
                 $this->assertEquals(200, $rcode);
                 $this->assertEquals('req_123', $rheaders['request-id']);
                 $this->assertEquals(0, $errno);

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -13,7 +13,7 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems'
         );
         $resources = InvoiceItem::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -14,7 +14,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices'
         );
         $resources = Invoice::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Invoice::class, $resources->data[0]);
     }
 
@@ -152,6 +152,6 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID . '/lines'
         );
         $resources = Invoice::allLines(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/Issuing/AuthorizationTest.php
+++ b/tests/Stripe/Issuing/AuthorizationTest.php
@@ -13,7 +13,7 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations'
         );
         $resources = Authorization::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Issuing/CardTest.php
+++ b/tests/Stripe/Issuing/CardTest.php
@@ -13,7 +13,7 @@ class CardTest extends \Stripe\TestCase
             '/v1/issuing/cards'
         );
         $resources = Card::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Issuing/CardholderTest.php
+++ b/tests/Stripe/Issuing/CardholderTest.php
@@ -37,7 +37,7 @@ class CardholderTest extends \Stripe\TestCase
             '/v1/issuing/cardholders'
         );
         $resources = Cardholder::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Issuing/DisputeTest.php
+++ b/tests/Stripe/Issuing/DisputeTest.php
@@ -29,7 +29,7 @@ class DisputeTest extends \Stripe\TestCase
             '/v1/issuing/disputes'
         );
         $resources = Dispute::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Issuing/TransactionTest.php
+++ b/tests/Stripe/Issuing/TransactionTest.php
@@ -13,7 +13,7 @@ class TransactionTest extends \Stripe\TestCase
             '/v1/issuing/transactions'
         );
         $resources = Transaction::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Issuing\Transaction::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/OAuthTest.php
+++ b/tests/Stripe/OAuthTest.php
@@ -30,12 +30,11 @@ class OAuthTest extends TestCase
         $this->assertSame('US', $params['stripe_user']['country']);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\AuthenticationException
-     * @expectedExceptionMessageRegExp #No client_id provided#
-     */
     public function testRaisesAuthenticationErrorWhenNoClientId()
     {
+        $this->expectException(\Stripe\Exception\AuthenticationException::class);
+        $this->expectExceptionMessageRegExp('#No client_id provided#');
+
         Stripe::setClientId(null);
         OAuth::authorizeUrl();
     }

--- a/tests/Stripe/OrderReturnTest.php
+++ b/tests/Stripe/OrderReturnTest.php
@@ -13,7 +13,7 @@ class OrderReturnTest extends TestCase
             '/v1/order_returns'
         );
         $resources = OrderReturn::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\OrderReturn::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -13,7 +13,7 @@ class OrderTest extends TestCase
             '/v1/orders'
         );
         $resources = Order::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Order::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -13,7 +13,7 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents'
         );
         $resources = PaymentIntent::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/PaymentMethodTest.php
+++ b/tests/Stripe/PaymentMethodTest.php
@@ -16,7 +16,7 @@ class PaymentMethodTest extends TestCase
             'customer' => 'cus_123',
             'type' => 'card',
         ]);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -13,7 +13,7 @@ class PayoutTest extends TestCase
             '/v1/payouts'
         );
         $resources = Payout::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Payout::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/PersonTest.php
+++ b/tests/Stripe/PersonTest.php
@@ -16,11 +16,10 @@ class PersonTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyRetrievable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Person::retrieve(self::TEST_RESOURCE_ID);
     }
 
@@ -36,11 +35,10 @@ class PersonTest extends TestCase
         $this->assertSame(\Stripe\Person::class, get_class($resource));
     }
 
-    /**
-     * @expectedException \Stripe\Exception\BadMethodCallException
-     */
     public function testIsNotDirectlyUpdatable()
     {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+
         Person::update(self::TEST_RESOURCE_ID, [
             "first_name" => ["John"],
         ]);

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -13,7 +13,7 @@ class PlanTest extends TestCase
             '/v1/plans'
         );
         $resources = Plan::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Plan::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -13,7 +13,7 @@ class ProductTest extends TestCase
             '/v1/products'
         );
         $resources = Product::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Product::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Radar/EarlyFraudWarningTest.php
+++ b/tests/Stripe/Radar/EarlyFraudWarningTest.php
@@ -13,7 +13,7 @@ class EarlyFraudWarningTest extends \Stripe\TestCase
             '/v1/radar/early_fraud_warnings'
         );
         $resources = EarlyFraudWarning::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Radar/ValueListItemTest.php
+++ b/tests/Stripe/Radar/ValueListItemTest.php
@@ -15,7 +15,7 @@ class ValueListItemTest extends \Stripe\TestCase
         $resources = ValueListItem::all([
             "value_list" => "rsl_123",
         ]);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Radar/ValueListTest.php
+++ b/tests/Stripe/Radar/ValueListTest.php
@@ -13,7 +13,7 @@ class ValueListTest extends \Stripe\TestCase
             '/v1/radar/value_lists'
         );
         $resources = ValueList::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -13,7 +13,7 @@ class RecipientTest extends TestCase
             '/v1/recipients'
         );
         $resources = Recipient::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Recipient::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -13,7 +13,7 @@ class RefundTest extends TestCase
             '/v1/refunds'
         );
         $resources = Refund::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Refund::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Reporting/ReportRunTest.php
+++ b/tests/Stripe/Reporting/ReportRunTest.php
@@ -31,7 +31,7 @@ class ReportRunTest extends \Stripe\TestCase
             '/v1/reporting/report_runs'
         );
         $resources = ReportRun::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Reporting/ReportTypeTest.php
+++ b/tests/Stripe/Reporting/ReportTypeTest.php
@@ -13,7 +13,7 @@ class ReportTypeTest extends \Stripe\TestCase
             '/v1/reporting/report_types'
         );
         $resources = ReportType::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Reporting\ReportType::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/ReviewTest.php
+++ b/tests/Stripe/ReviewTest.php
@@ -24,7 +24,7 @@ class ReviewTest extends \Stripe\TestCase
             '/v1/reviews'
         );
         $resources = Review::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Review::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -13,7 +13,7 @@ class SKUTest extends TestCase
             '/v1/skus'
         );
         $resources = SKU::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SKU::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/SetupIntentTest.php
+++ b/tests/Stripe/SetupIntentTest.php
@@ -13,7 +13,7 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents'
         );
         $resources = SetupIntent::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SetupIntent::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Sigma/ScheduledQueryRunTest.php
+++ b/tests/Stripe/Sigma/ScheduledQueryRunTest.php
@@ -9,7 +9,7 @@ class ScheduledQueryRunTest extends \Stripe\TestCase
     public function testIsListable()
     {
         $resources = ScheduledQueryRun::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -100,11 +100,10 @@ class SourceTest extends TestCase
         $this->assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\UnexpectedValueException
-     */
     public function testIsNotDetachableWhenUnattached()
     {
+        $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
+
         $resource = Source::retrieve(self::TEST_RESOURCE_ID);
         $resource->detach();
     }
@@ -117,7 +116,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . $source->id . "/source_transactions"
         );
         $resources = $source->sourceTransactions();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
     }
 
@@ -128,7 +127,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID . "/source_transactions"
         );
         $resources = Source::allSourceTransactions(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -60,16 +60,16 @@ class StripeObjectTest extends TestCase
     public function testCount()
     {
         $s = new StripeObject();
-        $this->assertSame(0, count($s));
+        $this->assertCount(0, $s);
 
         $s['key1'] = 'value1';
-        $this->assertSame(1, count($s));
+        $this->assertCount(1, $s);
 
         $s['key2'] = 'value2';
-        $this->assertSame(2, count($s));
+        $this->assertCount(2, $s);
 
         unset($s['key1']);
-        $this->assertSame(1, count($s));
+        $this->assertCount(1, $s);
     }
 
     public function testKeys()
@@ -169,20 +169,18 @@ EOS;
         $this->assertSame($s->metadata, ['baz', 'qux']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetPermanentAttribute()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $s = new StripeObject();
         $s->id = 'abc_123';
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetEmptyStringValue()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $s = new StripeObject();
         $s->foo = '';
     }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -18,7 +18,7 @@ class SubscriptionItemTest extends TestCase
         $resources = SubscriptionItem::all([
             "subscription" => "sub_123"
         ]);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resources->data[0]);
     }
 
@@ -101,7 +101,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id . "/usage_record_summaries"
         );
         $resources = $resource->usageRecordSummaries();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
     }
 
@@ -112,7 +112,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . self::TEST_RESOURCE_ID . "/usage_record_summaries"
         );
         $resources =SubscriptionItem::allUsageRecordSummaries(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/SubscriptionScheduleTest.php
+++ b/tests/Stripe/SubscriptionScheduleTest.php
@@ -14,7 +14,7 @@ class SubscriptionScheduleTest extends TestCase
             '/v1/subscription_schedules'
         );
         $resources = SubscriptionSchedule::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -13,7 +13,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions'
         );
         $resources = Subscription::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Subscription::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/TaxRateTest.php
+++ b/tests/Stripe/TaxRateTest.php
@@ -13,7 +13,7 @@ class TaxRateTest extends TestCase
             '/v1/tax_rates'
         );
         $resources = TaxRate::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\TaxRate::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Terminal/LocationTest.php
+++ b/tests/Stripe/Terminal/LocationTest.php
@@ -13,7 +13,7 @@ class LocationTest extends \Stripe\TestCase
             '/v1/terminal/locations'
         );
         $resources = Location::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/Terminal/ReaderTest.php
+++ b/tests/Stripe/Terminal/ReaderTest.php
@@ -13,7 +13,7 @@ class ReaderTest extends \Stripe\TestCase
             '/v1/terminal/readers'
         );
         $resources = Reader::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/TopupTest.php
+++ b/tests/Stripe/TopupTest.php
@@ -13,7 +13,7 @@ class TopupTest extends TestCase
             '/v1/topups'
         );
         $resources = Topup::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Topup::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -14,7 +14,7 @@ class TransferTest extends TestCase
             '/v1/transfers'
         );
         $resources = Transfer::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\Transfer::class, $resources->data[0]);
     }
 
@@ -123,7 +123,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
         );
         $resources = Transfer::allReversals(self::TEST_RESOURCE_ID);
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\TransferReversal::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/Util/CaseInsensitiveArrayTest.php
+++ b/tests/Stripe/Util/CaseInsensitiveArrayTest.php
@@ -27,7 +27,7 @@ class CaseInsensitiveArrayTest extends \Stripe\TestCase
     {
         $arr = new CaseInsensitiveArray(["One" => "1", "TWO" => "2"]);
 
-        $this->assertSame(2, count($arr));
+        $this->assertCount(2, $arr);
     }
 
     public function testIterable()

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -59,11 +59,10 @@ class RequestOptionsTest extends \Stripe\TestCase
         $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
-    /**
-     * @expectedException Stripe\Exception\InvalidArgumentException
-     */
     public function testWrongType()
     {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+
         $opts = RequestOptions::parse(5);
     }
 

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -31,7 +31,7 @@ class UtilTest extends \Stripe\TestCase
             ],
             null
         );
-        $this->assertTrue(array_key_exists("id", $customer->toArray()));
+        $this->assertArrayHasKey("id", $customer->toArray());
     }
 
     public function testUtf8()

--- a/tests/Stripe/WebhookEndpointTest.php
+++ b/tests/Stripe/WebhookEndpointTest.php
@@ -13,7 +13,7 @@ class WebhookEndpointTest extends TestCase
             '/v1/webhook_endpoints'
         );
         $resources = WebhookEndpoint::all();
-        $this->assertTrue(is_array($resources->data));
+        $this->assertInternalType('array', $resources->data);
         $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resources->data[0]);
     }
 

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -31,71 +31,64 @@ class WebhookTest extends TestCase
         $this->assertEquals("evt_test_webhook", $event->id);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\UnexpectedValueException
-     */
     public function testInvalidJson()
     {
+        $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
+
         $payload = "this is not valid JSON";
         $sigHeader = $this->generateHeader(["payload" => $payload]);
         Webhook::constructEvent($payload, $sigHeader, self::SECRET);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     */
     public function testValidJsonAndInvalidHeader()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+
         $sigHeader = "bad_header";
         Webhook::constructEvent(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     * @expectedExceptionMessage Unable to extract timestamp and signatures from header
-     */
     public function testMalformedHeader()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('Unable to extract timestamp and signatures from header');
+
         $sigHeader = "i'm not even a real signature header";
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     * @expectedExceptionMessage No signatures found with expected scheme
-     */
     public function testNoSignaturesWithExpectedScheme()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('No signatures found with expected scheme');
+
         $sigHeader = $this->generateHeader(["scheme" => "v0"]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     * @expectedExceptionMessage No signatures found matching the expected signature for payload
-     */
     public function testNoValidSignatureForPayload()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
+
         $sigHeader = $this->generateHeader(["signature" => "bad_signature"]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     * @expectedExceptionMessage Timestamp outside the tolerance zone
-     */
     public function testTimestampTooOld()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('Timestamp outside the tolerance zone');
+
         $sigHeader = $this->generateHeader(["timestamp" => time() - 15]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10);
     }
 
-    /**
-     * @expectedException \Stripe\Exception\SignatureVerificationException
-     * @expectedExceptionMessage Timestamp outside the tolerance zone
-     */
     public function testTimestampTooRecent()
     {
+        $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('Timestamp outside the tolerance zone');
+
         $sigHeader = $this->generateHeader(["timestamp" => time() + 15]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,7 @@ namespace Stripe;
 /**
  * Base class for Stripe test cases.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /** @var string original API base URL */
     protected $origApiBase;


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 

Similar to #846, this is the result of running `./vendor/bin/php-cs-fixer fix --allow-risky=yes --rules=@PHPUnit57Migration:risky .` to upgrade our tests to use the proper syntax for PHPUnit 5.7 (our current version).

Changes:
- `$this->assertTrue(is_array($foo))` --> `$this->assertInternalType('array', $foo)`
- `@expectedException` magic comment -> `$this->expectException()`
- `$this->setExpectedException()` -> `$this->expectException()` + `$this->expectExceptionMessage()`
- `$this->assertSame(42, count($foo));` -> `$this->assertCount(42, $foo);`
- `$this->assertTrue(array_key_exists("key", $arr))` -> `$this->assertArrayHasKey("key", $arr);`
- `\PHPUnit_Framework_TestCase` -> `\PHPUnit\Framework\TestCase`