### PR TITLE
Upgrade PHPStan and fix settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ clover.xml
 # Ignore PHP CS Fixer local config and cache
 .php_cs
 .php_cs.cache
+
+# Ignore PHPStan local config
+.phpstan.neon

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export PHPSTAN_VERSION := 0.11.19
+export PHPSTAN_VERSION := 0.12.8
 
 vendor: composer.json
 	composer install
@@ -14,9 +14,9 @@ fmt: vendor
 .PHONY: fmt
 
 phpstan: vendor
-	vendor/bin/phpstan analyse -c phpstan.neon lib tests
+	vendor/bin/phpstan analyse lib tests
 .PHONY: phpstan
 
 phpstan-baseline: vendor
-	vendor/bin/phpstan analyse -c phpstan.neon --error-format baselineNeon lib tests > phpstan-baseline.neon
+	vendor/bin/phpstan analyse --error-format baselineNeon lib tests > phpstan-baseline.neon
 .PHONY: phpstan-baseline

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,0 @@
-includes:
-	- phpstan-baseline.neon
-
-parameters:
-	level: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 1
+
+	bootstrap: tests/bootstrap.php
+
+	ignoreErrors:
+		- '#Unsafe usage of new static\(\).#'


### PR DESCRIPTION
r? @remi-stripe 

A few changes to PHPStan:
- upgrade to latest version 0.12.8
- rename `phpstan.neon` to `phpstan.neon.dist` and add `phpstan.neon` to `.gitignore` (so one can play with custom settings locally)
- add `tests/bootstrap.php` to the `bootstrap` setting, otherwise the `MOCK_URL` constant is seen as missing
- ignore the `Unsafe usage of new static().` error. We're relying pretty heavily on this right now. We should be able to fix most of these once we stop relying on traits
