### PR TITLE
Use PHP-CS-Fixer rules to improve PHPDoc

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'linebreak_after_opening_tag' => true,
         'native_function_invocation' => true,
         'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_indent' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -28,5 +28,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_last',
         ],
+        'phpdoc_var_annotation_correct_order' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
         'phpdoc_no_empty_return' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,5 +21,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
+        'phpdoc_single_line_var_spacing' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_return_self_reference' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,5 +23,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_scalar' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
+        'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -19,6 +19,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_access' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         ],
         'linebreak_after_opening_tag' => true,
         'native_function_invocation' => true,
+        'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,5 +22,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
         'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_trim' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,6 +16,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
+        'phpdoc_no_access' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,6 +15,7 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_indent' => true,
+        'phpdoc_inline_tag' => true,
         'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -25,5 +25,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+        ],
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,5 +24,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,5 +13,6 @@ return PhpCsFixer\Config::create()
         ],
         'linebreak_after_opening_tag' => true,
         'native_function_invocation' => true,
+        'phpdoc_scalar' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -29,5 +29,6 @@ return PhpCsFixer\Config::create()
             'null_adjustment' => 'always_last',
         ],
         'phpdoc_var_annotation_correct_order' => true,
+        'phpdoc_var_without_name' => true,
     ])
 ;

--- a/lib/AlipayAccount.php
+++ b/lib/AlipayAccount.php
@@ -8,7 +8,7 @@ namespace Stripe;
  * @package Stripe
  *
  * @deprecated Alipay accounts are deprecated. Please use the sources API instead.
- * @link https://stripe.com/docs/sources/alipay
+ * @see https://stripe.com/docs/sources/alipay
  */
 class AlipayAccount extends ApiResource
 {
@@ -43,7 +43,7 @@ class AlipayAccount extends ApiResource
      * @throws \Stripe\Exception\BadMethodCallException
      *
      * @deprecated Alipay accounts are deprecated. Please use the sources API instead.
-     * @link https://stripe.com/docs/sources/alipay
+     * @see https://stripe.com/docs/sources/alipay
      */
     public static function retrieve($_id, $_opts = null)
     {
@@ -61,7 +61,7 @@ class AlipayAccount extends ApiResource
      * @throws \Stripe\Exception\BadMethodCallException
      *
      * @deprecated Alipay accounts are deprecated. Please use the sources API instead.
-     * @link https://stripe.com/docs/sources/alipay
+     * @see https://stripe.com/docs/sources/alipay
      */
     public static function update($_id, $_params = null, $_options = null)
     {

--- a/lib/ApiOperations/Request.php
+++ b/lib/ApiOperations/Request.php
@@ -10,7 +10,7 @@ namespace Stripe\ApiOperations;
 trait Request
 {
     /**
-     * @param array|null|mixed $params The list of parameters to validate
+     * @param array|mixed|null $params The list of parameters to validate
      *
      * @throws \Stripe\Exception\InvalidArgumentException if $params exists and is not an array
      */

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -46,9 +46,11 @@ class ApiRequestor
 
     /**
      * Creates a telemetry json blob for use in 'X-Stripe-Client-Telemetry' headers
+     *
      * @static
      *
      * @param RequestTelemetry $requestTelemetry
+     *
      * @return string
      */
     private static function _telemetryJson($requestTelemetry)

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -71,9 +71,9 @@ class ApiRequestor
     /**
      * @static
      *
-     * @param ApiResource|bool|array|mixed $d
+     * @param ApiResource|array|bool|mixed $d
      *
-     * @return ApiResource|array|string|mixed
+     * @return ApiResource|array|mixed|string
      */
     private static function _encodeObjects($d)
     {
@@ -194,7 +194,7 @@ class ApiRequestor
     /**
      * @static
      *
-     * @param string|bool $rbody
+     * @param bool|string $rbody
      * @param int         $rcode
      * @param array       $rheaders
      * @param array       $resp
@@ -227,9 +227,9 @@ class ApiRequestor
     /**
      * @static
      *
-     * @param null|array $appInfo
+     * @param array|null $appInfo
      *
-     * @return null|string
+     * @return string|null
      */
     private static function _formatAppInfo($appInfo)
     {

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -28,7 +28,7 @@ abstract class ApiResource extends StripeObject
     }
 
     /**
-     * @var boolean A flag that can be set a behavior that will cause this
+     * @var bool A flag that can be set a behavior that will cause this
      * resource to be encoded and sent up along with an update of its parent
      * resource. This is usually not desirable because resources are updated
      * individually on their own endpoints, but there are certain cases,

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -88,6 +88,10 @@ abstract class ApiResource extends StripeObject
     }
 
     /**
+     * @param string|null $id the ID of the resource
+     *
+     * @throws Exception\UnexpectedValueException if $id is null
+     *
      * @return string The instance endpoint URL for the given class.
      */
     public static function resourceUrl($id)

--- a/lib/ApiResponse.php
+++ b/lib/ApiResponse.php
@@ -33,7 +33,7 @@ class ApiResponse
 
     /**
      * @param string $body
-     * @param integer $code
+     * @param int $code
      * @param array|CaseInsensitiveArray|null $headers
      * @param array|null $json
      */

--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -23,6 +23,7 @@ class Capability extends ApiResource
 
     /**
      * Possible string representations of a capability's status.
+     *
      * @link https://stripe.com/docs/api/capabilities/object#capability_object-status
      */
     const STATUS_ACTIVE      = 'active';

--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -24,7 +24,7 @@ class Capability extends ApiResource
     /**
      * Possible string representations of a capability's status.
      *
-     * @link https://stripe.com/docs/api/capabilities/object#capability_object-status
+     * @see https://stripe.com/docs/api/capabilities/object#capability_object-status
      */
     const STATUS_ACTIVE      = 'active';
     const STATUS_INACTIVE    = 'inactive';

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -168,7 +168,7 @@ class Collection extends StripeObject implements \IteratorAggregate
     /**
      * Returns true if the page object contains no element.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty()
     {

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -158,6 +158,7 @@ class Collection extends StripeObject implements \IteratorAggregate
      * behavior of the API when it attempts to return a page beyond the last.
      *
      * @param array|string|null $opts
+     *
      * @return Collection
      */
     public static function emptyCollection($opts = null)
@@ -183,6 +184,7 @@ class Collection extends StripeObject implements \IteratorAggregate
      *
      * @param array|null $params
      * @param array|string|null $opts
+     *
      * @return Collection
      */
     public function nextPage($params = null, $opts = null)
@@ -210,6 +212,7 @@ class Collection extends StripeObject implements \IteratorAggregate
      *
      * @param array|null $params
      * @param array|string|null $opts
+     *
      * @return Collection
      */
     public function previousPage($params = null, $opts = null)

--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -27,6 +27,7 @@ class CustomerBalanceTransaction extends ApiResource
 
     /**
      * Possible string representations of a balance transaction's type.
+     *
      * @link https://stripe.com/docs/api/customers/customer_balance_transaction_object#customer_balance_transaction_object-type
      */
     const TYPE_ADJUSTEMENT             = 'adjustment';

--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -28,7 +28,7 @@ class CustomerBalanceTransaction extends ApiResource
     /**
      * Possible string representations of a balance transaction's type.
      *
-     * @link https://stripe.com/docs/api/customers/customer_balance_transaction_object#customer_balance_transaction_object-type
+     * @see https://stripe.com/docs/api/customers/customer_balance_transaction_object#customer_balance_transaction_object-type
      */
     const TYPE_ADJUSTEMENT             = 'adjustment';
     const TYPE_APPLIED_TO_INVOICE      = 'applied_to_invoice';

--- a/lib/ErrorObject.php
+++ b/lib/ErrorObject.php
@@ -38,6 +38,7 @@ class ErrorObject extends StripeObject
 {
     /**
      * Possible string representations of an error's code.
+     *
      * @link https://stripe.com/docs/error-codes
      */
     const CODE_ACCOUNT_ALREADY_EXISTS                     = 'account_already_exists';

--- a/lib/ErrorObject.php
+++ b/lib/ErrorObject.php
@@ -137,7 +137,7 @@ class ErrorObject extends StripeObject
      *
      * @param array $values
      * @param null|string|array|Util\RequestOptions $opts
-     * @param boolean $partial Defaults to false.
+     * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)
     {

--- a/lib/ErrorObject.php
+++ b/lib/ErrorObject.php
@@ -136,7 +136,7 @@ class ErrorObject extends StripeObject
      * Refreshes this object using the provided values.
      *
      * @param array $values
-     * @param null|string|array|Util\RequestOptions $opts
+     * @param array|string|Util\RequestOptions|null $opts
      * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)

--- a/lib/ErrorObject.php
+++ b/lib/ErrorObject.php
@@ -39,7 +39,7 @@ class ErrorObject extends StripeObject
     /**
      * Possible string representations of an error's code.
      *
-     * @link https://stripe.com/docs/error-codes
+     * @see https://stripe.com/docs/error-codes
      */
     const CODE_ACCOUNT_ALREADY_EXISTS                     = 'account_already_exists';
     const CODE_ACCOUNT_COUNTRY_INVALID_ADDRESS            = 'account_country_invalid_address';

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -14,6 +14,7 @@ interface ClientInterface
      *
      * @throws \Stripe\Exception\ApiConnectionException
      * @throws \Stripe\Exception\UnexpectedValueException
+     *
      * @return array An array whose first element is raw request body, second
      *    element is HTTP status code and third array of HTTP headers.
      */

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -9,7 +9,7 @@ interface ClientInterface
      * @param string $absUrl The URL being requested, including domain and protocol
      * @param array $headers Headers to be used in the request (full strings, not KV pairs)
      * @param array $params KV pairs for parameters. Can be nested for arrays and hashes
-     * @param boolean $hasFile Whether or not $params references a file (via an @ prefix or
+     * @param bool $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CURLFile)
      *
      * @throws \Stripe\Exception\ApiConnectionException

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -343,6 +343,7 @@ class CurlClient implements ClientInterface
      * @param int $errno
      * @param string $message
      * @param int $numRetries
+     *
      * @throws Exception\ApiConnectionException
      */
     private function handleCurlError($url, $errno, $message, $numRetries)
@@ -521,6 +522,7 @@ class CurlClient implements ClientInterface
      *
      * @param string[] $headers
      * @param string $name
+     *
      * @return bool
      */
     private function hasHeader($headers, $name)

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -63,6 +63,7 @@ class CurlClient implements ClientInterface
      * throw an exception if $defaultOptions returns a non-array value.
      *
      * @param array|callable|null $defaultOptions
+     * @param \Stripe\Util\RandomGenerator|null $randomGenerator
      */
     public function __construct($defaultOptions = null, $randomGenerator = null)
     {
@@ -273,6 +274,7 @@ class CurlClient implements ClientInterface
 
     /**
      * @param array $opts cURL options
+     * @param string $absUrl
      */
     private function executeRequestWithRetries($opts, $absUrl)
     {

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -98,7 +98,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getEnablePersistentConnections()
     {
@@ -106,7 +106,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * @param boolean $enable
+     * @param bool $enable
      */
     public function setEnablePersistentConnections($enable)
     {
@@ -114,7 +114,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function getEnableHttp2()
     {
@@ -122,7 +122,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * @param boolean $enable
+     * @param bool $enable
      */
     public function setEnableHttp2($enable)
     {
@@ -504,7 +504,7 @@ class CurlClient implements ClientInterface
     /**
      * Indicates whether it is safe to use HTTP/2 or not.
      *
-     * @return boolean
+     * @return bool
      */
     private function canSafelyUseHttp2()
     {
@@ -519,7 +519,7 @@ class CurlClient implements ClientInterface
      *
      * @param string[] $headers
      * @param string $name
-     * @return boolean
+     * @return bool
      */
     private function hasHeader($headers, $name)
     {

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -114,8 +114,8 @@ class Invoice extends ApiResource
 
     /**
      * Possible string representations of the `billing` property.
-     * @deprecated Use `collection_method` instead.
      *
+     * @deprecated Use `collection_method` instead.
      * @see https://stripe.com/docs/api/invoices/object#invoice_object-billing
      */
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';

--- a/lib/OAuthErrorObject.php
+++ b/lib/OAuthErrorObject.php
@@ -16,7 +16,7 @@ class OAuthErrorObject extends StripeObject
      * Refreshes this object using the provided values.
      *
      * @param array $values
-     * @param null|string|array|Util\RequestOptions $opts
+     * @param array|string|Util\RequestOptions|null $opts
      * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)

--- a/lib/OAuthErrorObject.php
+++ b/lib/OAuthErrorObject.php
@@ -17,7 +17,7 @@ class OAuthErrorObject extends StripeObject
      *
      * @param array $values
      * @param null|string|array|Util\RequestOptions $opts
-     * @param boolean $partial Defaults to false.
+     * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)
     {

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -56,7 +56,6 @@ class PaymentIntent extends ApiResource
     /**
      * These constants are possible representations of the status field.
      *
-     *
      * @see https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
      */
     const STATUS_CANCELED                = 'canceled';

--- a/lib/Person.php
+++ b/lib/Person.php
@@ -42,6 +42,7 @@ class Person extends ApiResource
 
     /**
      * Possible string representations of a person's gender.
+     *
      * @link https://stripe.com/docs/api/persons/object#person_object-gender
      */
     const GENDER_MALE   = 'male';
@@ -49,6 +50,7 @@ class Person extends ApiResource
 
     /**
      * Possible string representations of a person's verification status.
+     *
      * @link https://stripe.com/docs/api/persons/object#person_object-verification-status
      */
     const VERIFICATION_STATUS_PENDING    = 'pending';

--- a/lib/Person.php
+++ b/lib/Person.php
@@ -43,7 +43,7 @@ class Person extends ApiResource
     /**
      * Possible string representations of a person's gender.
      *
-     * @link https://stripe.com/docs/api/persons/object#person_object-gender
+     * @see https://stripe.com/docs/api/persons/object#person_object-gender
      */
     const GENDER_MALE   = 'male';
     const GENDER_FEMALE = 'female';
@@ -51,7 +51,7 @@ class Person extends ApiResource
     /**
      * Possible string representations of a person's verification status.
      *
-     * @link https://stripe.com/docs/api/persons/object#person_object-verification-status
+     * @see https://stripe.com/docs/api/persons/object#person_object-verification-status
      */
     const VERIFICATION_STATUS_PENDING    = 'pending';
     const VERIFICATION_STATUS_UNVERIFIED = 'unverified';

--- a/lib/RequestTelemetry.php
+++ b/lib/RequestTelemetry.php
@@ -6,6 +6,7 @@ namespace Stripe;
  * Class RequestTelemetry
  *
  * Tracks client request telemetry
+ *
  * @package Stripe
  */
 class RequestTelemetry

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -40,7 +40,6 @@ class SetupIntent extends ApiResource
     /**
      * These constants are possible representations of the status field.
      *
-     *
      * @see https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status
      */
     const STATUS_CANCELED                = 'canceled';

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -202,8 +202,9 @@ class Stripe
 
     /**
      * @param string $appName The application's name
-     * @param string $appVersion The application's version
-     * @param string $appUrl The application's URL
+     * @param string|null $appVersion The application's version
+     * @param string|null $appUrl The application's URL
+     * @param string|null $appPartnerId The application's partner ID
      */
     public static function setAppInfo($appName, $appVersion = null, $appUrl = null, $appPartnerId = null)
     {

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -159,7 +159,7 @@ class Stripe
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public static function getVerifySslCerts()
     {
@@ -167,7 +167,7 @@ class Stripe
     }
 
     /**
-     * @param boolean $verify
+     * @param bool $verify
      */
     public static function setVerifySslCerts($verify)
     {

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -234,7 +234,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      *
      * @param array $values
      * @param null|string|array|Util\RequestOptions $opts
-     * @param boolean $partial Defaults to false.
+     * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)
     {
@@ -271,7 +271,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      *
      * @param array $values
      * @param null|string|array|Util\RequestOptions $opts
-     * @param boolean $dirty Defaults to true.
+     * @param bool $dirty Defaults to true.
      */
     public function updateAttributes($values, $opts = null, $dirty = true)
     {

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -532,7 +532,6 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      * Sets the last response from the Stripe API
      *
      * @param ApiResponse $resp
-     * @return void
      */
     public function setLastResponse($resp)
     {

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -218,7 +218,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      * This unfortunately needs to be public to be used in Util\Util
      *
      * @param array $values
-     * @param null|string|array|Util\RequestOptions $opts
+     * @param array|string|Util\RequestOptions|null $opts
      *
      * @return static The object constructed from the given values.
      */
@@ -233,7 +233,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      * Refreshes this object using the provided values.
      *
      * @param array $values
-     * @param null|string|array|Util\RequestOptions $opts
+     * @param array|string|Util\RequestOptions|null $opts
      * @param bool $partial Defaults to false.
      */
     public function refreshFrom($values, $opts, $partial = false)
@@ -270,7 +270,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      * Mass assigns attributes on the model.
      *
      * @param array $values
-     * @param null|string|array|Util\RequestOptions $opts
+     * @param array|string|Util\RequestOptions|null $opts
      * @param bool $dirty Defaults to true.
      */
     public function updateAttributes($values, $opts = null, $dirty = true)

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -294,6 +294,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
 
     /**
      * @param bool $force Defaults to false.
+     *
      * @return array A recursive mapping of attributes to values for this object,
      *    including the proper value for deleted attributes.
      */

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -293,6 +293,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     }
 
     /**
+     * @param bool $force Defaults to false.
      * @return array A recursive mapping of attributes to values for this object,
      *    including the proper value for deleted attributes.
      */
@@ -477,6 +478,8 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     /**
      * Produces a deep copy of the given object including support for arrays
      * and StripeObjects.
+     *
+     * @param mixed $obj
      */
     protected static function deepCopy($obj)
     {
@@ -499,6 +502,8 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     /**
      * Returns a hash of empty values for all the values that are in the given
      * StripeObject.
+     *
+     * @param mixed $obj
      */
     public static function emptyValues($obj)
     {

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -55,7 +55,6 @@ class Subscription extends ApiResource
     /**
      * These constants are possible representations of the status field.
      *
-     *
      * @see https://stripe.com/docs/api#subscription_object-status
      */
     const STATUS_ACTIVE             = 'active';

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -26,7 +26,7 @@ class TaxId extends ApiResource
     /**
      * Possible string representations of a tax id's type.
      *
-     * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-type
+     * @see https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-type
      */
     const TYPE_AU_ABN  = 'au_abn';
     const TYPE_CA_BN   = 'ca_bn';
@@ -48,7 +48,7 @@ class TaxId extends ApiResource
     /**
      * Possible string representations of the verification status.
      *
-     * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-verification
+     * @see https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-verification
      */
     const VERIFICATION_STATUS_PENDING     = 'pending';
     const VERIFICATION_STATUS_UNAVAILABLE = 'unavailable';

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -25,6 +25,7 @@ class TaxId extends ApiResource
 
     /**
      * Possible string representations of a tax id's type.
+     *
      * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-type
      */
     const TYPE_AU_ABN  = 'au_abn';
@@ -46,6 +47,7 @@ class TaxId extends ApiResource
 
     /**
      * Possible string representations of the verification status.
+     *
      * @link https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-verification
      */
     const VERIFICATION_STATUS_PENDING     = 'pending';

--- a/lib/Util/LoggerInterface.php
+++ b/lib/Util/LoggerInterface.php
@@ -30,7 +30,6 @@ interface LoggerInterface
      *
      * @param string $message
      * @param array $context
-     * @return void
      */
     public function error($message, array $context = []);
 }

--- a/lib/Util/RandomGenerator.php
+++ b/lib/Util/RandomGenerator.php
@@ -12,6 +12,7 @@ class RandomGenerator
      * Returns a random value between 0 and $max.
      *
      * @param float $max (optional)
+     *
      * @return float
      */
     public function randFloat($max = 1.0)

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -37,6 +37,7 @@ class RequestOptions
     /**
      * Unpacks an options array and merges it into the existing RequestOptions
      * object.
+     *
      * @param array|string|null $options a key => value array
      *
      * @return RequestOptions
@@ -68,6 +69,7 @@ class RequestOptions
 
     /**
      * Unpacks an options array into an RequestOptions object
+     *
      * @param array|string|null $options a key => value array
      *
      * @return RequestOptions

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -15,6 +15,7 @@ abstract class Util
      * integers starting at 0. Empty arrays are considered to be lists.
      *
      * @param array|mixed $array
+     *
      * @return bool true if the given object is a list.
      */
     public static function isList($array)
@@ -36,6 +37,7 @@ abstract class Util
      *
      * @param array $resp The response from the Stripe API.
      * @param array $opts
+     *
      * @return array|StripeObject
      */
     public static function convertToStripeObject($resp, $opts)
@@ -175,6 +177,7 @@ abstract class Util
      *
      * @param string $a one of the strings to compare.
      * @param string $b the other string to compare.
+     *
      * @return bool true if the strings are equal, false otherwise.
      */
     public static function secureCompare($a, $b)
@@ -204,6 +207,7 @@ abstract class Util
      * Also clears out null values.
      *
      * @param mixed $h
+     *
      * @return mixed
      */
     public static function objectsToIds($h)

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -15,7 +15,7 @@ abstract class Util
      * integers starting at 0. Empty arrays are considered to be lists.
      *
      * @param array|mixed $array
-     * @return boolean true if the given object is a list.
+     * @return bool true if the given object is a list.
      */
     public static function isList($array)
     {
@@ -327,7 +327,7 @@ abstract class Util
     /**
      * Returns UNIX timestamp in milliseconds
      *
-     * @return integer current time in millis
+     * @return int current time in millis
      */
     public static function currentTimeMillis()
     {

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -36,7 +36,7 @@ abstract class Util
      *
      * @param array $resp The response from the Stripe API.
      * @param array $opts
-     * @return StripeObject|array
+     * @return array|StripeObject
      */
     public static function convertToStripeObject($resp, $opts)
     {
@@ -144,9 +144,9 @@ abstract class Util
     }
 
     /**
-     * @param string|mixed $value A string to UTF8-encode.
+     * @param mixed|string $value A string to UTF8-encode.
      *
-     * @return string|mixed The UTF8-encoded string, or the object passed in if
+     * @return mixed|string The UTF8-encoded string, or the object passed in if
      *    it wasn't a string.
      */
     public static function utf8($value)

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -18,7 +18,9 @@ abstract class Webhook
      * @param string $secret secret used to generate the signature.
      * @param int $tolerance maximum difference allowed between the header's
      *  timestamp and the current time
+     *
      * @return Event the Event instance
+     *
      * @throws Exception\UnexpectedValueException if the payload is not valid JSON,
      * @throws Exception\SignatureVerificationException if the verification fails.
      */

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -17,7 +17,9 @@ abstract class WebhookSignature
      * @param string $secret secret used to generate the signature.
      * @param int $tolerance maximum difference allowed between the header's
      *  timestamp and the current time
+     *
      * @throws Exception\SignatureVerificationException if the verification fails.
+     *
      * @return bool
      */
     public static function verifyHeader($payload, $header, $secret, $tolerance = null)
@@ -75,6 +77,7 @@ abstract class WebhookSignature
      * Extracts the timestamp in a signature header.
      *
      * @param string $header the signature header
+     *
      * @return int the timestamp contained in the header, or -1 if no valid
      *  timestamp is found
      */
@@ -100,6 +103,7 @@ abstract class WebhookSignature
      *
      * @param string $header the signature header
      * @param string $scheme the signature scheme to look for.
+     *
      * @return array the list of signatures matching the provided scheme.
      */
     private static function getSignatures($header, $scheme)
@@ -124,6 +128,7 @@ abstract class WebhookSignature
      *
      * @param string $payload the payload to sign.
      * @param string $secret the secret used to generate the signature.
+     *
      * @return string the signature as a string.
      */
     private static function computeSignature($payload, $secret)

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -10,13 +10,13 @@ class CurlClientTest extends \Stripe\TestCase
     /** @var \ReflectionProperty */
     private $maxNetworkRetryDelayProperty;
 
-    /** @var double */
+    /** @var float */
     private $origInitialNetworkRetryDelay;
 
     /** @var int */
     private $origMaxNetworkRetries;
 
-    /** @var double */
+    /** @var float */
     private $origMaxNetworkRetryDelay;
 
     /** @var \ReflectionMethod */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -105,7 +105,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param bool $hasFile Whether the request parameters contains a file.
      *   Defaults to false.
      * @param array $response
-     * @param integer $rcode
+     * @param int $rcode
      * @param string|null $base
      *
      * @return array


### PR DESCRIPTION
r? @cjavilla-stripe  @richardm-stripe 
cc @stripe/api-libraries 

Enable a bunch of PHP-CS-Fixer rules to make PHPDoc blocks better/more consistent.

This PR is easier to review commit by commit.
