### PR TITLE
Docstrings: StripeObject -> ErrorObject where appropriate

### DIFF
--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -23,7 +23,7 @@ namespace Stripe;
  * @property string|null $customer
  * @property string|null $description
  * @property string|null $invoice
- * @property \Stripe\StripeObject|null $last_payment_error
+ * @property \Stripe\ErrorObject|null $last_payment_error
  * @property bool $livemode
  * @property \Stripe\StripeObject $metadata
  * @property \Stripe\StripeObject|null $next_action

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -13,7 +13,7 @@ namespace Stripe;
  * @property int $created
  * @property string|null $customer
  * @property string|null $description
- * @property \Stripe\StripeObject|null $last_setup_error
+ * @property \Stripe\ErrorObject|null $last_setup_error
  * @property bool $livemode
  * @property string|null $mandate
  * @property \Stripe\StripeObject $metadata


### PR DESCRIPTION
r? @ob-stripe 
PaymentIntent.last_payment_error and SetupIntent.last_setup_error should be \Stripe\StripeError, not \Stripe\StripeObject.
[Reported by](https://github.com/stripe/stripe-php/pull/841#pullrequestreview-352064828) @ruudk. 