### PR TITLE
Get closer to @PhpCsFixer standard ruleset

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -106,4 +106,5 @@ return PhpCsFixer\Config::create()
         'standardize_increment' => true,
         'standardize_not_equals' => true,
         'strict_comparison' => true,
+        'strict_param' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -66,5 +66,6 @@ return PhpCsFixer\Config::create()
         'no_null_property_initialization' => true,
         'no_short_bool_cast' => true,
         'no_short_echo_tag' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -47,6 +47,7 @@ return PhpCsFixer\Config::create()
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,
         'native_constant_invocation' => true,
+        'native_function_casing' => true,
         'native_function_invocation' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -87,5 +87,6 @@ return PhpCsFixer\Config::create()
         'php_unit_construct' => true,
         'php_unit_fqcn_annotation' => true,
         'php_unit_method_casing' => true,
+        'php_unit_mock_short_will_return' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -99,5 +99,7 @@ return PhpCsFixer\Config::create()
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'simple_to_complex_string_variable' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_line_comment_style' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -108,4 +108,5 @@ return PhpCsFixer\Config::create()
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,
+        'ternary_operator_spaces' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -91,5 +91,6 @@ return PhpCsFixer\Config::create()
         'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_annotation' => true,
+        'php_unit_test_case_static_method_calls' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -82,5 +82,6 @@ return PhpCsFixer\Config::create()
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
+        'normalize_index_brace' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -92,5 +92,6 @@ return PhpCsFixer\Config::create()
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => true,
+        'psr4' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -105,4 +105,5 @@ return PhpCsFixer\Config::create()
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
+        'strict_comparison' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -62,5 +62,6 @@ return PhpCsFixer\Config::create()
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,
+        'no_multiline_whitespace_around_double_arrow' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -96,5 +96,6 @@ return PhpCsFixer\Config::create()
         'return_assignment' => true,
         'return_type_declaration' => true,
         'semicolon_after_instruction' => true,
+        'set_type_to_cast' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -102,5 +102,6 @@ return PhpCsFixer\Config::create()
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => true,
         'single_trait_insert_per_statement' => true,
+        'space_after_semicolon' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -53,5 +53,6 @@ return PhpCsFixer\Config::create()
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
+        'no_binary_string' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -58,5 +58,6 @@ return PhpCsFixer\Config::create()
         'no_empty_comment' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
+        'no_homoglyph_names' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -107,4 +107,5 @@ return PhpCsFixer\Config::create()
         'standardize_not_equals' => true,
         'strict_comparison' => true,
         'strict_param' => true,
+        'string_line_ending' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -94,5 +94,6 @@ return PhpCsFixer\Config::create()
         'php_unit_test_case_static_method_calls' => true,
         'psr4' => true,
         'return_assignment' => true,
+        'return_type_declaration' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -60,5 +60,6 @@ return PhpCsFixer\Config::create()
         'no_extra_blank_lines' => true,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -75,5 +75,6 @@ return PhpCsFixer\Config::create()
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
+        'no_unset_cast' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -83,5 +83,6 @@ return PhpCsFixer\Config::create()
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,
+        'object_operator_without_whitespace' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -52,5 +52,6 @@ return PhpCsFixer\Config::create()
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
+        'no_alternative_syntax' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -65,5 +65,6 @@ return PhpCsFixer\Config::create()
         'no_multiline_whitespace_around_double_arrow' => true,
         'no_null_property_initialization' => true,
         'no_short_bool_cast' => true,
+        'no_short_echo_tag' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -68,5 +68,6 @@ return PhpCsFixer\Config::create()
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
+        'no_superfluous_elseif' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -57,5 +57,6 @@ return PhpCsFixer\Config::create()
         'no_blank_lines_after_class_opening' => true,
         'no_empty_comment' => true,
         'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -109,4 +109,5 @@ return PhpCsFixer\Config::create()
         'strict_param' => true,
         'string_line_ending' => true,
         'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline_array' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -103,5 +103,5 @@ return PhpCsFixer\Config::create()
         'single_line_comment_style' => true,
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
-    ])
-;
+        'standardize_increment' => true,
+    ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -112,4 +112,5 @@ return PhpCsFixer\Config::create()
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -80,5 +80,6 @@ return PhpCsFixer\Config::create()
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -95,5 +95,6 @@ return PhpCsFixer\Config::create()
         'psr4' => true,
         'return_assignment' => true,
         'return_type_declaration' => true,
+        'semicolon_after_instruction' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -86,5 +86,6 @@ return PhpCsFixer\Config::create()
         'object_operator_without_whitespace' => true,
         'php_unit_construct' => true,
         'php_unit_fqcn_annotation' => true,
+        'php_unit_method_casing' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -73,5 +73,6 @@ return PhpCsFixer\Config::create()
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
+        'no_unneeded_final_method' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -113,4 +113,5 @@ return PhpCsFixer\Config::create()
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'whitespace_after_comma_in_array' => true,
+        'yoda_style' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -71,5 +71,6 @@ return PhpCsFixer\Config::create()
         'no_superfluous_elseif' => true,
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_control_parentheses' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -93,5 +93,6 @@ return PhpCsFixer\Config::create()
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => true,
         'psr4' => true,
+        'return_assignment' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -63,5 +63,6 @@ return PhpCsFixer\Config::create()
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => true,
         'no_multiline_whitespace_around_double_arrow' => true,
+        'no_null_property_initialization' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -76,5 +76,6 @@ return PhpCsFixer\Config::create()
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
+        'no_unused_imports' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -55,5 +55,6 @@ return PhpCsFixer\Config::create()
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
+        'no_empty_comment' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -84,5 +84,6 @@ return PhpCsFixer\Config::create()
         'non_printable_character' => true,
         'normalize_index_brace' => true,
         'object_operator_without_whitespace' => true,
+        'php_unit_construct' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -61,5 +61,6 @@ return PhpCsFixer\Config::create()
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -56,5 +56,6 @@ return PhpCsFixer\Config::create()
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_empty_comment' => true,
+        'no_empty_statement' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -78,5 +78,6 @@ return PhpCsFixer\Config::create()
         'no_unset_cast' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
+        'no_useless_return' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -64,5 +64,6 @@ return PhpCsFixer\Config::create()
         'no_mixed_echo_print' => true,
         'no_multiline_whitespace_around_double_arrow' => true,
         'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -67,5 +67,6 @@ return PhpCsFixer\Config::create()
         'no_short_bool_cast' => true,
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -51,5 +51,6 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => true,
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
+        'no_alias_functions' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -81,5 +81,6 @@ return PhpCsFixer\Config::create()
         'no_useless_return' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
+        'non_printable_character' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -85,5 +85,6 @@ return PhpCsFixer\Config::create()
         'normalize_index_brace' => true,
         'object_operator_without_whitespace' => true,
         'php_unit_construct' => true,
+        'php_unit_fqcn_annotation' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,5 +50,6 @@ return PhpCsFixer\Config::create()
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'native_function_type_declaration_casing' => true,
+        'new_with_braces' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -59,5 +59,6 @@ return PhpCsFixer\Config::create()
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'no_homoglyph_names' => true,
+        'no_leading_import_slash' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -49,5 +49,6 @@ return PhpCsFixer\Config::create()
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
+        'native_function_type_declaration_casing' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -77,5 +77,6 @@ return PhpCsFixer\Config::create()
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unused_imports' => true,
+        'no_useless_else' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -89,5 +89,6 @@ return PhpCsFixer\Config::create()
         'php_unit_method_casing' => true,
         'php_unit_mock_short_will_return' => true,
         'php_unit_ordered_covers' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -110,4 +110,5 @@ return PhpCsFixer\Config::create()
         'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,
+        'trim_array_spaces' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -72,5 +72,6 @@ return PhpCsFixer\Config::create()
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
+        'no_unneeded_curly_braces' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -98,5 +98,6 @@ return PhpCsFixer\Config::create()
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
+        'simple_to_complex_string_variable' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -111,4 +111,5 @@ return PhpCsFixer\Config::create()
         'ternary_operator_spaces' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -90,5 +90,6 @@ return PhpCsFixer\Config::create()
         'php_unit_mock_short_will_return' => true,
         'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => true,
+        'php_unit_test_annotation' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -88,5 +88,6 @@ return PhpCsFixer\Config::create()
         'php_unit_fqcn_annotation' => true,
         'php_unit_method_casing' => true,
         'php_unit_mock_short_will_return' => true,
+        'php_unit_ordered_covers' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -54,5 +54,6 @@ return PhpCsFixer\Config::create()
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
+        'no_blank_lines_after_class_opening' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -74,5 +74,6 @@ return PhpCsFixer\Config::create()
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
+        'no_unreachable_default_argument_value' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -97,5 +97,6 @@ return PhpCsFixer\Config::create()
         'return_type_declaration' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
+        'short_scalar_cast' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -104,4 +104,5 @@ return PhpCsFixer\Config::create()
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
+        'standardize_not_equals' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -79,5 +79,6 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
+        'no_whitespace_before_comma_in_array' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -69,5 +69,6 @@ return PhpCsFixer\Config::create()
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_list_call' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -70,5 +70,6 @@ return PhpCsFixer\Config::create()
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
         'no_trailing_comma_in_list_call' => true,
+        'no_trailing_comma_in_singleline_array' => true,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -101,5 +101,6 @@ return PhpCsFixer\Config::create()
         'simple_to_complex_string_variable' => true,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => true,
+        'single_trait_insert_per_statement' => true,
     ])
 ;

--- a/build.php
+++ b/build.php
@@ -9,7 +9,7 @@ if (!$autoload) {
     // Modify composer to not autoload Stripe
     $composer = \json_decode(\file_get_contents('composer.json'), true);
     unset($composer['autoload'], $composer['autoload-dev']);
-    
+
     \file_put_contents('composer.json', \json_encode($composer, \JSON_PRETTY_PRINT));
 }
 

--- a/build.php
+++ b/build.php
@@ -19,7 +19,7 @@ if ($returnStatus !== 0) {
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
-\passthru("./vendor/bin/phpunit -c ${config}", $returnStatus);
+\passthru("./vendor/bin/phpunit -c {$config}", $returnStatus);
 if ($returnStatus !== 0) {
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -14,12 +14,12 @@ if (!$autoload) {
 }
 
 \passthru('composer update', $returnStatus);
-if ($returnStatus !== 0) {
+if (0 !== $returnStatus) {
     exit(1);
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
 \passthru("./vendor/bin/phpunit -c {$config}", $returnStatus);
-if ($returnStatus !== 0) {
+if (0 !== $returnStatus) {
     exit(1);
 }

--- a/examples/oauth.php
+++ b/examples/oauth.php
@@ -20,8 +20,8 @@ if (isset($_GET['code'])) {
 
     $accountId = $resp->stripe_user_id;
 
-    echo "<p>Success! Account <code>${accountId}</code> is connected.</p>\n";
-    echo "<p>Click <a href=\"?deauth=${accountId}\">here</a> to disconnect the account.</p>\n";
+    echo "<p>Success! Account <code>{$accountId}</code> is connected.</p>\n";
+    echo "<p>Click <a href=\"?deauth={$accountId}\">here</a> to disconnect the account.</p>\n";
 } elseif (isset($_GET['error'])) {
     // The user was redirect back from the OAuth form with an error.
     $error = $_GET['error'];
@@ -47,5 +47,5 @@ if (isset($_GET['code'])) {
     $url = \Stripe\OAuth::authorizeUrl([
         'scope' => 'read_only',
     ]);
-    echo "<a href=\"${url}\">Connect with Stripe</a>\n";
+    echo "<a href=\"{$url}\">Connect with Stripe</a>\n";
 }

--- a/examples/oauth.php
+++ b/examples/oauth.php
@@ -5,7 +5,6 @@ require('../init.php');
 \Stripe\Stripe::setApiKey(\getenv('STRIPE_SECRET_KEY'));
 \Stripe\Stripe::setClientId(\getenv('STRIPE_CLIENT_ID'));
 
-
 if (isset($_GET['code'])) {
     // The user was redirected back from the OAuth form with an authorization code.
     $code = $_GET['code'];

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -201,7 +201,6 @@ class Account extends ApiResource
      * capabilities property which is a hash and not the sub-list of capabilities.
      */
 
-
     const PATH_CAPABILITIES = '/capabilities';
 
     /**

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -77,7 +77,7 @@ class Account extends ApiResource
     public static function getSavedNestedResources()
     {
         static $savedNestedResources = null;
-        if ($savedNestedResources === null) {
+        if (null === $savedNestedResources) {
             $savedNestedResources = new Util\Set([
                 'external_account',
                 'bank_account',
@@ -88,7 +88,7 @@ class Account extends ApiResource
 
     public function instanceUrl()
     {
-        if ($this['id'] === null) {
+        if (null === $this['id']) {
             return '/v1/account';
         }
         return parent::instanceUrl();
@@ -154,7 +154,7 @@ class Account extends ApiResource
      */
     public static function retrieve($id = null, $opts = null)
     {
-        if (!$opts && \is_string($id) && \substr($id, 0, 3) === 'sk_') {
+        if (!$opts && \is_string($id) && 'sk_' === \substr($id, 0, 3)) {
             $opts = $id;
             $id = null;
         }

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -193,7 +193,7 @@ class Account extends ApiResource
         $this->refreshFrom($response, $opts);
         return $this;
     }
-    
+
     /*
      * Capabilities methods
      * We can not add the capabilities() method today as the Account object already has a

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -135,7 +135,7 @@ class Account extends ApiResource
             if ($update !== []) {
                 if (!$originalValue ||
                     !\array_key_exists($i, $originalValue) ||
-                    ($update != $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
+                    ($update !== $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
                     $updateArr[$i] = $update;
                 }
             }

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -90,9 +90,8 @@ class Account extends ApiResource
     {
         if ($this['id'] === null) {
             return '/v1/account';
-        } else {
-            return parent::instanceUrl();
         }
+        return parent::instanceUrl();
     }
 
     public function serializeParameters($force = false)

--- a/lib/AlipayAccount.php
+++ b/lib/AlipayAccount.php
@@ -33,7 +33,7 @@ class AlipayAccount extends ApiResource
         }
         $parentExtn = \urlencode(Util\Util::utf8($parent));
         $extn = \urlencode(Util\Util::utf8($this['id']));
-        return "${base}/${parentExtn}/${path}/${extn}";
+        return "{$base}/{$parentExtn}/{$path}/{$extn}";
     }
 
     /**

--- a/lib/ApiOperations/NestedResource.php
+++ b/lib/ApiOperations/NestedResource.php
@@ -37,7 +37,7 @@ trait NestedResource
     protected static function _nestedResourceUrl($id, $nestedPath, $nestedId = null)
     {
         $url = static::resourceUrl($id) . $nestedPath;
-        if ($nestedId !== null) {
+        if (null !== $nestedId) {
             $url .= "/{$nestedId}";
         }
         return $url;

--- a/lib/ApiOperations/NestedResource.php
+++ b/lib/ApiOperations/NestedResource.php
@@ -38,7 +38,7 @@ trait NestedResource
     {
         $url = static::resourceUrl($id) . $nestedPath;
         if ($nestedId !== null) {
-            $url .= "/${nestedId}";
+            $url .= "/{$nestedId}";
         }
         return $url;
     }

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -61,7 +61,7 @@ class ApiRequestor
         ];
 
         $result = \json_encode($payload);
-        if ($result != false) {
+        if ($result !== false) {
             return $result;
         }
         Stripe::getLogger()->error("Serializing telemetry payload failed!");
@@ -170,10 +170,10 @@ class ApiRequestor
             case 400:
                 // 'rate_limit' code is deprecated, but left here for backwards compatibility
                 // for API versions earlier than 2015-09-08
-                if ($code == 'rate_limit') {
+                if ($code === 'rate_limit') {
                     return Exception\RateLimitException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
                 }
-                if ($type == 'idempotency_error') {
+                if ($type === 'idempotency_error') {
                     return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
                 }
 
@@ -332,7 +332,7 @@ class ApiRequestor
             $defaultHeaders['Stripe-Account'] = Stripe::$accountId;
         }
 
-        if (Stripe::$enableTelemetry && self::$requestTelemetry != null) {
+        if (Stripe::$enableTelemetry && self::$requestTelemetry !== null) {
             $defaultHeaders["X-Stripe-Client-Telemetry"] = self::_telemetryJson(self::$requestTelemetry);
         }
 

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -261,7 +261,7 @@ class ApiRequestor
         $uaString = 'Stripe/v1 PhpBindings/' . Stripe::VERSION;
 
         $langVersion = \PHP_VERSION;
-        $uname_disabled = \in_array('php_uname', \explode(',', \ini_get('disable_functions')));
+        $uname_disabled = \in_array('php_uname', \explode(',', \ini_get('disable_functions')), true);
         $uname = $uname_disabled ? '(disabled)' : \php_uname();
 
         $appInfo = Stripe::getAppInfo();

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -129,8 +129,8 @@ class ApiRequestor
     public function handleErrorResponse($rbody, $rcode, $rheaders, $resp)
     {
         if (!\is_array($resp) || !isset($resp['error'])) {
-            $msg = "Invalid response object from API: ${rbody} "
-              . "(HTTP response code was ${rcode})";
+            $msg = "Invalid response object from API: {$rbody} "
+              . "(HTTP response code was {$rcode})";
             throw new Exception\UnexpectedValueException($msg);
         }
 
@@ -420,8 +420,8 @@ class ApiRequestor
         $resp = \json_decode($rbody, true);
         $jsonError = \json_last_error();
         if ($resp === null && $jsonError !== \JSON_ERROR_NONE) {
-            $msg = "Invalid response body from API: ${rbody} "
-              . "(HTTP response code was ${rcode}, json_last_error() was ${jsonError})";
+            $msg = "Invalid response body from API: {$rbody} "
+              . "(HTTP response code was {$rcode}, json_last_error() was {$jsonError})";
             throw new Exception\UnexpectedValueException($msg, $rcode);
         }
 

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -80,11 +80,14 @@ class ApiRequestor
     {
         if ($d instanceof ApiResource) {
             return Util\Util::utf8($d->id);
-        } elseif ($d === true) {
+        }
+        if ($d === true) {
             return 'true';
-        } elseif ($d === false) {
+        }
+        if ($d === false) {
             return 'false';
-        } elseif (\is_array($d)) {
+        }
+        if (\is_array($d)) {
             $res = [];
             foreach ($d as $k => $v) {
                 $res[$k] = self::_encodeObjects($v);

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -61,7 +61,7 @@ class ApiRequestor
         ];
 
         $result = \json_encode($payload);
-        if ($result !== false) {
+        if (false !== $result) {
             return $result;
         }
         Stripe::getLogger()->error("Serializing telemetry payload failed!");
@@ -80,10 +80,10 @@ class ApiRequestor
         if ($d instanceof ApiResource) {
             return Util\Util::utf8($d->id);
         }
-        if ($d === true) {
+        if (true === $d) {
             return 'true';
         }
-        if ($d === false) {
+        if (false === $d) {
             return 'false';
         }
         if (\is_array($d)) {
@@ -170,10 +170,10 @@ class ApiRequestor
             case 400:
                 // 'rate_limit' code is deprecated, but left here for backwards compatibility
                 // for API versions earlier than 2015-09-08
-                if ($code === 'rate_limit') {
+                if ('rate_limit' === $code) {
                     return Exception\RateLimitException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
                 }
-                if ($type === 'idempotency_error') {
+                if ('idempotency_error' === $type) {
                     return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
                 }
 
@@ -235,12 +235,12 @@ class ApiRequestor
      */
     private static function _formatAppInfo($appInfo)
     {
-        if ($appInfo !== null) {
+        if (null !== $appInfo) {
             $string = $appInfo['name'];
-            if ($appInfo['version'] !== null) {
+            if (null !== $appInfo['version']) {
                 $string .= '/' . $appInfo['version'];
             }
-            if ($appInfo['url'] !== null) {
+            if (null !== $appInfo['url']) {
                 $string .= ' (' . $appInfo['url'] . ')';
             }
             return $string;
@@ -275,7 +275,7 @@ class ApiRequestor
         if ($clientInfo) {
             $ua = \array_merge($clientInfo, $ua);
         }
-        if ($appInfo !== null) {
+        if (null !== $appInfo) {
             $uaString .= ' ' . self::_formatAppInfo($appInfo);
             $ua['application'] = $appInfo;
         }
@@ -332,7 +332,7 @@ class ApiRequestor
             $defaultHeaders['Stripe-Account'] = Stripe::$accountId;
         }
 
-        if (Stripe::$enableTelemetry && self::$requestTelemetry !== null) {
+        if (Stripe::$enableTelemetry && null !== self::$requestTelemetry) {
             $defaultHeaders["X-Stripe-Client-Telemetry"] = self::_telemetryJson(self::$requestTelemetry);
         }
 
@@ -388,14 +388,14 @@ class ApiRequestor
      */
     private function _processResourceParam($resource)
     {
-        if (\get_resource_type($resource) !== 'stream') {
+        if ('stream' !== \get_resource_type($resource)) {
             throw new Exception\InvalidArgumentException(
                 'Attempted to upload a resource that is not a stream'
             );
         }
 
         $metaData = \stream_get_meta_data($resource);
-        if ($metaData['wrapper_type'] !== 'plainfile') {
+        if ('plainfile' !== $metaData['wrapper_type']) {
             throw new Exception\InvalidArgumentException(
                 'Only plainfile resource streams are supported'
             );
@@ -419,7 +419,7 @@ class ApiRequestor
     {
         $resp = \json_decode($rbody, true);
         $jsonError = \json_last_error();
-        if ($resp === null && $jsonError !== \JSON_ERROR_NONE) {
+        if (null === $resp && \JSON_ERROR_NONE !== $jsonError) {
             $msg = "Invalid response body from API: {$rbody} "
               . "(HTTP response code was {$rcode}, json_last_error() was {$jsonError})";
             throw new Exception\UnexpectedValueException($msg, $rcode);

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -63,10 +63,9 @@ class ApiRequestor
         $result = \json_encode($payload);
         if ($result != false) {
             return $result;
-        } else {
-            Stripe::getLogger()->error("Serializing telemetry payload failed!");
-            return "{}";
         }
+        Stripe::getLogger()->error("Serializing telemetry payload failed!");
+        return "{}";
     }
 
     /**
@@ -93,9 +92,8 @@ class ApiRequestor
                 $res[$k] = self::_encodeObjects($v);
             }
             return $res;
-        } else {
-            return Util\Util::utf8($d);
         }
+        return Util\Util::utf8($d);
     }
 
     /**
@@ -246,9 +244,8 @@ class ApiRequestor
                 $string .= ' (' . $appInfo['url'] . ')';
             }
             return $string;
-        } else {
-            return null;
         }
+        return null;
     }
 
     /**

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -280,12 +280,11 @@ class ApiRequestor
             $ua['application'] = $appInfo;
         }
 
-        $defaultHeaders = [
+        return [
             'X-Stripe-Client-User-Agent' => \json_encode($ua),
             'User-Agent' => $uaString,
             'Authorization' => 'Bearer ' . $apiKey,
         ];
-        return $defaultHeaders;
     }
 
     /**

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -84,7 +84,7 @@ abstract class ApiResource extends StripeObject
         // Replace dots with slashes for namespaced resources, e.g. if the object's name is
         // "foo.bar", then its URL will be "/v1/foo/bars".
         $base = \str_replace('.', '/', static::OBJECT_NAME);
-        return "/v1/${base}s";
+        return "/v1/{$base}s";
     }
 
     /**
@@ -95,13 +95,13 @@ abstract class ApiResource extends StripeObject
         if ($id === null) {
             $class = \get_called_class();
             $message = "Could not determine which URL to request: "
-               . "${class} instance has invalid ID: ${id}";
+               . "{$class} instance has invalid ID: {$id}";
             throw new Exception\UnexpectedValueException($message);
         }
         $id = Util\Util::utf8($id);
         $base = static::classUrl();
         $extn = \urlencode($id);
-        return "${base}/${extn}";
+        return "{$base}/{$extn}";
     }
 
     /**

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -21,7 +21,7 @@ abstract class ApiResource extends StripeObject
     public static function getSavedNestedResources()
     {
         static $savedNestedResources = null;
-        if ($savedNestedResources === null) {
+        if (null === $savedNestedResources) {
             $savedNestedResources = new Util\Set();
         }
         return $savedNestedResources;
@@ -92,7 +92,7 @@ abstract class ApiResource extends StripeObject
      */
     public static function resourceUrl($id)
     {
-        if ($id === null) {
+        if (null === $id) {
             $class = \get_called_class();
             $message = "Could not determine which URL to request: "
                . "{$class} instance has invalid ID: {$id}";

--- a/lib/ApiResponse.php
+++ b/lib/ApiResponse.php
@@ -15,7 +15,7 @@ class ApiResponse
      * @var array|CaseInsensitiveArray|null
      */
     public $headers;
-    
+
     /**
      * @var string
      */

--- a/lib/ApplicationFee.php
+++ b/lib/ApplicationFee.php
@@ -30,7 +30,6 @@ class ApplicationFee extends ApiResource
     use ApiOperations\NestedResource;
     use ApiOperations\Retrieve;
 
-
     const PATH_REFUNDS = '/refunds';
 
     /**

--- a/lib/ApplicationFeeRefund.php
+++ b/lib/ApplicationFeeRefund.php
@@ -34,7 +34,7 @@ class ApplicationFeeRefund extends ApiResource
         if (!$id) {
             throw new Exception\UnexpectedValueException(
                 "Could not determine which URL to request: " .
-                "class instance has invalid ID: ${id}",
+                "class instance has invalid ID: {$id}",
                 null
             );
         }
@@ -44,7 +44,7 @@ class ApplicationFeeRefund extends ApiResource
         $base = ApplicationFee::classUrl();
         $feeExtn = \urlencode($fee);
         $extn = \urlencode($id);
-        return "${base}/${feeExtn}/refunds/${extn}";
+        return "{$base}/{$feeExtn}/refunds/{$extn}";
     }
 
     /**

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -60,7 +60,7 @@ class BankAccount extends ApiResource
         }
         $parentExtn = \urlencode(Util\Util::utf8($parent));
         $extn = \urlencode(Util\Util::utf8($this['id']));
-        return "${base}/${parentExtn}/${path}/${extn}";
+        return "{$base}/{$parentExtn}/{$path}/{$extn}";
     }
 
     /**

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -62,10 +62,9 @@ class BitcoinReceiver extends ApiResource
             $parentExtn = \urlencode(Util\Util::utf8($parent));
             $extn = \urlencode(Util\Util::utf8($this['id']));
             return "${base}/${parentExtn}/${path}/${extn}";
-        } else {
-            $base = BitcoinReceiver::classUrl();
-            $extn = \urlencode(Util\Util::utf8($this['id']));
-            return "${base}/${extn}";
         }
+        $base = BitcoinReceiver::classUrl();
+        $extn = \urlencode(Util\Util::utf8($this['id']));
+        return "${base}/${extn}";
     }
 }

--- a/lib/BitcoinReceiver.php
+++ b/lib/BitcoinReceiver.php
@@ -61,10 +61,10 @@ class BitcoinReceiver extends ApiResource
             $path = 'sources';
             $parentExtn = \urlencode(Util\Util::utf8($parent));
             $extn = \urlencode(Util\Util::utf8($this['id']));
-            return "${base}/${parentExtn}/${path}/${extn}";
+            return "{$base}/{$parentExtn}/{$path}/{$extn}";
         }
         $base = BitcoinReceiver::classUrl();
         $extn = \urlencode(Util\Util::utf8($this['id']));
-        return "${base}/${extn}";
+        return "{$base}/{$extn}";
     }
 }

--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -40,7 +40,7 @@ class Capability extends ApiResource
         if (!$id) {
             throw new Exception\UnexpectedValueException(
                 "Could not determine which URL to request: " .
-                "class instance has invalid ID: ${id}",
+                "class instance has invalid ID: {$id}",
                 null
             );
         }
@@ -50,7 +50,7 @@ class Capability extends ApiResource
         $base = Account::classUrl();
         $accountExtn = \urlencode($account);
         $extn = \urlencode($id);
-        return "${base}/${accountExtn}/capabilities/${extn}";
+        return "{$base}/{$accountExtn}/capabilities/{$extn}";
     }
 
     /**

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -93,7 +93,7 @@ class Card extends ApiResource
         }
         $parentExtn = \urlencode(Util\Util::utf8($parent));
         $extn = \urlencode(Util\Util::utf8($this['id']));
-        return "${base}/${parentExtn}/${path}/${extn}";
+        return "{$base}/{$parentExtn}/{$path}/{$extn}";
     }
 
     /**

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -95,7 +95,7 @@ class Collection extends StripeObject implements \IteratorAggregate
         $extn = \urlencode($id);
         list($response, $opts) = $this->_request(
             'get',
-            "${url}/${extn}",
+            "{$url}/{$extn}",
             $params,
             $opts
         );
@@ -232,7 +232,7 @@ class Collection extends StripeObject implements \IteratorAggregate
     {
         $url = \parse_url($this->url);
         if (!isset($url['path'])) {
-            throw new Exception\UnexpectedValueException("Could not parse list url into parts: ${url}");
+            throw new Exception\UnexpectedValueException("Could not parse list url into parts: {$url}");
         }
 
         if (isset($url['query'])) {

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -53,13 +53,12 @@ class Collection extends StripeObject implements \IteratorAggregate
     {
         if (\is_string($k)) {
             return parent::offsetGet($k);
-        } else {
-            $msg = "You tried to access the {$k} index, but Collection " .
+        }
+        $msg = "You tried to access the {$k} index, but Collection " .
                    "types only support string keys. (HINT: List calls " .
                    "return an object with a `data` (which is the data " .
                    "array). You likely want to call ->data[{$k}])";
-            throw new Exception\InvalidArgumentException($msg);
-        }
+        throw new Exception\InvalidArgumentException($msg);
     }
 
     public function all($params = null, $opts = null)

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -53,7 +53,7 @@ class Customer extends ApiResource
     public static function getSavedNestedResources()
     {
         static $savedNestedResources = null;
-        if ($savedNestedResources === null) {
+        if (null === $savedNestedResources) {
             $savedNestedResources = new Util\Set([
                 'source',
             ]);

--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -46,7 +46,7 @@ class CustomerBalanceTransaction extends ApiResource
         $customer = $this['customer'];
         if (!$id) {
             throw new Exception\UnexpectedValueException(
-                "Could not determine which URL to request: class instance has invalid ID: ${id}",
+                "Could not determine which URL to request: class instance has invalid ID: {$id}",
                 null
             );
         }
@@ -56,7 +56,7 @@ class CustomerBalanceTransaction extends ApiResource
         $base = Customer::classUrl();
         $customerExtn = \urlencode($customer);
         $extn = \urlencode($id);
-        return "${base}/${customerExtn}/balance_transactions/${extn}";
+        return "{$base}/{$customerExtn}/balance_transactions/{$extn}";
     }
 
     /**

--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -202,8 +202,8 @@ abstract class ApiErrorException extends \Exception implements ExceptionInterfac
      */
     public function __toString()
     {
-        $statusStr = ($this->getHttpStatus() === null) ? "" : "(Status {$this->getHttpStatus()}) ";
-        $idStr = ($this->getRequestId() === null) ? "" : "(Request {$this->getRequestId()}) ";
+        $statusStr = (null === $this->getHttpStatus()) ? "" : "(Status {$this->getHttpStatus()}) ";
+        $idStr = (null === $this->getRequestId()) ? "" : "(Request {$this->getRequestId()}) ";
         return "{$statusStr}{$idStr}{$this->getMessage()}";
     }
 

--- a/lib/Exception/ApiErrorException.php
+++ b/lib/Exception/ApiErrorException.php
@@ -202,8 +202,8 @@ abstract class ApiErrorException extends \Exception implements ExceptionInterfac
      */
     public function __toString()
     {
-        $statusStr = ($this->getHttpStatus() == null) ? "" : "(Status {$this->getHttpStatus()}) ";
-        $idStr = ($this->getRequestId() == null) ? "" : "(Request {$this->getRequestId()}) ";
+        $statusStr = ($this->getHttpStatus() === null) ? "" : "(Status {$this->getHttpStatus()}) ";
+        $idStr = ($this->getRequestId() === null) ? "" : "(Request {$this->getRequestId()}) ";
         return "{$statusStr}{$idStr}{$this->getMessage()}";
     }
 

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -204,7 +204,7 @@ class CurlClient implements ClientInterface
 
         $params = Util\Util::objectsToIds($params);
 
-        if ($method === 'get') {
+        if ('get' === $method) {
             if ($hasFile) {
                 throw new Exception\UnexpectedValueException(
                     "Issuing a GET request with a file parameter"
@@ -215,10 +215,10 @@ class CurlClient implements ClientInterface
                 $encoded = Util\Util::encodeParameters($params);
                 $absUrl = "{$absUrl}?{$encoded}";
             }
-        } elseif ($method === 'post') {
+        } elseif ('post' === $method) {
             $opts[\CURLOPT_POST] = 1;
             $opts[\CURLOPT_POSTFIELDS] = $hasFile ? $params : Util\Util::encodeParameters($params);
-        } elseif ($method === 'delete') {
+        } elseif ('delete' === $method) {
             $opts[\CURLOPT_CUSTOMREQUEST] = 'DELETE';
             if (\count($params) > 0) {
                 $encoded = Util\Util::encodeParameters($params);
@@ -230,7 +230,7 @@ class CurlClient implements ClientInterface
 
         // It is only safe to retry network failures on POST requests if we
         // add an Idempotency-Key header
-        if (($method === 'post') && (Stripe::$maxNetworkRetries > 0)) {
+        if (('post' === $method) && (Stripe::$maxNetworkRetries > 0)) {
             if (!$this->hasHeader($headers, "Idempotency-Key")) {
                 \array_push($headers, 'Idempotency-Key: ' . $this->randomGenerator->uuid());
             }
@@ -277,7 +277,7 @@ class CurlClient implements ClientInterface
     private function executeRequestWithRetries($opts, $absUrl)
     {
         $numRetries = 0;
-        $isPost = \array_key_exists(\CURLOPT_POST, $opts) && $opts[\CURLOPT_POST] === 1;
+        $isPost = \array_key_exists(\CURLOPT_POST, $opts) && 1 === $opts[\CURLOPT_POST];
 
         while (true) {
             $rcode = 0;
@@ -288,7 +288,7 @@ class CurlClient implements ClientInterface
             $rheaders = new Util\CaseInsensitiveArray();
             $headerCallback = function ($curl, $header_line) use (&$rheaders) {
                 // Ignore the HTTP request line (HTTP/1.1 200 OK)
-                if (\strpos($header_line, ":") === false) {
+                if (false === \strpos($header_line, ":")) {
                     return \strlen($header_line);
                 }
                 list($key, $value) = \explode(":", \trim($header_line), 2);
@@ -301,7 +301,7 @@ class CurlClient implements ClientInterface
             \curl_setopt_array($this->curlHandle, $opts);
             $rbody = \curl_exec($this->curlHandle);
 
-            if ($rbody === false) {
+            if (false === $rbody) {
                 $errno = \curl_errno($this->curlHandle);
                 $message = \curl_error($this->curlHandle);
             } else {
@@ -329,7 +329,7 @@ class CurlClient implements ClientInterface
             }
         }
 
-        if ($rbody === false) {
+        if (false === $rbody) {
             $this->handleCurlError($absUrl, $errno, $message, $numRetries);
         }
 
@@ -395,30 +395,30 @@ class CurlClient implements ClientInterface
         }
 
         // Retry on timeout-related problems (either on open or read).
-        if ($errno === \CURLE_OPERATION_TIMEOUTED) {
+        if (\CURLE_OPERATION_TIMEOUTED === $errno) {
             return true;
         }
 
         // Destination refused the connection, the connection was reset, or a
         // variety of other connection failures. This could occur from a single
         // saturated server, so retry in case it's intermittent.
-        if ($errno === \CURLE_COULDNT_CONNECT) {
+        if (\CURLE_COULDNT_CONNECT === $errno) {
             return true;
         }
 
         // The API may ask us not to retry (eg; if doing so would be a no-op)
         // or advise us to retry (eg; in cases of lock timeouts); we defer to that.
         if (isset($rheaders['stripe-should-retry'])) {
-            if ($rheaders['stripe-should-retry'] === 'false') {
+            if ('false' === $rheaders['stripe-should-retry']) {
                 return false;
             }
-            if ($rheaders['stripe-should-retry'] === 'true') {
+            if ('true' === $rheaders['stripe-should-retry']) {
                 return true;
             }
         }
 
         // 409 Conflict
-        if ($rcode === 409) {
+        if (409 === $rcode) {
             return true;
         }
 
@@ -524,7 +524,7 @@ class CurlClient implements ClientInterface
     private function hasHeader($headers, $name)
     {
         foreach ($headers as $header) {
-            if (\strncasecmp($header, "{$name}: ", \strlen($name) + 2) === 0) {
+            if (0 === \strncasecmp($header, "{$name}: ", \strlen($name) + 2)) {
                 return true;
             }
         }

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -321,7 +321,7 @@ class CurlClient implements ClientInterface
             }
 
             if ($shouldRetry) {
-                $numRetries += 1;
+                ++$numRetries;
                 $sleepSeconds = $this->sleepTime($numRetries, $rheaders);
                 \usleep((int) ($sleepSeconds * 1000000));
             } else {

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -511,7 +511,7 @@ class CurlClient implements ClientInterface
         // Versions of curl older than 7.60.0 don't respect GOAWAY frames
         // (cf. https://github.com/curl/curl/issues/2416), which Stripe use.
         $curlVersion = \curl_version()['version'];
-        return (\version_compare($curlVersion, '7.60.0') >= 0);
+        return \version_compare($curlVersion, '7.60.0') >= 0;
     }
 
     /**

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -204,7 +204,7 @@ class CurlClient implements ClientInterface
 
         $params = Util\Util::objectsToIds($params);
 
-        if ($method == 'get') {
+        if ($method === 'get') {
             if ($hasFile) {
                 throw new Exception\UnexpectedValueException(
                     "Issuing a GET request with a file parameter"
@@ -215,10 +215,10 @@ class CurlClient implements ClientInterface
                 $encoded = Util\Util::encodeParameters($params);
                 $absUrl = "{$absUrl}?{$encoded}";
             }
-        } elseif ($method == 'post') {
+        } elseif ($method === 'post') {
             $opts[\CURLOPT_POST] = 1;
             $opts[\CURLOPT_POSTFIELDS] = $hasFile ? $params : Util\Util::encodeParameters($params);
-        } elseif ($method == 'delete') {
+        } elseif ($method === 'delete') {
             $opts[\CURLOPT_CUSTOMREQUEST] = 'DELETE';
             if (\count($params) > 0) {
                 $encoded = Util\Util::encodeParameters($params);
@@ -230,7 +230,7 @@ class CurlClient implements ClientInterface
 
         // It is only safe to retry network failures on POST requests if we
         // add an Idempotency-Key header
-        if (($method == 'post') && (Stripe::$maxNetworkRetries > 0)) {
+        if (($method === 'post') && (Stripe::$maxNetworkRetries > 0)) {
             if (!$this->hasHeader($headers, "Idempotency-Key")) {
                 \array_push($headers, 'Idempotency-Key: ' . $this->randomGenerator->uuid());
             }
@@ -277,7 +277,7 @@ class CurlClient implements ClientInterface
     private function executeRequestWithRetries($opts, $absUrl)
     {
         $numRetries = 0;
-        $isPost = \array_key_exists(\CURLOPT_POST, $opts) && $opts[\CURLOPT_POST] == 1;
+        $isPost = \array_key_exists(\CURLOPT_POST, $opts) && $opts[\CURLOPT_POST] === 1;
 
         while (true) {
             $rcode = 0;
@@ -461,7 +461,7 @@ class CurlClient implements ClientInterface
 
         // And never sleep less than the time the API asks us to wait, assuming it's a reasonable ask.
         $retryAfter = isset($rheaders['retry-after']) ? (float) ($rheaders['retry-after']) : 0.0;
-        if (\floor($retryAfter) == $retryAfter && $retryAfter <= Stripe::getMaxRetryAfter()) {
+        if (\floor($retryAfter) === $retryAfter && $retryAfter <= Stripe::getMaxRetryAfter()) {
             $sleepSeconds = \max($sleepSeconds, $retryAfter);
         }
 

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -45,11 +45,11 @@ class CurlClient implements ClientInterface
 
     protected $enablePersistentConnections = true;
 
-    protected $enableHttp2 = null;
+    protected $enableHttp2;
 
-    protected $curlHandle = null;
+    protected $curlHandle;
 
-    protected $requestStatusCallback = null;
+    protected $requestStatusCallback;
 
     /**
      * CurlClient constructor.

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -213,7 +213,7 @@ class CurlClient implements ClientInterface
             $opts[\CURLOPT_HTTPGET] = 1;
             if (\count($params) > 0) {
                 $encoded = Util\Util::encodeParameters($params);
-                $absUrl = "${absUrl}?${encoded}";
+                $absUrl = "{$absUrl}?{$encoded}";
             }
         } elseif ($method == 'post') {
             $opts[\CURLOPT_POST] = 1;
@@ -222,10 +222,10 @@ class CurlClient implements ClientInterface
             $opts[\CURLOPT_CUSTOMREQUEST] = 'DELETE';
             if (\count($params) > 0) {
                 $encoded = Util\Util::encodeParameters($params);
-                $absUrl = "${absUrl}?${encoded}";
+                $absUrl = "{$absUrl}?{$encoded}";
             }
         } else {
-            throw new Exception\UnexpectedValueException("Unrecognized method ${method}");
+            throw new Exception\UnexpectedValueException("Unrecognized method {$method}");
         }
 
         // It is only safe to retry network failures on POST requests if we
@@ -349,7 +349,7 @@ class CurlClient implements ClientInterface
             case \CURLE_COULDNT_CONNECT:
             case \CURLE_COULDNT_RESOLVE_HOST:
             case \CURLE_OPERATION_TIMEOUTED:
-                $msg = "Could not connect to Stripe (${url}).  Please check your "
+                $msg = "Could not connect to Stripe ({$url}).  Please check your "
                  . "internet connection and try again.  If this problem persists, "
                  . "you should check Stripe's service status at "
                  . "https://twitter.com/stripestatus, or";
@@ -358,7 +358,7 @@ class CurlClient implements ClientInterface
             case \CURLE_SSL_PEER_CERTIFICATE:
                 $msg = "Could not verify Stripe's SSL certificate.  Please make sure "
                  . "that your network is not intercepting certificates.  "
-                 . "(Try going to ${url} in your browser.)  "
+                 . "(Try going to {$url} in your browser.)  "
                  . "If this problem persists,";
                 break;
             default:
@@ -367,10 +367,10 @@ class CurlClient implements ClientInterface
         }
         $msg .= " let us know at support@stripe.com.";
 
-        $msg .= "\n\n(Network error [errno ${errno}]: ${message})";
+        $msg .= "\n\n(Network error [errno {$errno}]: {$message})";
 
         if ($numRetries > 0) {
-            $msg .= "\n\nRequest was retried ${numRetries} times.";
+            $msg .= "\n\nRequest was retried {$numRetries} times.";
         }
 
         throw new Exception\ApiConnectionException($msg);

--- a/lib/OAuth.php
+++ b/lib/OAuth.php
@@ -79,10 +79,10 @@ abstract class OAuth
     private static function _getClientId($params = null)
     {
         $clientId = ($params && \array_key_exists('client_id', $params)) ? $params['client_id'] : null;
-        if ($clientId === null) {
+        if (null === $clientId) {
             $clientId = Stripe::getClientId();
         }
-        if ($clientId === null) {
+        if (null === $clientId) {
             $msg = 'No client_id provided.  (HINT: set your client_id using '
               . '"Stripe::setClientId(<CLIENT-ID>)".  You can find your client_ids '
               . 'in your Stripe dashboard at '

--- a/lib/Person.php
+++ b/lib/Person.php
@@ -65,7 +65,7 @@ class Person extends ApiResource
         if (!$id) {
             throw new Exception\UnexpectedValueException(
                 "Could not determine which URL to request: " .
-                "class instance has invalid ID: ${id}",
+                "class instance has invalid ID: {$id}",
                 null
             );
         }
@@ -75,7 +75,7 @@ class Person extends ApiResource
         $base = Account::classUrl();
         $accountExtn = \urlencode($account);
         $extn = \urlencode($id);
-        return "${base}/${accountExtn}/persons/${extn}";
+        return "{$base}/{$accountExtn}/persons/{$extn}";
     }
 
     /**

--- a/lib/SingletonApiResource.php
+++ b/lib/SingletonApiResource.php
@@ -25,7 +25,7 @@ abstract class SingletonApiResource extends ApiResource
         // Replace dots with slashes for namespaced resources, e.g. if the object's name is
         // "foo.bar", then its URL will be "/v1/foo/bar".
         $base = \str_replace('.', '/', static::OBJECT_NAME);
-        return "/v1/${base}";
+        return "/v1/{$base}";
     }
 
     /**

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -98,8 +98,8 @@ class Source extends ApiResource
         $id = $this['id'];
         if (!$id) {
             $class = \get_class($this);
-            $msg = "Could not determine which URL to request: ${class} instance "
-             . "has invalid ID: ${id}";
+            $msg = "Could not determine which URL to request: {$class} instance "
+             . "has invalid ID: {$id}";
             throw new Exception\UnexpectedValueException($msg, null);
         }
 
@@ -107,7 +107,7 @@ class Source extends ApiResource
             $base = Customer::classUrl();
             $parentExtn = \urlencode(Util\Util::utf8($this['customer']));
             $extn = \urlencode(Util\Util::utf8($id));
-            $url = "${base}/${parentExtn}/sources/${extn}";
+            $url = "{$base}/{$parentExtn}/sources/{$extn}";
 
             list($response, $opts) = $this->_request('delete', $url, $params, $opts);
             $this->refreshFrom($response, $opts);

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -112,11 +112,10 @@ class Source extends ApiResource
             list($response, $opts) = $this->_request('delete', $url, $params, $opts);
             $this->refreshFrom($response, $opts);
             return $this;
-        } else {
-            $message = "This source object does not appear to be currently attached "
-               . "to a customer object.";
-            throw new Exception\UnexpectedValueException($message);
         }
+        $message = "This source object does not appear to be currently attached "
+               . "to a customer object.";
+        throw new Exception\UnexpectedValueException($message);
     }
 
     /**

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -84,7 +84,7 @@ class Stripe
      */
     public static function getLogger()
     {
-        if (self::$logger === null) {
+        if (null === self::$logger) {
             return new Util\DefaultLogger();
         }
         return self::$logger;

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -84,7 +84,7 @@ class Stripe
      */
     public static function getLogger()
     {
-        if (self::$logger == null) {
+        if (self::$logger === null) {
             return new Util\DefaultLogger();
         }
         return self::$logger;

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -165,11 +165,10 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                     . "available on this object are: ${attrs}";
             Stripe::getLogger()->error($message);
             return $nullval;
-        } else {
-            $class = \get_class($this);
-            Stripe::getLogger()->error("Stripe Notice: Undefined property of ${class} instance: ${k}");
-            return $nullval;
         }
+        $class = \get_class($this);
+        Stripe::getLogger()->error("Stripe Notice: Undefined property of ${class} instance: ${k}");
+        return $nullval;
     }
 
     // Magic method for var_dump output. Only works with PHP >= 5.6
@@ -368,13 +367,12 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             }
             if (isset($value->id)) {
                 return $value;
-            } else {
-                throw new Exception\InvalidArgumentException(
+            }
+            throw new Exception\InvalidArgumentException(
                     "Cannot save property `${key}` containing an API resource of type " .
                     \get_class($value) . ". It doesn't appear to be persisted and is " .
                     "not marked as `saveWithParent`."
                 );
-            }
         } elseif (\is_array($value)) {
             if (Util\Util::isList($value)) {
                 // Sequential array, i.e. a list
@@ -495,9 +493,8 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 self::deepCopy($obj->_values),
                 clone $obj->_opts
             );
-        } else {
-            return $obj;
         }
+        return $obj;
     }
 
     /**

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -118,7 +118,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         if (static::getPermanentAttributes()->includes($k)) {
             throw new Exception\InvalidArgumentException(
                 "Cannot set ${k} on this object. HINT: you can't set: " .
-                \join(', ', static::getPermanentAttributes()->toArray())
+                \implode(', ', static::getPermanentAttributes()->toArray())
             );
         }
 
@@ -155,7 +155,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             return $this->_values[$k];
         } elseif (!empty($this->_transientValues) && $this->_transientValues->includes($k)) {
             $class = \get_class($this);
-            $attrs = \join(', ', \array_keys($this->_values));
+            $attrs = \implode(', ', \array_keys($this->_values));
             $message = "Stripe Notice: Undefined property of ${class} instance: ${k}. "
                     . "HINT: The ${k} attribute was set in the past, however. "
                     . "It was then wiped when refreshing the object "

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -513,8 +513,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 "empty_values got unexpected object type: " . \get_class($obj)
             );
         }
-        $update = \array_fill_keys(\array_keys($values), "");
-        return $update;
+        return \array_fill_keys(\array_keys($values), "");
     }
 
     /**

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -369,11 +369,12 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 return $value;
             }
             throw new Exception\InvalidArgumentException(
-                    "Cannot save property `${key}` containing an API resource of type " .
+                "Cannot save property `${key}` containing an API resource of type " .
                     \get_class($value) . ". It doesn't appear to be persisted and is " .
                     "not marked as `saveWithParent`."
-                );
-        } elseif (\is_array($value)) {
+            );
+        }
+        if (\is_array($value)) {
             if (Util\Util::isList($value)) {
                 // Sequential array, i.e. a list
                 $update = [];

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -153,7 +153,8 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         $nullval = null;
         if (!empty($this->_values) && \array_key_exists($k, $this->_values)) {
             return $this->_values[$k];
-        } elseif (!empty($this->_transientValues) && $this->_transientValues->includes($k)) {
+        }
+        if (!empty($this->_transientValues) && $this->_transientValues->includes($k)) {
             $class = \get_class($this);
             $attrs = \implode(', ', \array_keys($this->_values));
             $message = "Stripe Notice: Undefined property of ${class} instance: ${k}. "
@@ -360,10 +361,12 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         // user intended it to.
         if ($value === null) {
             return "";
-        } elseif (($value instanceof ApiResource) && (!$value->saveWithParent)) {
+        }
+        if (($value instanceof ApiResource) && (!$value->saveWithParent)) {
             if (!$unsaved) {
                 return null;
-            } elseif (isset($value->id)) {
+            }
+            if (isset($value->id)) {
                 return $value;
             } else {
                 throw new Exception\InvalidArgumentException(
@@ -486,7 +489,8 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 $copy[$k] = self::deepCopy($v);
             }
             return $copy;
-        } elseif ($obj instanceof StripeObject) {
+        }
+        if ($obj instanceof StripeObject) {
             return $obj::constructFrom(
                 self::deepCopy($obj->_values),
                 clone $obj->_opts

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -24,7 +24,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     public static function getPermanentAttributes()
     {
         static $permanentAttributes = null;
-        if ($permanentAttributes === null) {
+        if (null === $permanentAttributes) {
             $permanentAttributes = new Util\Set([
                 'id',
             ]);
@@ -85,7 +85,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     public static function getAdditiveParams()
     {
         static $additiveParams = null;
-        if ($additiveParams === null) {
+        if (null === $additiveParams) {
             // Set `metadata` as additive so that when it's set directly we remember
             // to clear keys that may have been previously set by sending empty
             // values for them.
@@ -107,7 +107,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         $this->_values = [];
         $this->_unsavedValues = new Util\Set();
         $this->_transientValues = new Util\Set();
-        if ($id !== null) {
+        if (null !== $id) {
             $this->_values['id'] = $id;
         }
     }
@@ -122,7 +122,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             );
         }
 
-        if ($v === "") {
+        if ("" === $v) {
             throw new Exception\InvalidArgumentException(
                 'You cannot set \'' . $k . '\'to an empty string. '
                 . 'We interpret empty strings as NULL in requests. '
@@ -280,7 +280,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             // This is necessary in case metadata is empty, as PHP arrays do
             // not differentiate between lists and hashes, and we consider
             // empty arrays to be lists.
-            if (($k === "metadata") && (\is_array($v))) {
+            if (("metadata" === $k) && (\is_array($v))) {
                 $this->_values[$k] = StripeObject::constructFrom($v, $opts);
             } else {
                 $this->_values[$k] = Util\Util::convertToStripeObject($v, $opts);
@@ -327,7 +327,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         $updateParams = \array_filter(
             $updateParams,
             function ($v) {
-                return $v !== null;
+                return null !== $v;
             }
         );
 
@@ -358,7 +358,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         // We throw an error if a property was set explicitly but we can't do
         // anything with it because the integration is probably not working as the
         // user intended it to.
-        if ($value === null) {
+        if (null === $value) {
             return "";
         }
         if (($value instanceof ApiResource) && (!$value->saveWithParent)) {
@@ -422,7 +422,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         };
 
         return \array_reduce(\array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {
-            if ($k[0] === '_') {
+            if ('_' === $k[0]) {
                 return $acc;
             }
             $v = $this->_values[$k];

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -422,7 +422,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         };
 
         return \array_reduce(\array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {
-            if ($k[0] == '_') {
+            if ($k[0] === '_') {
                 return $acc;
             }
             $v = $this->_values[$k];

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -117,7 +117,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     {
         if (static::getPermanentAttributes()->includes($k)) {
             throw new Exception\InvalidArgumentException(
-                "Cannot set ${k} on this object. HINT: you can't set: " .
+                "Cannot set {$k} on this object. HINT: you can't set: " .
                 \implode(', ', static::getPermanentAttributes()->toArray())
             );
         }
@@ -157,17 +157,17 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         if (!empty($this->_transientValues) && $this->_transientValues->includes($k)) {
             $class = \get_class($this);
             $attrs = \implode(', ', \array_keys($this->_values));
-            $message = "Stripe Notice: Undefined property of ${class} instance: ${k}. "
-                    . "HINT: The ${k} attribute was set in the past, however. "
+            $message = "Stripe Notice: Undefined property of {$class} instance: {$k}. "
+                    . "HINT: The {$k} attribute was set in the past, however. "
                     . "It was then wiped when refreshing the object "
                     . "with the result returned by Stripe's API, "
                     . "probably as a result of a save(). The attributes currently "
-                    . "available on this object are: ${attrs}";
+                    . "available on this object are: {$attrs}";
             Stripe::getLogger()->error($message);
             return $nullval;
         }
         $class = \get_class($this);
-        Stripe::getLogger()->error("Stripe Notice: Undefined property of ${class} instance: ${k}");
+        Stripe::getLogger()->error("Stripe Notice: Undefined property of {$class} instance: {$k}");
         return $nullval;
     }
 
@@ -369,7 +369,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 return $value;
             }
             throw new Exception\InvalidArgumentException(
-                "Cannot save property `${key}` containing an API resource of type " .
+                "Cannot save property `{$key}` containing an API resource of type " .
                     \get_class($value) . ". It doesn't appear to be persisted and is " .
                     "not marked as `saveWithParent`."
             );

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -72,7 +72,7 @@ class Subscription extends ApiResource
     public static function getSavedNestedResources()
     {
         static $savedNestedResources = null;
-        if ($savedNestedResources === null) {
+        if (null === $savedNestedResources) {
             $savedNestedResources = new Util\Set([
                 'source',
             ]);

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -62,7 +62,7 @@ class TaxId extends ApiResource
         $customer = $this['customer'];
         if (!$id) {
             throw new Exception\UnexpectedValueException(
-                "Could not determine which URL to request: class instance has invalid ID: ${id}"
+                "Could not determine which URL to request: class instance has invalid ID: {$id}"
             );
         }
         $id = Util\Util::utf8($id);
@@ -71,7 +71,7 @@ class TaxId extends ApiResource
         $base = Customer::classUrl();
         $customerExtn = \urlencode($customer);
         $extn = \urlencode($id);
-        return "${base}/${customerExtn}/tax_ids/${extn}";
+        return "{$base}/{$customerExtn}/tax_ids/{$extn}";
     }
 
     /**

--- a/lib/TransferReversal.php
+++ b/lib/TransferReversal.php
@@ -36,7 +36,7 @@ class TransferReversal extends ApiResource
         if (!$id) {
             throw new Exception\UnexpectedValueException(
                 "Could not determine which URL to request: " .
-                "class instance has invalid ID: ${id}",
+                "class instance has invalid ID: {$id}",
                 null
             );
         }
@@ -46,7 +46,7 @@ class TransferReversal extends ApiResource
         $base = Transfer::classUrl();
         $transferExtn = \urlencode($transfer);
         $extn = \urlencode($id);
-        return "${base}/${transferExtn}/reversals/${extn}";
+        return "{$base}/{$transferExtn}/reversals/{$extn}";
     }
 
     /**

--- a/lib/Util/CaseInsensitiveArray.php
+++ b/lib/Util/CaseInsensitiveArray.php
@@ -63,8 +63,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \IteratorAggrega
     {
         if (\is_string($v)) {
             return \strtolower($v);
-        } else {
-            return $v;
         }
+        return $v;
     }
 }

--- a/lib/Util/DefaultLogger.php
+++ b/lib/Util/DefaultLogger.php
@@ -10,7 +10,7 @@ class DefaultLogger implements LoggerInterface
 {
     public $messageType = 0;
 
-    public $destination = null;
+    public $destination;
 
     public function error($message, array $context = [])
     {

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -60,7 +60,7 @@ class RequestOptions
     public function discardNonPersistentHeaders()
     {
         foreach ($this->headers as $k => $v) {
-            if (!\in_array($k, self::$HEADERS_TO_PERSIST)) {
+            if (!\in_array($k, self::$HEADERS_TO_PERSIST, true)) {
                 unset($this->headers[$k]);
             }
         }

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -44,10 +44,10 @@ class RequestOptions
     public function merge($options)
     {
         $other_options = self::parse($options);
-        if ($other_options->apiKey === null) {
+        if (null === $other_options->apiKey) {
             $other_options->apiKey = $this->apiKey;
         }
-        if ($other_options->apiBase === null) {
+        if (null === $other_options->apiBase) {
             $other_options->apiBase = $this->apiBase;
         }
         $other_options->headers = \array_merge($this->headers, $other_options->headers);

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -162,7 +162,7 @@ abstract class Util
             }
         }
 
-        if (\is_string($value) && self::$isMbstringAvailable && \mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
+        if (\is_string($value) && self::$isMbstringAvailable && \mb_detect_encoding($value, "UTF-8", true) !== "UTF-8") {
             return \utf8_encode($value);
         }
         return $value;
@@ -185,7 +185,7 @@ abstract class Util
         if (self::$isHashEqualsAvailable) {
             return \hash_equals($a, $b);
         }
-        if (\strlen($a) != \strlen($b)) {
+        if (\strlen($a) !== \strlen($b)) {
             return false;
         }
 
@@ -193,7 +193,7 @@ abstract class Util
         for ($i = 0; $i < \strlen($a); ++$i) {
             $result |= \ord($a[$i]) ^ \ord($b[$i]);
         }
-        return $result == 0;
+        return $result === 0;
     }
 
     /**

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -131,7 +131,8 @@ abstract class Util
                 \array_push($mapped, self::convertToStripeObject($i, $opts));
             }
             return $mapped;
-        } elseif (\is_array($resp)) {
+        }
+        if (\is_array($resp)) {
             if (isset($resp['object']) && \is_string($resp['object']) && isset($types[$resp['object']])) {
                 $class = $types[$resp['object']];
             } else {
@@ -210,13 +211,15 @@ abstract class Util
     {
         if ($h instanceof \Stripe\ApiResource) {
             return $h->id;
-        } elseif (static::isList($h)) {
+        }
+        if (static::isList($h)) {
             $results = [];
             foreach ($h as $v) {
                 \array_push($results, static::objectsToIds($v));
             }
             return $results;
-        } elseif (\is_array($h)) {
+        }
+        if (\is_array($h)) {
             $results = [];
             foreach ($h as $k => $v) {
                 if (null === $v) {

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -139,9 +139,8 @@ abstract class Util
                 $class = \Stripe\StripeObject::class;
             }
             return $class::constructFrom($resp, $opts);
-        } else {
-            return $resp;
         }
+        return $resp;
     }
 
     /**
@@ -165,9 +164,8 @@ abstract class Util
 
         if (\is_string($value) && self::$isMbstringAvailable && \mb_detect_encoding($value, "UTF-8", true) != "UTF-8") {
             return \utf8_encode($value);
-        } else {
-            return $value;
         }
+        return $value;
     }
 
     /**
@@ -186,17 +184,16 @@ abstract class Util
 
         if (self::$isHashEqualsAvailable) {
             return \hash_equals($a, $b);
-        } else {
-            if (\strlen($a) != \strlen($b)) {
-                return false;
-            }
-
-            $result = 0;
-            for ($i = 0; $i < \strlen($a); ++$i) {
-                $result |= \ord($a[$i]) ^ \ord($b[$i]);
-            }
-            return $result == 0;
         }
+        if (\strlen($a) != \strlen($b)) {
+            return false;
+        }
+
+        $result = 0;
+        for ($i = 0; $i < \strlen($a); ++$i) {
+            $result |= \ord($a[$i]) ^ \ord($b[$i]);
+        }
+        return $result == 0;
     }
 
     /**
@@ -228,9 +225,8 @@ abstract class Util
                 $results[$k] = static::objectsToIds($v);
             }
             return $results;
-        } else {
-            return $h;
         }
+        return $h;
     }
 
     /**

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -195,7 +195,7 @@ abstract class Util
             for ($i = 0; $i < \strlen($a); ++$i) {
                 $result |= \ord($a[$i]) ^ \ord($b[$i]);
             }
-            return ($result == 0);
+            return $result == 0;
         }
     }
 

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -151,7 +151,7 @@ abstract class Util
      */
     public static function utf8($value)
     {
-        if (self::$isMbstringAvailable === null) {
+        if (null === self::$isMbstringAvailable) {
             self::$isMbstringAvailable = \function_exists('mb_detect_encoding');
 
             if (!self::$isMbstringAvailable) {
@@ -162,7 +162,7 @@ abstract class Util
             }
         }
 
-        if (\is_string($value) && self::$isMbstringAvailable && \mb_detect_encoding($value, "UTF-8", true) !== "UTF-8") {
+        if (\is_string($value) && self::$isMbstringAvailable && "UTF-8" !== \mb_detect_encoding($value, "UTF-8", true)) {
             return \utf8_encode($value);
         }
         return $value;
@@ -178,7 +178,7 @@ abstract class Util
      */
     public static function secureCompare($a, $b)
     {
-        if (self::$isHashEqualsAvailable === null) {
+        if (null === self::$isHashEqualsAvailable) {
             self::$isHashEqualsAvailable = \function_exists('hash_equals');
         }
 
@@ -193,7 +193,7 @@ abstract class Util
         for ($i = 0; $i < \strlen($a); ++$i) {
             $result |= \ord($a[$i]) ^ \ord($b[$i]);
         }
-        return $result === 0;
+        return 0 === $result;
     }
 
     /**

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -306,9 +306,7 @@ abstract class Util
         // characters back to their literals. This is fine by the server, and
         // makes these parameter strings easier to read.
         $s = \str_replace('%5B', '[', $s);
-        $s = \str_replace('%5D', ']', $s);
-
-        return $s;
+        return \str_replace('%5D', ']', $s);
     }
 
     public static function normalizeId($id)

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -33,8 +33,6 @@ abstract class Webhook
               . "(json_last_error() was ${jsonError})";
             throw new Exception\UnexpectedValueException($msg);
         }
-        $event = Event::constructFrom($data);
-
-        return $event;
+        return Event::constructFrom($data);
     }
 }

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -28,7 +28,7 @@ abstract class Webhook
 
         $data = \json_decode($payload, true);
         $jsonError = \json_last_error();
-        if ($data === null && $jsonError !== \JSON_ERROR_NONE) {
+        if (null === $data && \JSON_ERROR_NONE !== $jsonError) {
             $msg = "Invalid payload: {$payload} "
               . "(json_last_error() was {$jsonError})";
             throw new Exception\UnexpectedValueException($msg);

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -29,8 +29,8 @@ abstract class Webhook
         $data = \json_decode($payload, true);
         $jsonError = \json_last_error();
         if ($data === null && $jsonError !== \JSON_ERROR_NONE) {
-            $msg = "Invalid payload: ${payload} "
-              . "(json_last_error() was ${jsonError})";
+            $msg = "Invalid payload: {$payload} "
+              . "(json_last_error() was {$jsonError})";
             throw new Exception\UnexpectedValueException($msg);
         }
         return Event::constructFrom($data);

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -25,7 +25,7 @@ abstract class WebhookSignature
         // Extract timestamp and signatures from header
         $timestamp = self::getTimestamp($header);
         $signatures = self::getSignatures($header, self::EXPECTED_SCHEME);
-        if ($timestamp == -1) {
+        if ($timestamp === -1) {
             throw Exception\SignatureVerificationException::factory(
                 "Unable to extract timestamp and signatures from header",
                 $payload,
@@ -84,7 +84,7 @@ abstract class WebhookSignature
 
         foreach ($items as $item) {
             $itemParts = \explode("=", $item, 2);
-            if ($itemParts[0] == "t") {
+            if ($itemParts[0] === "t") {
                 if (!\is_numeric($itemParts[1])) {
                     return -1;
                 }
@@ -109,7 +109,7 @@ abstract class WebhookSignature
 
         foreach ($items as $item) {
             $itemParts = \explode("=", $item, 2);
-            if ($itemParts[0] == $scheme) {
+            if ($itemParts[0] === $scheme) {
                 \array_push($signatures, $itemParts[1]);
             }
         }

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -42,7 +42,7 @@ abstract class WebhookSignature
 
         // Check if expected signature is found in list of signatures from
         // header
-        $signedPayload = "${timestamp}.${payload}";
+        $signedPayload = "{$timestamp}.{$payload}";
         $expectedSignature = self::computeSignature($signedPayload, $secret);
         $signatureFound = false;
         foreach ($signatures as $signature) {

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -25,7 +25,7 @@ abstract class WebhookSignature
         // Extract timestamp and signatures from header
         $timestamp = self::getTimestamp($header);
         $signatures = self::getSignatures($header, self::EXPECTED_SCHEME);
-        if ($timestamp === -1) {
+        if (-1 === $timestamp) {
             throw Exception\SignatureVerificationException::factory(
                 "Unable to extract timestamp and signatures from header",
                 $payload,
@@ -84,7 +84,7 @@ abstract class WebhookSignature
 
         foreach ($items as $item) {
             $itemParts = \explode("=", $item, 2);
-            if ($itemParts[0] === "t") {
+            if ("t" === $itemParts[0]) {
                 if (!\is_numeric($itemParts[1])) {
                     return -1;
                 }

--- a/tests/Stripe/AccountLinkTest.php
+++ b/tests/Stripe/AccountLinkTest.php
@@ -16,6 +16,6 @@ class AccountLinkTest extends TestCase
             "success_url" => "https://stripe.com/success",
             "type" => "custom_account_verification",
         ]);
-        $this->assertInstanceOf(\Stripe\AccountLink::class, $resource);
+        static::assertInstanceOf(\Stripe\AccountLink::class, $resource);
     }
 }

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -236,8 +236,8 @@ class AccountTest extends TestCase
             "dob" => [
                 "day" => 1,
                 "month" => 1,
-                "year" => 1980
-            ]
+                "year" => 1980,
+            ],
         ]);
         static::assertInstanceOf(\Stripe\Person::class, $resource);
     }

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -16,8 +16,8 @@ class AccountTest extends TestCase
             '/v1/accounts'
         );
         $resources = Account::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Account::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Account::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -27,7 +27,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID
         );
         $resource = Account::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsRetrievableWithoutId()
@@ -37,7 +37,7 @@ class AccountTest extends TestCase
             '/v1/account'
         );
         $resource = Account::retrieve();
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsCreatable()
@@ -47,7 +47,7 @@ class AccountTest extends TestCase
             '/v1/accounts'
         );
         $resource = Account::create(["type" => "custom"]);
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsSaveable()
@@ -59,7 +59,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -71,7 +71,7 @@ class AccountTest extends TestCase
         $resource = Account::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsDeletable()
@@ -82,7 +82,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
     }
 
     public function testIsRejectable()
@@ -93,8 +93,8 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $account->id . '/reject'
         );
         $resource = $account->reject(["reason" => "fraud"]);
-        $this->assertInstanceOf(\Stripe\Account::class, $resource);
-        $this->assertSame($resource, $account);
+        static::assertInstanceOf(\Stripe\Account::class, $resource);
+        static::assertSame($resource, $account);
     }
 
     public function testIsDeauthorizable()
@@ -126,8 +126,8 @@ class AccountTest extends TestCase
             '/v1/accounts/' . $account->id . '/persons'
         );
         $persons = $account->persons();
-        $this->assertInternalType('array', $persons->data);
-        $this->assertInstanceOf(\Stripe\Person::class, $persons->data[0]);
+        static::assertInternalType('array', $persons->data);
+        static::assertInstanceOf(\Stripe\Person::class, $persons->data[0]);
     }
 
     public function testCanRetrieveCapability()
@@ -137,7 +137,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities/' . self::TEST_CAPABILITY_ID
         );
         $resource = Account::retrieveCapability(self::TEST_RESOURCE_ID, self::TEST_CAPABILITY_ID);
-        $this->assertInstanceOf(\Stripe\Capability::class, $resource);
+        static::assertInstanceOf(\Stripe\Capability::class, $resource);
     }
 
     public function testCanUpdateCapability()
@@ -149,7 +149,7 @@ class AccountTest extends TestCase
         $resource = Account::updateCapability(self::TEST_RESOURCE_ID, self::TEST_CAPABILITY_ID, [
             "requested" => true,
         ]);
-        $this->assertInstanceOf(\Stripe\Capability::class, $resource);
+        static::assertInstanceOf(\Stripe\Capability::class, $resource);
     }
 
     public function testCanListCapabilities()
@@ -159,7 +159,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/capabilities'
         );
         $resources = Account::allCapabilities(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateExternalAccount()
@@ -171,7 +171,7 @@ class AccountTest extends TestCase
         $resource = Account::createExternalAccount(self::TEST_RESOURCE_ID, [
             "external_account" => "btok_123",
         ]);
-        $this->assertInstanceOf(\Stripe\BankAccount::class, $resource);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
     }
 
     public function testCanRetrieveExternalAccount()
@@ -181,7 +181,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
         $resource = Account::retrieveExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
-        $this->assertInstanceOf(\Stripe\BankAccount::class, $resource);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
     }
 
     public function testCanUpdateExternalAccount()
@@ -193,7 +193,7 @@ class AccountTest extends TestCase
         $resource = Account::updateExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID, [
             "name" => "name",
         ]);
-        $this->assertInstanceOf(\Stripe\BankAccount::class, $resource);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
     }
 
     public function testCanDeleteExternalAccount()
@@ -203,7 +203,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts/' . self::TEST_EXTERNALACCOUNT_ID
         );
         $resource = Account::deleteExternalAccount(self::TEST_RESOURCE_ID, self::TEST_EXTERNALACCOUNT_ID);
-        $this->assertTrue($resource->deleted);
+        static::assertTrue($resource->deleted);
     }
 
     public function testCanListExternalAccounts()
@@ -213,7 +213,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/external_accounts'
         );
         $resources = Account::allExternalAccounts(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateLoginLink()
@@ -223,7 +223,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/login_links'
         );
         $resource = Account::createLoginLink(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\LoginLink::class, $resource);
+        static::assertInstanceOf(\Stripe\LoginLink::class, $resource);
     }
 
     public function testCanCreatePerson()
@@ -239,7 +239,7 @@ class AccountTest extends TestCase
                 "year" => 1980
             ]
         ]);
-        $this->assertInstanceOf(\Stripe\Person::class, $resource);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
     }
 
     public function testCanRetrievePerson()
@@ -249,7 +249,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons/' . self::TEST_PERSON_ID
         );
         $resource = Account::retrievePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID);
-        $this->assertInstanceOf(\Stripe\Person::class, $resource);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
     }
 
     public function testCanUpdatePerson()
@@ -261,7 +261,7 @@ class AccountTest extends TestCase
         $resource = Account::updatePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID, [
             "first_name" => "First name",
         ]);
-        $this->assertInstanceOf(\Stripe\Person::class, $resource);
+        static::assertInstanceOf(\Stripe\Person::class, $resource);
     }
 
     public function testCanDeletePerson()
@@ -271,7 +271,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons/' . self::TEST_PERSON_ID
         );
         $resource = Account::deletePerson(self::TEST_RESOURCE_ID, self::TEST_PERSON_ID);
-        $this->assertTrue($resource->deleted);
+        static::assertTrue($resource->deleted);
     }
 
     public function testCanListPersons()
@@ -281,7 +281,7 @@ class AccountTest extends TestCase
             '/v1/accounts/' . self::TEST_RESOURCE_ID . '/persons'
         );
         $resources = Account::allPersons(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testSerializeNewAdditionalOwners()
@@ -303,7 +303,7 @@ class AccountTest extends TestCase
                 ],
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeAddAdditionalOwners()
@@ -326,7 +326,7 @@ class AccountTest extends TestCase
                 ],
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializePartiallyChangedAdditionalOwners()
@@ -349,7 +349,7 @@ class AccountTest extends TestCase
                 ],
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeUnchangedAdditionalOwners()
@@ -369,7 +369,7 @@ class AccountTest extends TestCase
                 'additional_owners' => [],
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeUnsetAdditionalOwners()
@@ -392,7 +392,7 @@ class AccountTest extends TestCase
                 'additional_owners' => '',
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeAdditionalOwnersDeletedItem()
@@ -423,7 +423,7 @@ class AccountTest extends TestCase
         $expected = [
             'external_account' => 'btok_123',
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeExternalAccountHash()
@@ -448,7 +448,7 @@ class AccountTest extends TestCase
                 'currency' => 'usd',
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeBankAccountString()
@@ -461,7 +461,7 @@ class AccountTest extends TestCase
         $expected = [
             'bank_account' => 'btok_123',
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeBankAccountHash()
@@ -486,7 +486,7 @@ class AccountTest extends TestCase
                 'currency' => 'usd',
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeNewIndividual()
@@ -497,7 +497,7 @@ class AccountTest extends TestCase
         $obj->individual = ['first_name' => 'Jane'];
 
         $expected = ['individual' => ['first_name' => 'Jane']];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializePartiallyChangedIndividual()
@@ -512,7 +512,7 @@ class AccountTest extends TestCase
         $obj->individual = ['first_name' => 'Jane'];
 
         $expected = ['individual' => ['first_name' => 'Jane']];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeUnchangedIndividual()
@@ -526,7 +526,7 @@ class AccountTest extends TestCase
         ], null);
 
         $expected = ['individual' => []];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeUnsetIndividual()
@@ -541,6 +541,6 @@ class AccountTest extends TestCase
         $obj->individual = null;
 
         $expected = ['individual' => ''];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 }

--- a/tests/Stripe/AlipayAccountTest.php
+++ b/tests/Stripe/AlipayAccountTest.php
@@ -27,7 +27,7 @@ class AlipayAccountTest extends TestCase
     public function testHasCorrectUrlForCustomer()
     {
         $resource = $this->createFixture(['customer' => 'cus_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/cus_123/sources/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -49,7 +49,7 @@ class AlipayAccountTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame(\Stripe\AlipayAccount::class, \get_class($resource));
+        static::assertSame(\Stripe\AlipayAccount::class, \get_class($resource));
     }
 
     public function testIsNotDirectlyUpdatable()
@@ -69,6 +69,6 @@ class AlipayAccountTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame(\Stripe\AlipayAccount::class, \get_class($resource));
+        static::assertSame(\Stripe\AlipayAccount::class, \get_class($resource));
     }
 }

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -14,26 +14,26 @@ class ApiRequestorTest extends TestCase
 
         $a = ['customer' => new Customer('abcd')];
         $enc = $method->invoke(null, $a);
-        $this->assertSame($enc, ['customer' => 'abcd']);
+        static::assertSame($enc, ['customer' => 'abcd']);
 
         // Preserves UTF-8
         $v = ['customer' => "☃"];
         $enc = $method->invoke(null, $v);
-        $this->assertSame($enc, $v);
+        static::assertSame($enc, $v);
 
         // Encodes latin-1 -> UTF-8
         $v = ['customer' => "\xe9"];
         $enc = $method->invoke(null, $v);
-        $this->assertSame($enc, ['customer' => "\xc3\xa9"]);
+        static::assertSame($enc, ['customer' => "\xc3\xa9"]);
 
         // Encodes booleans
         $v = true;
         $enc = $method->invoke(null, $v);
-        $this->assertSame('true', $enc);
+        static::assertSame('true', $enc);
 
         $v = false;
         $enc = $method->invoke(null, $v);
-        $this->assertSame('false', $enc);
+        static::assertSame('false', $enc);
     }
 
     public function testHttpClientInjection()
@@ -47,7 +47,7 @@ class ApiRequestorTest extends TestCase
         ApiRequestor::setHttpClient($curl);
 
         $injectedCurl = $method->invoke(new ApiRequestor());
-        $this->assertSame($injectedCurl, $curl);
+        static::assertSame($injectedCurl, $curl);
     }
 
     public function testDefaultHeaders()
@@ -64,19 +64,19 @@ class ApiRequestorTest extends TestCase
         $headers = $method->invoke(null, $apiKey, $clientInfo);
 
         $ua = \json_decode($headers['X-Stripe-Client-User-Agent']);
-        $this->assertSame($ua->application->name, 'MyTestApp');
-        $this->assertSame($ua->application->version, '1.2.34');
-        $this->assertSame($ua->application->url, 'https://mytestapp.example');
-        $this->assertSame($ua->application->partner_id, 'partner_1234');
+        static::assertSame($ua->application->name, 'MyTestApp');
+        static::assertSame($ua->application->version, '1.2.34');
+        static::assertSame($ua->application->url, 'https://mytestapp.example');
+        static::assertSame($ua->application->partner_id, 'partner_1234');
 
-        $this->assertSame($ua->httplib, 'testlib 0.1.2');
+        static::assertSame($ua->httplib, 'testlib 0.1.2');
 
-        $this->assertSame(
+        static::assertSame(
             $headers['User-Agent'],
             'Stripe/v1 PhpBindings/' . Stripe::VERSION . ' MyTestApp/1.2.34 (https://mytestapp.example)'
         );
 
-        $this->assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
+        static::assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
 
     public function testRaisesAuthenticationErrorWhenNoApiKey()
@@ -108,14 +108,14 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\InvalidRequestException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('Missing id', $e->getMessage());
-            $this->assertSame('id', $e->getStripeParam());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('Missing id', $e->getMessage());
+            static::assertSame('id', $e->getStripeParam());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -138,13 +138,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\IdempotencyException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame("Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.", $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame("Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than 'abc' if you meant to execute a different request.", $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -167,13 +167,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\AuthenticationException $e) {
-            $this->assertSame(401, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('You did not provide an API key.', $e->getMessage());
+            static::assertSame(401, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('You did not provide an API key.', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -200,16 +200,16 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\CardException $e) {
-            $this->assertSame(402, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('Your card was declined.', $e->getMessage());
-            $this->assertSame('card_declined', $e->getStripeCode());
-            $this->assertSame('generic_decline', $e->getDeclineCode());
-            $this->assertSame('exp_month', $e->getStripeParam());
+            static::assertSame(402, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('Your card was declined.', $e->getMessage());
+            static::assertSame('card_declined', $e->getStripeCode());
+            static::assertSame('generic_decline', $e->getDeclineCode());
+            static::assertSame('exp_month', $e->getStripeParam());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -232,13 +232,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             Account::retrieve('foo');
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\PermissionException $e) {
-            $this->assertSame(403, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame("The provided key 'sk_test_********************1234' does not have access to account 'foo' (or that account does not exist). Application access may have been revoked.", $e->getMessage());
+            static::assertSame(403, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame("The provided key 'sk_test_********************1234' does not have access to account 'foo' (or that account does not exist). Application access may have been revoked.", $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -262,14 +262,14 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::retrieve('foo');
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\InvalidRequestException $e) {
-            $this->assertSame(404, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('No such charge: foo', $e->getMessage());
-            $this->assertSame('id', $e->getStripeParam());
+            static::assertSame(404, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('No such charge: foo', $e->getMessage());
+            static::assertSame('id', $e->getStripeParam());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -291,14 +291,14 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\RateLimitException $e) {
-            $this->assertSame(429, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('Too many requests', $e->getMessage());
+            static::assertSame(429, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('Too many requests', $e->getMessage());
         } catch (\Exception $e) {
             \var_dump($e);
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -321,13 +321,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             Charge::create();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\RateLimitException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertInternalType('array', $e->getJsonBody());
-            $this->assertSame('Too many requests', $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertInternalType('array', $e->getJsonBody());
+            static::assertSame('Too many requests', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -349,13 +349,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\InvalidRequestException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertSame('invalid_request', $e->getStripeCode());
-            $this->assertSame('No grant type specified', $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('invalid_request', $e->getStripeCode());
+            static::assertSame('No grant type specified', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -377,13 +377,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\InvalidClientException $e) {
-            $this->assertSame(401, $e->getHttpStatus());
-            $this->assertSame('invalid_client', $e->getStripeCode());
-            $this->assertSame('No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter.', $e->getMessage());
+            static::assertSame(401, $e->getHttpStatus());
+            static::assertSame('invalid_client', $e->getStripeCode());
+            static::assertSame('No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter.', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -405,13 +405,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\InvalidGrantException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertSame('invalid_grant', $e->getStripeCode());
-            $this->assertSame('This authorization code has already been used. All tokens issued with this code have been revoked.', $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('invalid_grant', $e->getStripeCode());
+            static::assertSame('This authorization code has already been used. All tokens issued with this code have been revoked.', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -433,13 +433,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\InvalidScopeException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertSame('invalid_scope', $e->getStripeCode());
-            $this->assertSame('Invalid scope provided: invalid_scope.', $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('invalid_scope', $e->getStripeCode());
+            static::assertSame('Invalid scope provided: invalid_scope.', $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -460,12 +460,12 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\UnsupportedGrantTypeException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertSame('unsupported_grant_type', $e->getStripeCode());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('unsupported_grant_type', $e->getStripeCode());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -487,13 +487,13 @@ class ApiRequestorTest extends TestCase
 
         try {
             OAuth::token();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (Exception\OAuth\UnsupportedResponseTypeException $e) {
-            $this->assertSame(400, $e->getHttpStatus());
-            $this->assertSame('unsupported_response_type', $e->getStripeCode());
-            $this->assertSame("Only 'code' response_type is supported, but 'unsupported_response_type' was provided", $e->getMessage());
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('unsupported_response_type', $e->getStripeCode());
+            static::assertSame("Only 'code' response_type is supported, but 'unsupported_response_type' was provided", $e->getMessage());
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 

--- a/tests/Stripe/ApplePayDomainTest.php
+++ b/tests/Stripe/ApplePayDomainTest.php
@@ -13,8 +13,8 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains'
         );
         $resources = ApplePayDomain::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\ApplePayDomain::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains/' . self::TEST_RESOURCE_ID
         );
         $resource = ApplePayDomain::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class ApplePayDomainTest extends TestCase
         $resource = ApplePayDomain::create([
             "domain_name" => "domain",
         ]);
-        $this->assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
     }
 
     public function testIsDeletable()
@@ -47,6 +47,6 @@ class ApplePayDomainTest extends TestCase
             '/v1/apple_pay/domains/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplePayDomain::class, $resource);
     }
 }

--- a/tests/Stripe/ApplicationFeeRefundTest.php
+++ b/tests/Stripe/ApplicationFeeRefundTest.php
@@ -16,6 +16,6 @@ class ApplicationFeeRefundTest extends TestCase
             '/v1/application_fees/' . $resource->fee . '/refunds/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
     }
 }

--- a/tests/Stripe/ApplicationFeeTest.php
+++ b/tests/Stripe/ApplicationFeeTest.php
@@ -14,8 +14,8 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees'
         );
         $resources = ApplicationFee::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\ApplicationFee::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplicationFee::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID
         );
         $resource = ApplicationFee::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\ApplicationFee::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplicationFee::class, $resource);
     }
 
     public function testCanCreateRefund()
@@ -35,7 +35,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
         );
         $resource = ApplicationFee::createRefund(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
     }
 
     public function testCanRetrieveRefund()
@@ -45,7 +45,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
         );
         $resource = ApplicationFee::retrieveRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
-        $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
     }
 
     public function testCanUpdateRefund()
@@ -55,7 +55,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds/' . self::TEST_FEEREFUND_ID
         );
         $resource = ApplicationFee::updateRefund(self::TEST_RESOURCE_ID, self::TEST_FEEREFUND_ID);
-        $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resource);
     }
 
     public function testCanListRefunds()
@@ -65,7 +65,7 @@ class ApplicationFeeTest extends TestCase
             '/v1/application_fees/' . self::TEST_RESOURCE_ID . '/refunds'
         );
         $resources = ApplicationFee::allRefunds(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\ApplicationFeeRefund::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/BalanceTest.php
+++ b/tests/Stripe/BalanceTest.php
@@ -11,6 +11,6 @@ class BalanceTest extends TestCase
             '/v1/balance'
         );
         $resource = Balance::retrieve();
-        $this->assertInstanceOf(\Stripe\Balance::class, $resource);
+        static::assertInstanceOf(\Stripe\Balance::class, $resource);
     }
 }

--- a/tests/Stripe/BalanceTransactionTest.php
+++ b/tests/Stripe/BalanceTransactionTest.php
@@ -13,8 +13,8 @@ class BalanceTransactionTest extends TestCase
             '/v1/balance_transactions'
         );
         $resources = BalanceTransaction::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\BalanceTransaction::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\BalanceTransaction::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class BalanceTransactionTest extends TestCase
             '/v1/balance_transactions/' . self::TEST_RESOURCE_ID
         );
         $resource = BalanceTransaction::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\BalanceTransaction::class, $resource);
+        static::assertInstanceOf(\Stripe\BalanceTransaction::class, $resource);
     }
 }

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -27,7 +27,7 @@ class BankAccountTest extends TestCase
     public function testHasCorrectUrlForCustomer()
     {
         $resource = $this->createFixture(['customer' => 'cus_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/cus_123/sources/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -36,7 +36,7 @@ class BankAccountTest extends TestCase
     public function testHasCorrectUrlForAccount()
     {
         $resource = $this->createFixture(['account' => 'acct_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/accounts/acct_123/external_accounts/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -58,7 +58,7 @@ class BankAccountTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame(\Stripe\BankAccount::class, \get_class($resource));
+        static::assertSame(\Stripe\BankAccount::class, \get_class($resource));
     }
 
     public function testIsNotDirectlyUpdatable()
@@ -78,7 +78,7 @@ class BankAccountTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame(\Stripe\BankAccount::class, \get_class($resource));
+        static::assertSame(\Stripe\BankAccount::class, \get_class($resource));
     }
 
     public function testIsVerifiable()
@@ -92,6 +92,6 @@ class BankAccountTest extends TestCase
             ]
         );
         $resource->verify(["amounts" => [1, 2]]);
-        $this->assertInstanceOf(\Stripe\BankAccount::class, $resource);
+        static::assertInstanceOf(\Stripe\BankAccount::class, $resource);
     }
 }

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -88,7 +88,7 @@ class BankAccountTest extends TestCase
             'post',
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID . "/verify",
             [
-                "amounts" => [1, 2]
+                "amounts" => [1, 2],
             ]
         );
         $resource->verify(["amounts" => [1, 2]]);

--- a/tests/Stripe/BitcoinReceiverTest.php
+++ b/tests/Stripe/BitcoinReceiverTest.php
@@ -24,7 +24,7 @@ class BitcoinReceiverTest extends TestCase
     public function testHasCorrectStandaloneUrl()
     {
         $resource = $this->createFixture();
-        $this->assertSame(
+        static::assertSame(
             "/v1/bitcoin/receivers/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -33,7 +33,7 @@ class BitcoinReceiverTest extends TestCase
     public function testHasCorrectUrlForCustomer()
     {
         $resource = $this->createFixture(['customer' => 'cus_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/cus_123/sources/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -46,8 +46,8 @@ class BitcoinReceiverTest extends TestCase
             '/v1/bitcoin/receivers'
         );
         $resources = BitcoinReceiver::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertSame(\Stripe\BitcoinReceiver::class, \get_class($resources->data[0]));
+        static::assertInternalType('array', $resources->data);
+        static::assertSame(\Stripe\BitcoinReceiver::class, \get_class($resources->data[0]));
     }
 
     public function testIsRetrievable()
@@ -57,6 +57,6 @@ class BitcoinReceiverTest extends TestCase
             '/v1/bitcoin/receivers/' . self::TEST_RESOURCE_ID
         );
         $resource = BitcoinReceiver::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertSame(\Stripe\BitcoinReceiver::class, \get_class($resource));
+        static::assertSame(\Stripe\BitcoinReceiver::class, \get_class($resource));
     }
 }

--- a/tests/Stripe/CapabilityTest.php
+++ b/tests/Stripe/CapabilityTest.php
@@ -10,7 +10,7 @@ class CapabilityTest extends TestCase
     public function testHasCorrectUrl()
     {
         $resource = \Stripe\Account::retrieveCapability(self::TEST_ACCOUNT_ID, self::TEST_RESOURCE_ID);
-        $this->assertSame(
+        static::assertSame(
             "/v1/accounts/" . self::TEST_ACCOUNT_ID . "/capabilities/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -32,7 +32,7 @@ class CapabilityTest extends TestCase
             '/v1/accounts/' . self::TEST_ACCOUNT_ID . '/capabilities/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Capability::class, $resource);
+        static::assertInstanceOf(\Stripe\Capability::class, $resource);
     }
 
     public function testIsNotDirectlyUpdatable()

--- a/tests/Stripe/CardTest.php
+++ b/tests/Stripe/CardTest.php
@@ -27,7 +27,7 @@ class CardTest extends TestCase
     public function testHasCorrectUrlForCustomer()
     {
         $resource = $this->createFixture(['customer' => 'cus_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/cus_123/sources/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -36,7 +36,7 @@ class CardTest extends TestCase
     public function testHasCorrectUrlForAccount()
     {
         $resource = $this->createFixture(['account' => 'acct_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/accounts/acct_123/external_accounts/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -45,7 +45,7 @@ class CardTest extends TestCase
     public function testHasCorrectUrlForRecipient()
     {
         $resource = $this->createFixture(['recipient' => 'rp_123']);
-        $this->assertSame(
+        static::assertSame(
             "/v1/recipients/rp_123/cards/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -67,7 +67,7 @@ class CardTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame(\Stripe\Card::class, \get_class($resource));
+        static::assertSame(\Stripe\Card::class, \get_class($resource));
     }
 
     public function testIsNotDirectlyUpdatable()
@@ -87,6 +87,6 @@ class CardTest extends TestCase
             '/v1/customers/cus_123/sources/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame(\Stripe\Card::class, \get_class($resource));
+        static::assertSame(\Stripe\Card::class, \get_class($resource));
     }
 }

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -13,8 +13,8 @@ class ChargeTest extends TestCase
             '/v1/charges'
         );
         $resources = Charge::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Charge::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Charge::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . self::TEST_RESOURCE_ID
         );
         $resource = Charge::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Charge::class, $resource);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class ChargeTest extends TestCase
             "currency" => "usd",
             "source" => "tok_123"
         ]);
-        $this->assertInstanceOf(\Stripe\Charge::class, $resource);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Charge::class, $resource);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -62,7 +62,7 @@ class ChargeTest extends TestCase
         $resource = Charge::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Charge::class, $resource);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
     }
 
     public function testCanCapture()
@@ -73,7 +73,7 @@ class ChargeTest extends TestCase
             '/v1/charges/' . $charge->id . '/capture'
         );
         $resource = $charge->capture();
-        $this->assertInstanceOf(\Stripe\Charge::class, $resource);
-        $this->assertSame($resource, $charge);
+        static::assertInstanceOf(\Stripe\Charge::class, $resource);
+        static::assertSame($resource, $charge);
     }
 }

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -36,7 +36,7 @@ class ChargeTest extends TestCase
         $resource = Charge::create([
             "amount" => 100,
             "currency" => "usd",
-            "source" => "tok_123"
+            "source" => "tok_123",
         ]);
         static::assertInstanceOf(\Stripe\Charge::class, $resource);
     }

--- a/tests/Stripe/Checkout/SessionTest.php
+++ b/tests/Stripe/Checkout/SessionTest.php
@@ -33,7 +33,7 @@ class SessionTest extends \Stripe\TestCase
             'payment_method_types' => ['card'],
             'success_url' => 'https://stripe.com/success'
         ]);
-        $this->assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
+        static::assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
     }
 
     public function testIsRetrievable()
@@ -43,6 +43,6 @@ class SessionTest extends \Stripe\TestCase
             '/v1/checkout/sessions/' . self::TEST_RESOURCE_ID
         );
         $resource = Session::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
+        static::assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
     }
 }

--- a/tests/Stripe/Checkout/SessionTest.php
+++ b/tests/Stripe/Checkout/SessionTest.php
@@ -31,7 +31,7 @@ class SessionTest extends \Stripe\TestCase
                 'receipt_email' => 'test@stripe.com',
             ],
             'payment_method_types' => ['card'],
-            'success_url' => 'https://stripe.com/success'
+            'success_url' => 'https://stripe.com/success',
         ]);
         static::assertInstanceOf(\Stripe\Checkout\Session::class, $resource);
     }

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -44,7 +44,7 @@ class CollectionTest extends TestCase
         );
 
         $resources = $this->fixture->all();
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testCanRetrieve()
@@ -96,7 +96,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([1, 2, 3], $seen);
+        static::assertSame([1, 2, 3], $seen);
     }
 
     public function testCanIterateBackwards()
@@ -112,7 +112,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([3, 2, 1], $seen);
+        static::assertSame([3, 2, 1], $seen);
     }
 
     public function testSupportsIteratorToArray()
@@ -122,7 +122,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([1], $seen);
+        static::assertSame([1], $seen);
     }
 
     public function testProvidesAutoPagingIterator()
@@ -147,7 +147,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([1, 2, 3], $seen);
+        static::assertSame([1, 2, 3], $seen);
     }
 
     public function testAutoPagingIteratorSupportsIteratorToArray()
@@ -172,7 +172,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([1, 2, 3], $seen);
+        static::assertSame([1, 2, 3], $seen);
     }
 
     public function testProvidesAutoPagingIteratorThatSupportsBackwardsPagination()
@@ -204,7 +204,7 @@ class CollectionTest extends TestCase
             \array_push($seen, $item['id']);
         }
 
-        $this->assertSame([3, 2, 1], $seen);
+        static::assertSame([3, 2, 1], $seen);
     }
 
     public function testHeaders()
@@ -236,16 +236,16 @@ class CollectionTest extends TestCase
     public function testEmptyCollection()
     {
         $emptyCollection = Collection::emptyCollection();
-        $this->assertEquals([], $emptyCollection->data);
+        static::assertEquals([], $emptyCollection->data);
     }
 
     public function testIsEmpty()
     {
         $empty = Collection::constructFrom(['data' => []]);
-        $this->assertTrue($empty->isEmpty());
+        static::assertTrue($empty->isEmpty());
 
         $notEmpty = Collection::constructFrom(['data' => [['id' => 1]]]);
-        $this->assertFalse($notEmpty->isEmpty());
+        static::assertFalse($notEmpty->isEmpty());
     }
 
     public function testNextPage()
@@ -270,7 +270,7 @@ class CollectionTest extends TestCase
         foreach ($nextPage->data as $element) {
             \array_push($ids, $element['id']);
         }
-        $this->assertEquals([2, 3], $ids);
+        static::assertEquals([2, 3], $ids);
     }
 
     public function testPreviousPage()
@@ -291,6 +291,6 @@ class CollectionTest extends TestCase
         );
 
         $previousPage = $this->fixture->previousPage();
-        $this->assertEquals([], $previousPage->data);
+        static::assertEquals([], $previousPage->data);
     }
 }

--- a/tests/Stripe/CountrySpecTest.php
+++ b/tests/Stripe/CountrySpecTest.php
@@ -13,8 +13,8 @@ class CountrySpecTest extends TestCase
             '/v1/country_specs'
         );
         $resources = CountrySpec::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\CountrySpec::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CountrySpec::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class CountrySpecTest extends TestCase
             '/v1/country_specs/' . self::TEST_RESOURCE_ID
         );
         $resource = CountrySpec::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\CountrySpec::class, $resource);
+        static::assertInstanceOf(\Stripe\CountrySpec::class, $resource);
     }
 }

--- a/tests/Stripe/CouponTest.php
+++ b/tests/Stripe/CouponTest.php
@@ -13,8 +13,8 @@ class CouponTest extends TestCase
             '/v1/coupons'
         );
         $resources = Coupon::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource = Coupon::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class CouponTest extends TestCase
             "duration_in_months" => 3,
             "id" => self::TEST_RESOURCE_ID,
         ]);
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
     }
 
     public function testIsSaveable()
@@ -51,7 +51,7 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class CouponTest extends TestCase
         $resource = Coupon::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
     }
 
     public function testIsDeletable()
@@ -74,6 +74,6 @@ class CouponTest extends TestCase
             '/v1/coupons/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Coupon::class, $resource);
+        static::assertInstanceOf(\Stripe\Coupon::class, $resource);
     }
 }

--- a/tests/Stripe/CreditNoteTest.php
+++ b/tests/Stripe/CreditNoteTest.php
@@ -13,8 +13,8 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes'
         );
         $resources = CreditNote::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes/' . self::TEST_RESOURCE_ID
         );
         $resource = CreditNote::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class CreditNoteTest extends TestCase
             "invoice" => "in_132",
             "reason" => "duplicate",
         ]);
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -62,7 +62,7 @@ class CreditNoteTest extends TestCase
         $resource = CreditNote::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
     }
 
     public function testCanPreview()
@@ -75,7 +75,7 @@ class CreditNoteTest extends TestCase
             'amount' => 100,
             'invoice' => 'in_123',
         ]);
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
     }
 
     public function testCanVoidCreditNote()
@@ -86,8 +86,8 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes/' . $creditNote->id . '/void'
         );
         $resource = $creditNote->voidCreditNote();
-        $this->assertInstanceOf(\Stripe\CreditNote::class, $resource);
-        $this->assertSame($resource, $creditNote);
+        static::assertInstanceOf(\Stripe\CreditNote::class, $resource);
+        static::assertSame($resource, $creditNote);
     }
 
     public function testCanListLines()
@@ -97,6 +97,6 @@ class CreditNoteTest extends TestCase
             '/v1/credit_notes/' . self::TEST_RESOURCE_ID . '/lines'
         );
         $resources = CreditNote::allLines(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/CustomerBalanceTransactionTest.php
+++ b/tests/Stripe/CustomerBalanceTransactionTest.php
@@ -10,7 +10,7 @@ class CustomerBalanceTransactionTest extends TestCase
     public function testHasCorrectUrl()
     {
         $resource = \Stripe\Customer::retrieveBalanceTransaction(self::TEST_CUSTOMER_ID, self::TEST_RESOURCE_ID);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/" . self::TEST_CUSTOMER_ID . "/balance_transactions/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -16,8 +16,8 @@ class CustomerTest extends TestCase
             '/v1/customers'
         );
         $resources = Customer::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Customer::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Customer::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -27,7 +27,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID
         );
         $resource = Customer::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class CustomerTest extends TestCase
             '/v1/customers'
         );
         $resource = Customer::create();
-        $this->assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class CustomerTest extends TestCase
         $resource = Customer::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,7 +72,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Customer::class, $resource);
+        static::assertInstanceOf(\Stripe\Customer::class, $resource);
     }
 
     public function testCanDeleteDiscount()
@@ -83,7 +83,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . $customer->id . '/discount'
         );
         $customer->deleteDiscount();
-        $this->assertSame($customer->discount, null);
+        static::assertSame($customer->discount, null);
     }
 
     public function testCanCreateSource()
@@ -112,7 +112,7 @@ class CustomerTest extends TestCase
         );
         $resource = Customer::updateSource(self::TEST_RESOURCE_ID, self::TEST_SOURCE_ID, ["name" => "name"]);
         // stripe-mock returns a Card on this method and not a bank account
-        $this->assertInstanceOf(\Stripe\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Card::class, $resource);
     }
 
     public function testCanDeleteSource()
@@ -131,7 +131,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/sources'
         );
         $resources = Customer::allSources(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testSerializeSourceString()
@@ -144,7 +144,7 @@ class CustomerTest extends TestCase
         $expected = [
             'source' => 'tok_visa',
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testSerializeSourceMap()
@@ -167,7 +167,7 @@ class CustomerTest extends TestCase
                 'exp_year' => 2032,
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 
     public function testCanCreateTaxId()
@@ -207,7 +207,7 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/tax_ids'
         );
         $resources = Customer::allTaxIds(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 
     public function testCanCreateBalanceTransaction()
@@ -247,6 +247,6 @@ class CustomerTest extends TestCase
             '/v1/customers/' . self::TEST_RESOURCE_ID . '/balance_transactions'
         );
         $resources = Customer::allBalanceTransactions(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/DisputeTest.php
+++ b/tests/Stripe/DisputeTest.php
@@ -13,8 +13,8 @@ class DisputeTest extends TestCase
             '/v1/disputes'
         );
         $resources = Dispute::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Dispute::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . self::TEST_RESOURCE_ID
         );
         $resource = Dispute::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
     }
 
     public function testIsSaveable()
@@ -36,7 +36,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -48,7 +48,7 @@ class DisputeTest extends TestCase
         $resource = Dispute::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
     }
 
     public function testIsClosable()
@@ -59,7 +59,7 @@ class DisputeTest extends TestCase
             '/v1/disputes/' . $dispute->id . '/close'
         );
         $resource = $dispute->close();
-        $this->assertInstanceOf(\Stripe\Dispute::class, $resource);
-        $this->assertSame($resource, $dispute);
+        static::assertInstanceOf(\Stripe\Dispute::class, $resource);
+        static::assertSame($resource, $dispute);
     }
 }

--- a/tests/Stripe/EphemeralKeyTest.php
+++ b/tests/Stripe/EphemeralKeyTest.php
@@ -15,7 +15,7 @@ class EphemeralKeyTest extends TestCase
         $resource = EphemeralKey::create([
             "customer" => "cus_123",
         ], ["stripe_version" => "2017-05-25"]);
-        $this->assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
+        static::assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
     }
 
     public function testIsNotCreatableWithoutAnExplicitApiVersion()
@@ -37,6 +37,6 @@ class EphemeralKeyTest extends TestCase
             '/v1/ephemeral_keys/' . $key->id
         );
         $resource = $key->delete();
-        $this->assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
+        static::assertInstanceOf(\Stripe\EphemeralKey::class, $resource);
     }
 }

--- a/tests/Stripe/ErrorObjectTest.php
+++ b/tests/Stripe/ErrorObjectTest.php
@@ -8,16 +8,16 @@ class ErrorObjectTest extends TestCase
     {
         $error = ErrorObject::constructFrom([]);
 
-        $this->assertNull($error->charge);
-        $this->assertNull($error->code);
-        $this->assertNull($error->decline_code);
-        $this->assertNull($error->doc_url);
-        $this->assertNull($error->message);
-        $this->assertNull($error->param);
-        $this->assertNull($error->payment_intent);
-        $this->assertNull($error->payment_method);
-        $this->assertNull($error->setup_intent);
-        $this->assertNull($error->source);
-        $this->assertNull($error->type);
+        static::assertNull($error->charge);
+        static::assertNull($error->code);
+        static::assertNull($error->decline_code);
+        static::assertNull($error->doc_url);
+        static::assertNull($error->message);
+        static::assertNull($error->param);
+        static::assertNull($error->payment_intent);
+        static::assertNull($error->payment_method);
+        static::assertNull($error->setup_intent);
+        static::assertNull($error->source);
+        static::assertNull($error->type);
     }
 }

--- a/tests/Stripe/EventTest.php
+++ b/tests/Stripe/EventTest.php
@@ -13,8 +13,8 @@ class EventTest extends TestCase
             '/v1/events'
         );
         $resources = Event::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Event::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Event::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class EventTest extends TestCase
             '/v1/events/' . self::TEST_RESOURCE_ID
         );
         $resource = Event::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Event::class, $resource);
+        static::assertInstanceOf(\Stripe\Event::class, $resource);
     }
 }

--- a/tests/Stripe/Exception/ApiErrorExceptionTest.php
+++ b/tests/Stripe/Exception/ApiErrorExceptionTest.php
@@ -7,7 +7,7 @@ class ApiErrorExceptionTest extends \Stripe\TestCase
     public function createFixture()
     {
         $mock = $this->getMockForAbstractClass(ApiErrorException::class);
-        $instance = $mock::factory(
+        return $mock::factory(
             'message',
             200,
             '{"error": {"code": "some_code"}}',
@@ -18,7 +18,6 @@ class ApiErrorExceptionTest extends \Stripe\TestCase
             ],
             'some_code'
         );
-        return $instance;
     }
 
     public function testGetters()

--- a/tests/Stripe/Exception/ApiErrorExceptionTest.php
+++ b/tests/Stripe/Exception/ApiErrorExceptionTest.php
@@ -24,19 +24,19 @@ class ApiErrorExceptionTest extends \Stripe\TestCase
     public function testGetters()
     {
         $e = $this->createFixture();
-        $this->assertSame(200, $e->getHttpStatus());
-        $this->assertSame('{"error": {"code": "some_code"}}', $e->getHttpBody());
-        $this->assertSame(['error' => ['code' => 'some_code']], $e->getJsonBody());
-        $this->assertSame('Some Value', $e->getHttpHeaders()['Some-Header']);
-        $this->assertSame('req_test', $e->getRequestId());
-        $this->assertSame('some_code', $e->getStripeCode());
-        $this->assertNotNull($e->getError());
-        $this->assertSame('some_code', $e->getError()->code);
+        static::assertSame(200, $e->getHttpStatus());
+        static::assertSame('{"error": {"code": "some_code"}}', $e->getHttpBody());
+        static::assertSame(['error' => ['code' => 'some_code']], $e->getJsonBody());
+        static::assertSame('Some Value', $e->getHttpHeaders()['Some-Header']);
+        static::assertSame('req_test', $e->getRequestId());
+        static::assertSame('some_code', $e->getStripeCode());
+        static::assertNotNull($e->getError());
+        static::assertSame('some_code', $e->getError()->code);
     }
 
     public function testToString()
     {
         $e = $this->createFixture();
-        $this->assertContains("(Request req_test)", (string) $e);
+        static::assertContains("(Request req_test)", (string) $e);
     }
 }

--- a/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
+++ b/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
@@ -24,20 +24,20 @@ class OAuthErrorExceptionTest extends \Stripe\TestCase
     public function testGetters()
     {
         $e = $this->createFixture();
-        $this->assertSame(200, $e->getHttpStatus());
-        $this->assertSame('{"error": "code", "error_description": "description"}', $e->getHttpBody());
-        $this->assertSame(['error' => 'code', 'error_description' => 'description'], $e->getJsonBody());
-        $this->assertSame('Some Value', $e->getHttpHeaders()['Some-Header']);
-        $this->assertSame('req_test', $e->getRequestId());
-        $this->assertSame('code', $e->getStripeCode());
-        $this->assertNotNull($e->getError());
-        $this->assertSame('code', $e->getError()->error);
-        $this->assertSame('description', $e->getError()->error_description);
+        static::assertSame(200, $e->getHttpStatus());
+        static::assertSame('{"error": "code", "error_description": "description"}', $e->getHttpBody());
+        static::assertSame(['error' => 'code', 'error_description' => 'description'], $e->getJsonBody());
+        static::assertSame('Some Value', $e->getHttpHeaders()['Some-Header']);
+        static::assertSame('req_test', $e->getRequestId());
+        static::assertSame('code', $e->getStripeCode());
+        static::assertNotNull($e->getError());
+        static::assertSame('code', $e->getError()->error);
+        static::assertSame('description', $e->getError()->error_description);
     }
 
     public function testToString()
     {
         $e = $this->createFixture();
-        $this->assertContains("(Request req_test)", (string) $e);
+        static::assertContains("(Request req_test)", (string) $e);
     }
 }

--- a/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
+++ b/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
@@ -7,7 +7,7 @@ class OAuthErrorExceptionTest extends \Stripe\TestCase
     public function createFixture()
     {
         $mock = $this->getMockForAbstractClass(OAuthErrorException::class);
-        $instance = $mock::factory(
+        return $mock::factory(
             'description',
             200,
             '{"error": "code", "error_description": "description"}',
@@ -18,7 +18,6 @@ class OAuthErrorExceptionTest extends \Stripe\TestCase
             ],
             'code'
         );
-        return $instance;
     }
 
     public function testGetters()

--- a/tests/Stripe/Exception/SignatureVerificationExceptionTest.php
+++ b/tests/Stripe/Exception/SignatureVerificationExceptionTest.php
@@ -7,8 +7,8 @@ class SignatureVerificationExceptionTest extends \Stripe\TestCase
     public function testGetters()
     {
         $e = SignatureVerificationException::factory('message', 'payload', 'sig_header');
-        $this->assertSame('message', $e->getMessage());
-        $this->assertSame('payload', $e->getHttpBody());
-        $this->assertSame('sig_header', $e->getSigHeader());
+        static::assertSame('message', $e->getMessage());
+        static::assertSame('payload', $e->getHttpBody());
+        static::assertSame('sig_header', $e->getSigHeader());
     }
 }

--- a/tests/Stripe/ExchangeRateTest.php
+++ b/tests/Stripe/ExchangeRateTest.php
@@ -30,8 +30,8 @@ class ExchangeRateTest extends TestCase
         );
 
         $listRates = ExchangeRate::all();
-        $this->assertInternalType('array', $listRates->data);
-        $this->assertEquals('exchange_rate', $listRates->data[0]->object);
+        static::assertInternalType('array', $listRates->data);
+        static::assertEquals('exchange_rate', $listRates->data[0]->object);
     }
 
     public function testIsRetrievable()
@@ -49,6 +49,6 @@ class ExchangeRateTest extends TestCase
             ]
         );
         $rates = ExchangeRate::retrieve("usd");
-        $this->assertEquals('exchange_rate', $rates->object);
+        static::assertEquals('exchange_rate', $rates->object);
     }
 }

--- a/tests/Stripe/FileCreationTest.php
+++ b/tests/Stripe/FileCreationTest.php
@@ -42,7 +42,7 @@ class FileCreationTest extends TestCase
             "file" => $fp,
             "file_link_data" => ["create" => true]
         ]);
-        $this->assertInstanceOf(\Stripe\File::class, $resource);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
     }
 
     public function testIsCreatableWithCURLFile()
@@ -61,6 +61,6 @@ class FileCreationTest extends TestCase
             "file" => $curlFile,
             "file_link_data" => ["create" => true]
         ]);
-        $this->assertInstanceOf(\Stripe\File::class, $resource);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
     }
 }

--- a/tests/Stripe/FileCreationTest.php
+++ b/tests/Stripe/FileCreationTest.php
@@ -40,7 +40,7 @@ class FileCreationTest extends TestCase
         $resource = File::create([
             "purpose" => "dispute_evidence",
             "file" => $fp,
-            "file_link_data" => ["create" => true]
+            "file_link_data" => ["create" => true],
         ]);
         static::assertInstanceOf(\Stripe\File::class, $resource);
     }
@@ -59,7 +59,7 @@ class FileCreationTest extends TestCase
         $resource = File::create([
             "purpose" => "dispute_evidence",
             "file" => $curlFile,
-            "file_link_data" => ["create" => true]
+            "file_link_data" => ["create" => true],
         ]);
         static::assertInstanceOf(\Stripe\File::class, $resource);
     }

--- a/tests/Stripe/FileLinkTest.php
+++ b/tests/Stripe/FileLinkTest.php
@@ -13,8 +13,8 @@ class FileLinkTest extends TestCase
             '/v1/file_links'
         );
         $resources = FileLink::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\FileLink::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class FileLinkTest extends TestCase
             '/v1/file_links/' . self::TEST_RESOURCE_ID
         );
         $resource = FileLink::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\FileLink::class, $resource);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class FileLinkTest extends TestCase
         $resource = FileLink::create([
             "file" => "file_123"
         ]);
-        $this->assertInstanceOf(\Stripe\FileLink::class, $resource);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class FileLinkTest extends TestCase
             '/v1/file_links/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\FileLink::class, $resource);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -60,6 +60,6 @@ class FileLinkTest extends TestCase
         $resource = FileLink::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\FileLink::class, $resource);
+        static::assertInstanceOf(\Stripe\FileLink::class, $resource);
     }
 }

--- a/tests/Stripe/FileLinkTest.php
+++ b/tests/Stripe/FileLinkTest.php
@@ -34,7 +34,7 @@ class FileLinkTest extends TestCase
             '/v1/file_links'
         );
         $resource = FileLink::create([
-            "file" => "file_123"
+            "file" => "file_123",
         ]);
         static::assertInstanceOf(\Stripe\FileLink::class, $resource);
     }

--- a/tests/Stripe/FileTest.php
+++ b/tests/Stripe/FileTest.php
@@ -13,8 +13,8 @@ class FileTest extends TestCase
             '/v1/files'
         );
         $resources = File::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\File::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\File::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class FileTest extends TestCase
             '/v1/files/' . self::TEST_RESOURCE_ID
         );
         $resource = File::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\File::class, $resource);
+        static::assertInstanceOf(\Stripe\File::class, $resource);
     }
 
     public function testDeserializesFromFile()
@@ -32,7 +32,7 @@ class FileTest extends TestCase
         $obj = Util\Util::convertToStripeObject([
             'object' => 'file',
         ], null);
-        $this->assertInstanceOf(\Stripe\File::class, $obj);
+        static::assertInstanceOf(\Stripe\File::class, $obj);
     }
 
     public function testDeserializesFromFileUpload()
@@ -40,6 +40,6 @@ class FileTest extends TestCase
         $obj = Util\Util::convertToStripeObject([
             'object' => 'file_upload',
         ], null);
-        $this->assertInstanceOf(\Stripe\File::class, $obj);
+        static::assertInstanceOf(\Stripe\File::class, $obj);
     }
 }

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -87,27 +87,27 @@ class CurlClientTest extends \Stripe\TestCase
     public function testTimeout()
     {
         $curl = new CurlClient();
-        $this->assertSame(CurlClient::DEFAULT_TIMEOUT, $curl->getTimeout());
-        $this->assertSame(CurlClient::DEFAULT_CONNECT_TIMEOUT, $curl->getConnectTimeout());
+        static::assertSame(CurlClient::DEFAULT_TIMEOUT, $curl->getTimeout());
+        static::assertSame(CurlClient::DEFAULT_CONNECT_TIMEOUT, $curl->getConnectTimeout());
 
         // implicitly tests whether we're returning the CurlClient instance
         $curl = $curl->setConnectTimeout(1)->setTimeout(10);
-        $this->assertSame(1, $curl->getConnectTimeout());
-        $this->assertSame(10, $curl->getTimeout());
+        static::assertSame(1, $curl->getConnectTimeout());
+        static::assertSame(10, $curl->getTimeout());
 
         $curl->setTimeout(-1);
         $curl->setConnectTimeout(-999);
-        $this->assertSame(0, $curl->getTimeout());
-        $this->assertSame(0, $curl->getConnectTimeout());
+        static::assertSame(0, $curl->getTimeout());
+        static::assertSame(0, $curl->getConnectTimeout());
     }
 
     public function testUserAgentInfo()
     {
         $curl = new CurlClient();
         $uaInfo = $curl->getUserAgentInfo();
-        $this->assertNotNull($uaInfo);
-        $this->assertNotNull($uaInfo['httplib']);
-        $this->assertNotNull($uaInfo['ssllib']);
+        static::assertNotNull($uaInfo);
+        static::assertNotNull($uaInfo['httplib']);
+        static::assertNotNull($uaInfo['ssllib']);
     }
 
     public function testDefaultOptions()
@@ -115,7 +115,7 @@ class CurlClientTest extends \Stripe\TestCase
         // make sure options array loads/saves properly
         $optionsArray = [\CURLOPT_PROXY => 'localhost:80'];
         $withOptionsArray = new CurlClient($optionsArray);
-        $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+        static::assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
 
         // make sure closure-based options work properly, including argument passing
         $ref = null;
@@ -125,7 +125,7 @@ class CurlClientTest extends \Stripe\TestCase
         });
 
         $withClosure->request('get', 'https://httpbin.org/status/200', [], [], false);
-        $this->assertSame($ref, ['get', 'https://httpbin.org/status/200', [], [], false]);
+        static::assertSame($ref, ['get', 'https://httpbin.org/status/200', [], [], false]);
 
         // this is the last test case that will run, since it'll throw an exception at the end
         $withBadClosure = new CurlClient(function () {
@@ -141,7 +141,7 @@ class CurlClientTest extends \Stripe\TestCase
         // make sure options array loads/saves properly
         $optionsArray = [\CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1];
         $withOptionsArray = new CurlClient($optionsArray);
-        $this->assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+        static::assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
     }
 
     public function testShouldRetryOnTimeout()
@@ -150,7 +150,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0));
     }
 
     public function testShouldRetryOnConnectionFailure()
@@ -159,7 +159,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0));
     }
 
     public function testShouldRetryOnConflict()
@@ -168,7 +168,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0));
     }
 
     public function testShouldNotRetryOn429()
@@ -177,7 +177,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0));
+        static::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0));
     }
 
     public function testShouldRetryOn500()
@@ -186,7 +186,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
     }
 
     public function testShouldRetryOn503()
@@ -195,7 +195,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0));
     }
 
     public function testShouldRetryOnStripeShouldRetryTrue()
@@ -204,8 +204,8 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0));
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0));
+        static::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0));
     }
 
     public function testShouldNotRetryOnStripeShouldRetryFalse()
@@ -214,8 +214,8 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0));
+        static::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
+        static::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0));
     }
 
     public function testShouldNotRetryAtMaximumCount()
@@ -224,7 +224,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries()));
+        static::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries()));
     }
 
     public function testShouldNotRetryOnCertValidationError()
@@ -233,7 +233,7 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        $this->assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0));
+        static::assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0));
     }
 
     public function testSleepTimeShouldGrowExponentially()
@@ -242,19 +242,19 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
 
-        $this->assertEquals(
+        static::assertEquals(
             \Stripe\Stripe::getInitialNetworkRetryDelay() * 1,
             $this->sleepTimeMethod->invoke($curlClient, 1, [])
         );
-        $this->assertEquals(
+        static::assertEquals(
             \Stripe\Stripe::getInitialNetworkRetryDelay() * 2,
             $this->sleepTimeMethod->invoke($curlClient, 2, [])
         );
-        $this->assertEquals(
+        static::assertEquals(
             \Stripe\Stripe::getInitialNetworkRetryDelay() * 4,
             $this->sleepTimeMethod->invoke($curlClient, 3, [])
         );
-        $this->assertEquals(
+        static::assertEquals(
             \Stripe\Stripe::getInitialNetworkRetryDelay() * 8,
             $this->sleepTimeMethod->invoke($curlClient, 4, [])
         );
@@ -267,10 +267,10 @@ class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
 
-        $this->assertEquals(1, $this->sleepTimeMethod->invoke($curlClient, 1, []));
-        $this->assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, []));
-        $this->assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 3, []));
-        $this->assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 4, []));
+        static::assertEquals(1, $this->sleepTimeMethod->invoke($curlClient, 1, []));
+        static::assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, []));
+        static::assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 3, []));
+        static::assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 4, []));
     }
 
     public function testSleepTimeShouldRespectRetryAfter()
@@ -281,11 +281,11 @@ class CurlClientTest extends \Stripe\TestCase
         $curlClient = new CurlClient(null, $this->createFakeRandomGenerator());
 
         // Uses max of default and header.
-        $this->assertEquals(10, $this->sleepTimeMethod->invoke($curlClient, 1, ['retry-after' => '10']));
-        $this->assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, ['retry-after' => '1']));
+        static::assertEquals(10, $this->sleepTimeMethod->invoke($curlClient, 1, ['retry-after' => '10']));
+        static::assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, ['retry-after' => '1']));
 
         // Ignores excessively large values.
-        $this->assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, ['retry-after' => '100']));
+        static::assertEquals(2, $this->sleepTimeMethod->invoke($curlClient, 2, ['retry-after' => '100']));
     }
 
     public function testSleepTimeShouldAddSomeRandomness()
@@ -300,12 +300,12 @@ class CurlClientTest extends \Stripe\TestCase
 
         // the initial value cannot be smaller than the base,
         // so the randomness is ignored
-        $this->assertEquals(\Stripe\Stripe::getInitialNetworkRetryDelay(), $this->sleepTimeMethod->invoke($curlClient, 1, []));
+        static::assertEquals(\Stripe\Stripe::getInitialNetworkRetryDelay(), $this->sleepTimeMethod->invoke($curlClient, 1, []));
 
         // after the first one, the randomness is applied
-        $this->assertEquals($baseValue * 2, $this->sleepTimeMethod->invoke($curlClient, 2, []));
-        $this->assertEquals($baseValue * 4, $this->sleepTimeMethod->invoke($curlClient, 3, []));
-        $this->assertEquals($baseValue * 8, $this->sleepTimeMethod->invoke($curlClient, 4, []));
+        static::assertEquals($baseValue * 2, $this->sleepTimeMethod->invoke($curlClient, 2, []));
+        static::assertEquals($baseValue * 4, $this->sleepTimeMethod->invoke($curlClient, 3, []));
+        static::assertEquals($baseValue * 8, $this->sleepTimeMethod->invoke($curlClient, 4, []));
     }
 
     public function testResponseHeadersCaseInsensitive()
@@ -313,8 +313,8 @@ class CurlClientTest extends \Stripe\TestCase
         $charge = \Stripe\Charge::all();
 
         $headers = $charge->getLastResponse()->headers;
-        $this->assertNotNull($headers['request-id']);
-        $this->assertEquals($headers['request-id'], $headers['Request-Id']);
+        static::assertNotNull($headers['request-id']);
+        static::assertEquals($headers['request-id'], $headers['Request-Id']);
     }
 
     public function testSetRequestStatusCallback()
@@ -339,7 +339,7 @@ class CurlClientTest extends \Stripe\TestCase
 
             \Stripe\Charge::all();
 
-            $this->assertTrue($called);
+            static::assertTrue($called);
         } finally {
             \Stripe\ApiRequestor::setHttpClient(null);
         }

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -36,7 +36,7 @@ class InvoiceItemTest extends TestCase
         $resource = InvoiceItem::create([
             "amount" => 100,
             "currency" => "usd",
-            "customer" => "cus_123"
+            "customer" => "cus_123",
         ]);
         static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -13,8 +13,8 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems'
         );
         $resources = InvoiceItem::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . self::TEST_RESOURCE_ID
         );
         $resource = InvoiceItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class InvoiceItemTest extends TestCase
             "currency" => "usd",
             "customer" => "cus_123"
         ]);
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -62,7 +62,7 @@ class InvoiceItemTest extends TestCase
         $resource = InvoiceItem::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }
 
     public function testIsDeletable()
@@ -73,6 +73,6 @@ class InvoiceItemTest extends TestCase
             '/v1/invoiceitems/' . $invoiceItem->id
         );
         $resource = $invoiceItem->delete();
-        $this->assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
+        static::assertInstanceOf(\Stripe\InvoiceItem::class, $resource);
     }
 }

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -35,7 +35,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices'
         );
         $resource = Invoice::create([
-            "customer" => "cus_123"
+            "customer" => "cus_123",
         ]);
         static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -14,8 +14,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices'
         );
         $resources = Invoice::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID
         );
         $resource = Invoice::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class InvoiceTest extends TestCase
         $resource = Invoice::create([
             "customer" => "cus_123"
         ]);
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class InvoiceTest extends TestCase
         $resource = Invoice::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,7 +72,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testCanFinalizeInvoice()
@@ -83,8 +83,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/finalize'
         );
         $resource = $invoice->finalizeInvoice();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
-        $this->assertSame($resource, $invoice);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertSame($resource, $invoice);
     }
 
     public function testCanMarkUncollectible()
@@ -95,8 +95,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/mark_uncollectible'
         );
         $resource = $invoice->markUncollectible();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
-        $this->assertSame($resource, $invoice);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertSame($resource, $invoice);
     }
 
     public function testCanPay()
@@ -107,8 +107,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/pay'
         );
         $resource = $invoice->pay();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
-        $this->assertSame($resource, $invoice);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertSame($resource, $invoice);
     }
 
     public function testCanRetrieveUpcoming()
@@ -118,7 +118,7 @@ class InvoiceTest extends TestCase
             '/v1/invoices/upcoming'
         );
         $resource = Invoice::upcoming(["customer" => "cus_123"]);
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
     public function testCanSendInvoice()
@@ -129,8 +129,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/send'
         );
         $resource = $invoice->sendInvoice();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
-        $this->assertSame($resource, $invoice);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertSame($resource, $invoice);
     }
 
     public function testCanVoidInvoice()
@@ -141,8 +141,8 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . $invoice->id . '/void'
         );
         $resource = $invoice->voidInvoice();
-        $this->assertInstanceOf(\Stripe\Invoice::class, $resource);
-        $this->assertSame($resource, $invoice);
+        static::assertInstanceOf(\Stripe\Invoice::class, $resource);
+        static::assertSame($resource, $invoice);
     }
 
     public function testCanListLines()
@@ -152,6 +152,6 @@ class InvoiceTest extends TestCase
             '/v1/invoices/' . self::TEST_RESOURCE_ID . '/lines'
         );
         $resources = Invoice::allLines(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
+        static::assertInternalType('array', $resources->data);
     }
 }

--- a/tests/Stripe/Issuing/AuthorizationTest.php
+++ b/tests/Stripe/Issuing/AuthorizationTest.php
@@ -13,8 +13,8 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations'
         );
         $resources = Authorization::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID
         );
         $resource = Authorization::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -50,7 +50,7 @@ class AuthorizationTest extends \Stripe\TestCase
         $resource = Authorization::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
     }
 
     public function testIsApprovable()
@@ -62,7 +62,7 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID . '/approve'
         );
         $resource = $resource->approve();
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
     }
 
     public function testIsDeclinable()
@@ -74,6 +74,6 @@ class AuthorizationTest extends \Stripe\TestCase
             '/v1/issuing/authorizations/' . self::TEST_RESOURCE_ID . '/decline'
         );
         $resource = $resource->decline();
-        $this->assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Authorization::class, $resource);
     }
 }

--- a/tests/Stripe/Issuing/CardTest.php
+++ b/tests/Stripe/Issuing/CardTest.php
@@ -13,8 +13,8 @@ class CardTest extends \Stripe\TestCase
             '/v1/issuing/cards'
         );
         $resources = Card::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class CardTest extends \Stripe\TestCase
             '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
         );
         $resource = Card::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class CardTest extends \Stripe\TestCase
             '/v1/issuing/cards/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -50,7 +50,7 @@ class CardTest extends \Stripe\TestCase
         $resource = Card::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Card::class, $resource);
     }
 
     public function testCanRetrieveDetails()
@@ -61,6 +61,6 @@ class CardTest extends \Stripe\TestCase
             '/v1/issuing/cards/' . self::TEST_RESOURCE_ID . '/details'
         );
         $details = $resource->details();
-        $this->assertInstanceOf(\Stripe\Issuing\CardDetails::class, $details);
+        static::assertInstanceOf(\Stripe\Issuing\CardDetails::class, $details);
     }
 }

--- a/tests/Stripe/Issuing/CardholderTest.php
+++ b/tests/Stripe/Issuing/CardholderTest.php
@@ -27,7 +27,7 @@ class CardholderTest extends \Stripe\TestCase
             $params
         );
         $resource = Cardholder::create($params);
-        $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
     }
 
     public function testIsListable()
@@ -37,8 +37,8 @@ class CardholderTest extends \Stripe\TestCase
             '/v1/issuing/cardholders'
         );
         $resources = Cardholder::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -48,7 +48,7 @@ class CardholderTest extends \Stripe\TestCase
             '/v1/issuing/cardholders/' . self::TEST_RESOURCE_ID
         );
         $resource = Cardholder::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
     }
 
     public function testIsSaveable()
@@ -61,7 +61,7 @@ class CardholderTest extends \Stripe\TestCase
             '/v1/issuing/cardholders/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -74,6 +74,6 @@ class CardholderTest extends \Stripe\TestCase
         $resource = Cardholder::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Cardholder::class, $resource);
     }
 }

--- a/tests/Stripe/Issuing/DisputeTest.php
+++ b/tests/Stripe/Issuing/DisputeTest.php
@@ -19,7 +19,7 @@ class DisputeTest extends \Stripe\TestCase
             $params
         );
         $resource = Dispute::create($params);
-        $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
     }
 
     public function testIsListable()
@@ -29,8 +29,8 @@ class DisputeTest extends \Stripe\TestCase
             '/v1/issuing/disputes'
         );
         $resources = Dispute::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -40,7 +40,7 @@ class DisputeTest extends \Stripe\TestCase
             '/v1/issuing/disputes/' . self::TEST_RESOURCE_ID
         );
         $resource = Dispute::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
     }
 
     public function testIsSaveable()
@@ -53,7 +53,7 @@ class DisputeTest extends \Stripe\TestCase
             '/v1/issuing/disputes/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -66,6 +66,6 @@ class DisputeTest extends \Stripe\TestCase
         $resource = Dispute::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Dispute::class, $resource);
     }
 }

--- a/tests/Stripe/Issuing/TransactionTest.php
+++ b/tests/Stripe/Issuing/TransactionTest.php
@@ -13,8 +13,8 @@ class TransactionTest extends \Stripe\TestCase
             '/v1/issuing/transactions'
         );
         $resources = Transaction::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Issuing\Transaction::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class TransactionTest extends \Stripe\TestCase
             '/v1/issuing/transactions/' . self::TEST_RESOURCE_ID
         );
         $resource = Transaction::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class TransactionTest extends \Stripe\TestCase
             '/v1/issuing/transactions/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -50,6 +50,6 @@ class TransactionTest extends \Stripe\TestCase
         $resource = Transaction::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
+        static::assertInstanceOf(\Stripe\Issuing\Transaction::class, $resource);
     }
 }

--- a/tests/Stripe/MandateTest.php
+++ b/tests/Stripe/MandateTest.php
@@ -13,6 +13,6 @@ class MandateTest extends TestCase
             '/v1/mandates/' . self::TEST_RESOURCE_ID
         );
         $resource = Mandate::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Mandate::class, $resource);
+        static::assertInstanceOf(\Stripe\Mandate::class, $resource);
     }
 }

--- a/tests/Stripe/OAuthErrorObjectTest.php
+++ b/tests/Stripe/OAuthErrorObjectTest.php
@@ -8,7 +8,7 @@ class OAuthErrorObjectTest extends TestCase
     {
         $error = OAuthErrorObject::constructFrom([]);
 
-        $this->assertNull($error->error);
-        $this->assertNull($error->error_description);
+        static::assertNull($error->error);
+        static::assertNull($error->error_description);
     }
 }

--- a/tests/Stripe/OAuthTest.php
+++ b/tests/Stripe/OAuthTest.php
@@ -19,15 +19,15 @@ class OAuthTest extends TestCase
         $uri = \parse_url($uriStr);
         \parse_str($uri['query'], $params);
 
-        $this->assertSame('https', $uri['scheme']);
-        $this->assertSame('connect.stripe.com', $uri['host']);
-        $this->assertSame('/oauth/authorize', $uri['path']);
+        static::assertSame('https', $uri['scheme']);
+        static::assertSame('connect.stripe.com', $uri['host']);
+        static::assertSame('/oauth/authorize', $uri['path']);
 
-        $this->assertSame('ca_123', $params['client_id']);
-        $this->assertSame('read_write', $params['scope']);
-        $this->assertSame('test@example.com', $params['stripe_user']['email']);
-        $this->assertSame('https://example.com/profile/test', $params['stripe_user']['url']);
-        $this->assertSame('US', $params['stripe_user']['country']);
+        static::assertSame('ca_123', $params['client_id']);
+        static::assertSame('read_write', $params['scope']);
+        static::assertSame('test@example.com', $params['stripe_user']['email']);
+        static::assertSame('https://example.com/profile/test', $params['stripe_user']['url']);
+        static::assertSame('US', $params['stripe_user']['country']);
     }
 
     public function testRaisesAuthenticationErrorWhenNoClientId()
@@ -67,7 +67,7 @@ class OAuthTest extends TestCase
             'grant_type' => 'authorization_code',
             'code' => 'this_is_an_authorization_code',
         ]);
-        $this->assertSame('sk_access_token', $resp->access_token);
+        static::assertSame('sk_access_token', $resp->access_token);
     }
 
     public function testDeauthorize()
@@ -91,6 +91,6 @@ class OAuthTest extends TestCase
         $resp = OAuth::deauthorize([
             'stripe_user_id' => 'acct_test_deauth',
         ]);
-        $this->assertSame('acct_test_deauth', $resp->stripe_user_id);
+        static::assertSame('acct_test_deauth', $resp->stripe_user_id);
     }
 }

--- a/tests/Stripe/OrderReturnTest.php
+++ b/tests/Stripe/OrderReturnTest.php
@@ -13,8 +13,8 @@ class OrderReturnTest extends TestCase
             '/v1/order_returns'
         );
         $resources = OrderReturn::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\OrderReturn::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class OrderReturnTest extends TestCase
             '/v1/order_returns/' . self::TEST_RESOURCE_ID
         );
         $resource = OrderReturn::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\OrderReturn::class, $resource);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resource);
     }
 }

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -34,7 +34,7 @@ class OrderTest extends TestCase
             '/v1/orders'
         );
         $resource = Order::create([
-            'currency' => 'usd'
+            'currency' => 'usd',
         ]);
         static::assertInstanceOf(\Stripe\Order::class, $resource);
     }

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -13,8 +13,8 @@ class OrderTest extends TestCase
             '/v1/orders'
         );
         $resources = Order::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Order::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Order::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . self::TEST_RESOURCE_ID
         );
         $resource = Order::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Order::class, $resource);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class OrderTest extends TestCase
         $resource = Order::create([
             'currency' => 'usd'
         ]);
-        $this->assertInstanceOf(\Stripe\Order::class, $resource);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Order::class, $resource);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -60,7 +60,7 @@ class OrderTest extends TestCase
         $resource = Order::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Order::class, $resource);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
     }
 
     public function testIsPayable()
@@ -71,7 +71,7 @@ class OrderTest extends TestCase
             '/v1/orders/' . $resource->id . '/pay'
         );
         $resource->pay();
-        $this->assertInstanceOf(\Stripe\Order::class, $resource);
+        static::assertInstanceOf(\Stripe\Order::class, $resource);
     }
 
     public function testIsReturnable()
@@ -82,6 +82,6 @@ class OrderTest extends TestCase
             '/v1/orders/' . $order->id . '/returns'
         );
         $resource = $order->returnOrder();
-        $this->assertInstanceOf(\Stripe\OrderReturn::class, $resource);
+        static::assertInstanceOf(\Stripe\OrderReturn::class, $resource);
     }
 }

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -13,8 +13,8 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents'
         );
         $resources = PaymentIntent::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents/' . self::TEST_RESOURCE_ID
         );
         $resource = PaymentIntent::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class PaymentIntentTest extends TestCase
             "currency" => "usd",
             'payment_method_types' => ['card'],
         ]);
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -65,7 +65,7 @@ class PaymentIntentTest extends TestCase
                 "metadata" => ["key" => "value"],
             ]
         );
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsCancelable()
@@ -76,7 +76,7 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/cancel'
         );
         $resource->cancel();
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsCapturable()
@@ -87,7 +87,7 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/capture'
         );
         $resource->capture();
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 
     public function testIsConfirmable()
@@ -98,6 +98,6 @@ class PaymentIntentTest extends TestCase
             '/v1/payment_intents/' . self::TEST_RESOURCE_ID . '/confirm'
         );
         $resource->confirm();
-        $this->assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
 }

--- a/tests/Stripe/PaymentMethodTest.php
+++ b/tests/Stripe/PaymentMethodTest.php
@@ -16,8 +16,8 @@ class PaymentMethodTest extends TestCase
             'customer' => 'cus_123',
             'type' => 'card',
         ]);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -27,7 +27,7 @@ class PaymentMethodTest extends TestCase
             '/v1/payment_methods/' . self::TEST_RESOURCE_ID
         );
         $resource = PaymentMethod::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class PaymentMethodTest extends TestCase
         $resource = PaymentMethod::create([
             'type' => 'card',
         ]);
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
     }
 
     public function testIsSaveable()
@@ -51,7 +51,7 @@ class PaymentMethodTest extends TestCase
             '/v1/payment_methods/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class PaymentMethodTest extends TestCase
         $resource = PaymentMethod::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
     }
 
     public function testCanAttach()
@@ -76,8 +76,8 @@ class PaymentMethodTest extends TestCase
         $resource = $resource->attach([
             'customer' => 'cus_123',
         ]);
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
-        $this->assertSame($resource, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertSame($resource, $resource);
     }
 
     public function testCanDetach()
@@ -88,7 +88,7 @@ class PaymentMethodTest extends TestCase
             '/v1/payment_methods/' . $resource->id . '/detach'
         );
         $resource = $resource->detach();
-        $this->assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
-        $this->assertSame($resource, $resource);
+        static::assertInstanceOf(\Stripe\PaymentMethod::class, $resource);
+        static::assertSame($resource, $resource);
     }
 }

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -13,8 +13,8 @@ class PayoutTest extends TestCase
             '/v1/payouts'
         );
         $resources = Payout::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Payout::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Payout::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . self::TEST_RESOURCE_ID
         );
         $resource = Payout::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Payout::class, $resource);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class PayoutTest extends TestCase
             "amount" => 100,
             "currency" => "usd"
         ]);
-        $this->assertInstanceOf(\Stripe\Payout::class, $resource);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Payout::class, $resource);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class PayoutTest extends TestCase
         $resource = Payout::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Payout::class, $resource);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }
 
     public function testIsCancelable()
@@ -72,6 +72,6 @@ class PayoutTest extends TestCase
             '/v1/payouts/' . $resource->id . '/cancel'
         );
         $resource->cancel();
-        $this->assertInstanceOf(\Stripe\Payout::class, $resource);
+        static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }
 }

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -35,7 +35,7 @@ class PayoutTest extends TestCase
         );
         $resource = Payout::create([
             "amount" => 100,
-            "currency" => "usd"
+            "currency" => "usd",
         ]);
         static::assertInstanceOf(\Stripe\Payout::class, $resource);
     }

--- a/tests/Stripe/PersonTest.php
+++ b/tests/Stripe/PersonTest.php
@@ -10,7 +10,7 @@ class PersonTest extends TestCase
     public function testHasCorrectUrl()
     {
         $resource = \Stripe\Account::retrievePerson(self::TEST_ACCOUNT_ID, self::TEST_RESOURCE_ID);
-        $this->assertSame(
+        static::assertSame(
             "/v1/accounts/" . self::TEST_ACCOUNT_ID . "/persons/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -32,7 +32,7 @@ class PersonTest extends TestCase
             '/v1/accounts/' . self::TEST_ACCOUNT_ID . '/persons/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertSame(\Stripe\Person::class, \get_class($resource));
+        static::assertSame(\Stripe\Person::class, \get_class($resource));
     }
 
     public function testIsNotDirectlyUpdatable()
@@ -52,6 +52,6 @@ class PersonTest extends TestCase
             '/v1/accounts/' . self::TEST_ACCOUNT_ID . '/persons/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertSame(\Stripe\Person::class, \get_class($resource));
+        static::assertSame(\Stripe\Person::class, \get_class($resource));
     }
 }

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -38,7 +38,7 @@ class PlanTest extends TestCase
             'interval' => 'month',
             'currency' => 'usd',
             'nickname' => self::TEST_RESOURCE_ID,
-            'id' => self::TEST_RESOURCE_ID
+            'id' => self::TEST_RESOURCE_ID,
         ]);
         static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -13,8 +13,8 @@ class PlanTest extends TestCase
             '/v1/plans'
         );
         $resources = Plan::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Plan::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Plan::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class PlanTest extends TestCase
             '/v1/plans/' . self::TEST_RESOURCE_ID
         );
         $resource = Plan::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Plan::class, $resource);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }
 
     public function testIsCreatable()
@@ -40,7 +40,7 @@ class PlanTest extends TestCase
             'nickname' => self::TEST_RESOURCE_ID,
             'id' => self::TEST_RESOURCE_ID
         ]);
-        $this->assertInstanceOf(\Stripe\Plan::class, $resource);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }
 
     public function testIsSaveable()
@@ -52,7 +52,7 @@ class PlanTest extends TestCase
             '/v1/plans/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Plan::class, $resource);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -64,7 +64,7 @@ class PlanTest extends TestCase
         $resource = Plan::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Plan::class, $resource);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }
 
     public function testIsDeletable()
@@ -75,6 +75,6 @@ class PlanTest extends TestCase
             '/v1/plans/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Plan::class, $resource);
+        static::assertInstanceOf(\Stripe\Plan::class, $resource);
     }
 }

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -35,7 +35,7 @@ class ProductTest extends TestCase
         );
         $resource = Product::create([
             'name' => 'name',
-            'type' => 'good'
+            'type' => 'good',
         ]);
         static::assertInstanceOf(\Stripe\Product::class, $resource);
     }

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -13,8 +13,8 @@ class ProductTest extends TestCase
             '/v1/products'
         );
         $resources = Product::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Product::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Product::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ProductTest extends TestCase
             '/v1/products/' . self::TEST_RESOURCE_ID
         );
         $resource = Product::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Product::class, $resource);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class ProductTest extends TestCase
             'name' => 'name',
             'type' => 'good'
         ]);
-        $this->assertInstanceOf(\Stripe\Product::class, $resource);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class ProductTest extends TestCase
             '/v1/products/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Product::class, $resource);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class ProductTest extends TestCase
         $resource = Product::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Product::class, $resource);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class ProductTest extends TestCase
             '/v1/products/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Product::class, $resource);
+        static::assertInstanceOf(\Stripe\Product::class, $resource);
     }
 }

--- a/tests/Stripe/Radar/EarlyFraudWarningTest.php
+++ b/tests/Stripe/Radar/EarlyFraudWarningTest.php
@@ -13,8 +13,8 @@ class EarlyFraudWarningTest extends \Stripe\TestCase
             '/v1/radar/early_fraud_warnings'
         );
         $resources = EarlyFraudWarning::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class EarlyFraudWarningTest extends \Stripe\TestCase
             '/v1/radar/early_fraud_warnings/' . self::TEST_RESOURCE_ID
         );
         $resource = EarlyFraudWarning::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\EarlyFraudWarning::class, $resource);
     }
 }

--- a/tests/Stripe/Radar/ValueListItemTest.php
+++ b/tests/Stripe/Radar/ValueListItemTest.php
@@ -15,8 +15,8 @@ class ValueListItemTest extends \Stripe\TestCase
         $resources = ValueListItem::all([
             "value_list" => "rsl_123",
         ]);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -26,7 +26,7 @@ class ValueListItemTest extends \Stripe\TestCase
             '/v1/radar/value_list_items/' . self::TEST_RESOURCE_ID
         );
         $resource = ValueListItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class ValueListItemTest extends \Stripe\TestCase
             "value_list" => "rsl_123",
             "value" => "value",
         ]);
-        $this->assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
     }
 
     public function testIsDeletable()
@@ -50,6 +50,6 @@ class ValueListItemTest extends \Stripe\TestCase
             '/v1/radar/value_list_items/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueListItem::class, $resource);
     }
 }

--- a/tests/Stripe/Radar/ValueListTest.php
+++ b/tests/Stripe/Radar/ValueListTest.php
@@ -13,8 +13,8 @@ class ValueListTest extends \Stripe\TestCase
             '/v1/radar/value_lists'
         );
         $resources = ValueList::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ValueListTest extends \Stripe\TestCase
             '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
         );
         $resource = ValueList::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class ValueListTest extends \Stripe\TestCase
             "alias" => "alias",
             "name" => "name",
         ]);
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class ValueListTest extends \Stripe\TestCase
             '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class ValueListTest extends \Stripe\TestCase
         $resource = ValueList::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class ValueListTest extends \Stripe\TestCase
             '/v1/radar/value_lists/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
+        static::assertInstanceOf(\Stripe\Radar\ValueList::class, $resource);
     }
 }

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -13,8 +13,8 @@ class RecipientTest extends TestCase
             '/v1/recipients'
         );
         $resources = Recipient::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . self::TEST_RESOURCE_ID
         );
         $resource = Recipient::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resource);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class RecipientTest extends TestCase
             "name" => "name",
             "type" => "individual"
         ]);
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resource);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resource);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class RecipientTest extends TestCase
         $resource = Recipient::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resource);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class RecipientTest extends TestCase
             '/v1/recipients/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Recipient::class, $resource);
+        static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }
 }

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -35,7 +35,7 @@ class RecipientTest extends TestCase
         );
         $resource = Recipient::create([
             "name" => "name",
-            "type" => "individual"
+            "type" => "individual",
         ]);
         static::assertInstanceOf(\Stripe\Recipient::class, $resource);
     }

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -13,8 +13,8 @@ class RefundTest extends TestCase
             '/v1/refunds'
         );
         $resources = Refund::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Refund::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Refund::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class RefundTest extends TestCase
             '/v1/refunds/' . self::TEST_RESOURCE_ID
         );
         $resource = Refund::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Refund::class, $resource);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class RefundTest extends TestCase
         $resource = Refund::create([
             "charge" => "ch_123"
         ]);
-        $this->assertInstanceOf(\Stripe\Refund::class, $resource);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class RefundTest extends TestCase
             '/v1/refunds/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Refund::class, $resource);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -60,6 +60,6 @@ class RefundTest extends TestCase
         $resource = Refund::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Refund::class, $resource);
+        static::assertInstanceOf(\Stripe\Refund::class, $resource);
     }
 }

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -34,7 +34,7 @@ class RefundTest extends TestCase
             '/v1/refunds'
         );
         $resource = Refund::create([
-            "charge" => "ch_123"
+            "charge" => "ch_123",
         ]);
         static::assertInstanceOf(\Stripe\Refund::class, $resource);
     }

--- a/tests/Stripe/Reporting/ReportRunTest.php
+++ b/tests/Stripe/Reporting/ReportRunTest.php
@@ -10,7 +10,7 @@ class ReportRunTest extends \Stripe\TestCase
     {
         $params = [
             "parameters" => [
-                "connected_account" => "acct_123"
+                "connected_account" => "acct_123",
             ],
             "report_type" => "activity.summary.1",
         ];

--- a/tests/Stripe/Reporting/ReportRunTest.php
+++ b/tests/Stripe/Reporting/ReportRunTest.php
@@ -21,7 +21,7 @@ class ReportRunTest extends \Stripe\TestCase
             $params
         );
         $resource = ReportRun::create($params);
-        $this->assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
     }
 
     public function testIsListable()
@@ -31,8 +31,8 @@ class ReportRunTest extends \Stripe\TestCase
             '/v1/reporting/report_runs'
         );
         $resources = ReportRun::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -42,6 +42,6 @@ class ReportRunTest extends \Stripe\TestCase
             '/v1/reporting/report_runs/' . self::TEST_RESOURCE_ID
         );
         $resource = ReportRun::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
+        static::assertInstanceOf(\Stripe\Reporting\ReportRun::class, $resource);
     }
 }

--- a/tests/Stripe/Reporting/ReportTypeTest.php
+++ b/tests/Stripe/Reporting/ReportTypeTest.php
@@ -13,8 +13,8 @@ class ReportTypeTest extends \Stripe\TestCase
             '/v1/reporting/report_types'
         );
         $resources = ReportType::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Reporting\ReportType::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Reporting\ReportType::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,6 +24,6 @@ class ReportTypeTest extends \Stripe\TestCase
             '/v1/reporting/report_types/' . self::TEST_RESOURCE_ID
         );
         $resource = ReportType::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Reporting\ReportType::class, $resource);
+        static::assertInstanceOf(\Stripe\Reporting\ReportType::class, $resource);
     }
 }

--- a/tests/Stripe/ReviewTest.php
+++ b/tests/Stripe/ReviewTest.php
@@ -14,7 +14,7 @@ class ReviewTest extends \Stripe\TestCase
             '/v1/reviews/' . self::TEST_RESOURCE_ID . '/approve'
         );
         $resource->approve();
-        $this->assertInstanceOf(\Stripe\Review::class, $resource);
+        static::assertInstanceOf(\Stripe\Review::class, $resource);
     }
 
     public function testIsListable()
@@ -24,8 +24,8 @@ class ReviewTest extends \Stripe\TestCase
             '/v1/reviews'
         );
         $resources = Review::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Review::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Review::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -35,6 +35,6 @@ class ReviewTest extends \Stripe\TestCase
             '/v1/reviews/' . self::TEST_RESOURCE_ID
         );
         $resource = Review::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Review::class, $resource);
+        static::assertInstanceOf(\Stripe\Review::class, $resource);
     }
 }

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -37,10 +37,10 @@ class SKUTest extends TestCase
             'currency'  => 'usd',
             'inventory' => [
                 'type'     => 'finite',
-                'quantity' => 1
+                'quantity' => 1,
             ],
             'price'     => 100,
-            'product'   => "prod_123"
+            'product'   => "prod_123",
         ]);
         static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -13,8 +13,8 @@ class SKUTest extends TestCase
             '/v1/skus'
         );
         $resources = SKU::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SKU::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SKU::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SKUTest extends TestCase
             '/v1/skus/' . self::TEST_RESOURCE_ID
         );
         $resource = SKU::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }
 
     public function testIsCreatable()
@@ -42,7 +42,7 @@ class SKUTest extends TestCase
             'price'     => 100,
             'product'   => "prod_123"
         ]);
-        $this->assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }
 
     public function testIsSaveable()
@@ -54,7 +54,7 @@ class SKUTest extends TestCase
             '/v1/skus/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -66,7 +66,7 @@ class SKUTest extends TestCase
         $resource = SKU::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }
 
     public function testIsDeletable()
@@ -77,6 +77,6 @@ class SKUTest extends TestCase
             '/v1/skus/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\SKU::class, $resource);
+        static::assertInstanceOf(\Stripe\SKU::class, $resource);
     }
 }

--- a/tests/Stripe/SetupIntentTest.php
+++ b/tests/Stripe/SetupIntentTest.php
@@ -13,8 +13,8 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents'
         );
         $resources = SetupIntent::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents/' . self::TEST_RESOURCE_ID
         );
         $resource = SetupIntent::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class SetupIntentTest extends TestCase
         $resource = SetupIntent::create([
             'payment_method_types' => ['card'],
         ]);
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class SetupIntentTest extends TestCase
                 "metadata" => ["key" => "value"],
             ]
         );
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 
     public function testIsCancelable()
@@ -74,7 +74,7 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents/' . self::TEST_RESOURCE_ID . '/cancel'
         );
         $resource->cancel();
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 
     public function testIsConfirmable()
@@ -85,6 +85,6 @@ class SetupIntentTest extends TestCase
             '/v1/setup_intents/' . self::TEST_RESOURCE_ID . '/confirm'
         );
         $resource->confirm();
-        $this->assertInstanceOf(\Stripe\SetupIntent::class, $resource);
+        static::assertInstanceOf(\Stripe\SetupIntent::class, $resource);
     }
 }

--- a/tests/Stripe/Sigma/ScheduledQueryRunTest.php
+++ b/tests/Stripe/Sigma/ScheduledQueryRunTest.php
@@ -9,13 +9,13 @@ class ScheduledQueryRunTest extends \Stripe\TestCase
     public function testIsListable()
     {
         $resources = ScheduledQueryRun::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
     {
         $resource = ScheduledQueryRun::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resource);
+        static::assertInstanceOf(\Stripe\Sigma\ScheduledQueryRun::class, $resource);
     }
 }

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -13,7 +13,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID
         );
         $resource = Source::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
     public function testIsCreatable()
@@ -25,7 +25,7 @@ class SourceTest extends TestCase
         $resource = Source::create([
             "type" => "card"
         ]);
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class SourceTest extends TestCase
             '/v1/sources/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -49,7 +49,7 @@ class SourceTest extends TestCase
         $resource = Source::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
     public function testCanSaveCardExpiryDate()
@@ -84,8 +84,8 @@ class SourceTest extends TestCase
         $source->card->exp_year = 2022;
         $source->save();
 
-        $this->assertSame(12, $source->card->exp_month);
-        $this->assertSame(2022, $source->card->exp_year);
+        static::assertSame(12, $source->card->exp_month);
+        static::assertSame(2022, $source->card->exp_year);
     }
 
     public function testIsDetachableWhenAttached()
@@ -97,7 +97,7 @@ class SourceTest extends TestCase
             '/v1/customers/cus_123/sources/' . $resource->id
         );
         $resource->detach();
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 
     public function testIsNotDetachableWhenUnattached()
@@ -116,8 +116,8 @@ class SourceTest extends TestCase
             '/v1/sources/' . $source->id . "/source_transactions"
         );
         $resources = $source->sourceTransactions();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
     }
 
     public function testCanListSourceTransactions()
@@ -127,8 +127,8 @@ class SourceTest extends TestCase
             '/v1/sources/' . self::TEST_RESOURCE_ID . "/source_transactions"
         );
         $resources = Source::allSourceTransactions(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SourceTransaction::class, $resources->data[0]);
     }
 
     public function testCanVerify()
@@ -139,6 +139,6 @@ class SourceTest extends TestCase
             '/v1/sources/' . $resource->id . "/verify"
         );
         $resource->verify(["values" => [32, 45]]);
-        $this->assertInstanceOf(\Stripe\Source::class, $resource);
+        static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
 }

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -23,7 +23,7 @@ class SourceTest extends TestCase
             '/v1/sources'
         );
         $resource = Source::create([
-            "type" => "card"
+            "type" => "card",
         ]);
         static::assertInstanceOf(\Stripe\Source::class, $resource);
     }
@@ -73,7 +73,7 @@ class SourceTest extends TestCase
                 'card' => [
                     'exp_month' => 12,
                     'exp_year' => 2022,
-                ]
+                ],
             ],
             null,
             false,

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -31,59 +31,59 @@ class StripeObjectTest extends TestCase
     {
         $s = new StripeObject();
         $s['foo'] = 'a';
-        $this->assertSame($s['foo'], 'a');
-        $this->assertTrue(isset($s['foo']));
+        static::assertSame($s['foo'], 'a');
+        static::assertTrue(isset($s['foo']));
         unset($s['foo']);
-        $this->assertFalse(isset($s['foo']));
+        static::assertFalse(isset($s['foo']));
     }
 
     public function testNormalAccessorsSemantics()
     {
         $s = new StripeObject();
         $s->foo = 'a';
-        $this->assertSame($s->foo, 'a');
-        $this->assertTrue(isset($s->foo));
+        static::assertSame($s->foo, 'a');
+        static::assertTrue(isset($s->foo));
         unset($s->foo);
-        $this->assertFalse(isset($s->foo));
+        static::assertFalse(isset($s->foo));
     }
 
     public function testArrayAccessorsMatchNormalAccessors()
     {
         $s = new StripeObject();
         $s->foo = 'a';
-        $this->assertSame($s['foo'], 'a');
+        static::assertSame($s['foo'], 'a');
 
         $s['bar'] = 'b';
-        $this->assertSame($s->bar, 'b');
+        static::assertSame($s->bar, 'b');
     }
 
     public function testCount()
     {
         $s = new StripeObject();
-        $this->assertCount(0, $s);
+        static::assertCount(0, $s);
 
         $s['key1'] = 'value1';
-        $this->assertCount(1, $s);
+        static::assertCount(1, $s);
 
         $s['key2'] = 'value2';
-        $this->assertCount(2, $s);
+        static::assertCount(2, $s);
 
         unset($s['key1']);
-        $this->assertCount(1, $s);
+        static::assertCount(1, $s);
     }
 
     public function testKeys()
     {
         $s = new StripeObject();
         $s->foo = 'bar';
-        $this->assertSame($s->keys(), ['foo']);
+        static::assertSame($s->keys(), ['foo']);
     }
 
     public function testValues()
     {
         $s = new StripeObject();
         $s->foo = 'bar';
-        $this->assertSame($s->values(), ['bar']);
+        static::assertSame($s->values(), ['bar']);
     }
 
     public function testToArray()
@@ -97,8 +97,8 @@ class StripeObjectTest extends TestCase
 
         $converted = $s->toArray();
 
-        $this->assertInternalType('array', $converted);
-        $this->assertEquals($array, $converted);
+        static::assertInternalType('array', $converted);
+        static::assertEquals($array, $converted);
     }
 
     public function testToArrayRecursive()
@@ -122,7 +122,7 @@ class StripeObjectTest extends TestCase
             'list' => [$nestedArray],
         ];
 
-        $this->assertEquals($expected, $obj->toArray());
+        static::assertEquals($expected, $obj->toArray());
     }
 
     public function testNonexistentProperty()
@@ -132,9 +132,9 @@ class StripeObjectTest extends TestCase
 
         try {
             $s = new StripeObject();
-            $this->assertNull($s->nonexistent);
+            static::assertNull($s->nonexistent);
 
-            $this->assertRegExp(
+            static::assertRegExp(
                 "/Stripe Notice: Undefined property of Stripe\\\\StripeObject instance: nonexistent/",
                 \stream_get_contents($capture)
             );
@@ -147,7 +147,7 @@ class StripeObjectTest extends TestCase
     public function testPropertyDoesNotExists()
     {
         $s = new StripeObject();
-        $this->assertNull($s['nonexistent']);
+        static::assertNull($s['nonexistent']);
     }
 
     public function testJsonEncode()
@@ -155,7 +155,7 @@ class StripeObjectTest extends TestCase
         $s = new StripeObject();
         $s->foo = 'a';
 
-        $this->assertEquals('{"foo":"a"}', \json_encode($s));
+        static::assertEquals('{"foo":"a"}', \json_encode($s));
     }
 
     public function testToString()
@@ -169,7 +169,7 @@ Stripe\StripeObject JSON: {
     "foo": "a"
 }
 EOS;
-        $this->assertEquals($expected, $string);
+        static::assertEquals($expected, $string);
     }
 
     public function testReplaceNewNestedUpdatable()
@@ -177,9 +177,9 @@ EOS;
         $s = new StripeObject();
 
         $s->metadata = ['bar'];
-        $this->assertSame($s->metadata, ['bar']);
+        static::assertSame($s->metadata, ['bar']);
         $s->metadata = ['baz', 'qux'];
-        $this->assertSame($s->metadata, ['baz', 'qux']);
+        static::assertSame($s->metadata, ['baz', 'qux']);
     }
 
     public function testSetPermanentAttribute()
@@ -201,21 +201,21 @@ EOS;
     public function testSerializeParametersOnEmptyObject()
     {
         $obj = StripeObject::constructFrom([]);
-        $this->assertSame([], $obj->serializeParameters());
+        static::assertSame([], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnNewObjectWithSubObject()
     {
         $obj = new StripeObject();
         $obj->metadata = ['foo' => 'bar'];
-        $this->assertSame(['metadata' => ['foo' => 'bar']], $obj->serializeParameters());
+        static::assertSame(['metadata' => ['foo' => 'bar']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnBasicObject()
     {
         $obj = StripeObject::constructFrom(['foo' => null]);
         $obj->updateAttributes(['foo' => 'bar']);
-        $this->assertSame(['foo' => 'bar'], $obj->serializeParameters());
+        static::assertSame(['foo' => 'bar'], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnMoreComplexObject()
@@ -227,7 +227,7 @@ EOS;
             ]),
         ]);
         $obj->foo->bar = 'newbar';
-        $this->assertSame(['foo' => ['bar' => 'newbar']], $obj->serializeParameters());
+        static::assertSame(['foo' => ['bar' => 'newbar']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArray()
@@ -236,7 +236,7 @@ EOS;
             'foo' => null,
         ]);
         $obj->foo = ['new-value'];
-        $this->assertSame(['foo' => ['new-value']], $obj->serializeParameters());
+        static::assertSame(['foo' => ['new-value']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayThatShortens()
@@ -245,7 +245,7 @@ EOS;
             'foo' => ['0-index', '1-index', '2-index'],
         ]);
         $obj->foo = ['new-value'];
-        $this->assertSame(['foo' => ['new-value']], $obj->serializeParameters());
+        static::assertSame(['foo' => ['new-value']], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayThatLengthens()
@@ -254,7 +254,7 @@ EOS;
             'foo' => ['0-index', '1-index', '2-index'],
         ]);
         $obj->foo = \array_fill(0, 4, 'new-value');
-        $this->assertSame(['foo' => \array_fill(0, 4, 'new-value')], $obj->serializeParameters());
+        static::assertSame(['foo' => \array_fill(0, 4, 'new-value')], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnArrayOfHashes()
@@ -265,7 +265,7 @@ EOS;
         ];
 
         $obj->foo[0]->bar = 'baz';
-        $this->assertSame(['foo' => [['bar' => 'baz']]], $obj->serializeParameters());
+        static::assertSame(['foo' => [['bar' => 'baz']]], $obj->serializeParameters());
     }
 
     public function testSerializeParametersDoesNotIncludeUnchangedValues()
@@ -273,7 +273,7 @@ EOS;
         $obj = StripeObject::constructFrom([
             'foo' => null,
         ]);
-        $this->assertSame([], $obj->serializeParameters());
+        static::assertSame([], $obj->serializeParameters());
     }
 
     public function testSerializeParametersOnUnchangedArray()
@@ -282,7 +282,7 @@ EOS;
             'foo' => ['0-index', '1-index', '2-index'],
         ]);
         $obj->foo = ['0-index', '1-index', '2-index'];
-        $this->assertSame([], $obj->serializeParameters());
+        static::assertSame([], $obj->serializeParameters());
     }
 
     public function testSerializeParametersWithStripeObject()
@@ -291,7 +291,7 @@ EOS;
         $obj->metadata = StripeObject::constructFrom(['foo' => 'bar']);
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['foo' => 'bar'], $serialized['metadata']);
+        static::assertSame(['foo' => 'bar'], $serialized['metadata']);
     }
 
     public function testSerializeParametersOnReplacedStripeObject()
@@ -302,7 +302,7 @@ EOS;
         $obj->source = StripeObject::constructFrom(['baz' => 'foo']);
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['baz' => 'foo'], $serialized['source']);
+        static::assertSame(['baz' => 'foo'], $serialized['source']);
     }
 
     public function testSerializeParametersOnReplacedStripeObjectWhichIsMetadata()
@@ -313,7 +313,7 @@ EOS;
         $obj->metadata = StripeObject::constructFrom(['baz' => 'foo']);
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['bar' => '', 'baz' => 'foo'], $serialized['metadata']);
+        static::assertSame(['bar' => '', 'baz' => 'foo'], $serialized['metadata']);
     }
 
     public function testSerializeParametersOnArrayOfStripeObjects()
@@ -324,7 +324,7 @@ EOS;
         ];
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame([['foo' => 'bar']], $serialized['metadata']);
+        static::assertSame([['foo' => 'bar']], $serialized['metadata']);
     }
 
     public function testSerializeParametersOnSetApiResource()
@@ -337,7 +337,7 @@ EOS;
         $obj->customer = $customer;
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['customer' => $customer], $serialized);
+        static::assertSame(['customer' => $customer], $serialized);
     }
 
     public function testSerializeParametersOnNotSetApiResource()
@@ -346,7 +346,7 @@ EOS;
         $obj = StripeObject::constructFrom(['customer' => $customer]);
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame([], $serialized);
+        static::assertSame([], $serialized);
     }
 
     public function testSerializeParametersOnApiResourceFlaggedWithSaveWithParent()
@@ -357,7 +357,7 @@ EOS;
         $obj = StripeObject::constructFrom(['customer' => $customer]);
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['customer' => []], $serialized);
+        static::assertSame(['customer' => []], $serialized);
     }
 
     public function testSerializeParametersRaisesExceotionOnOtherEmbeddedApiResources()
@@ -372,15 +372,15 @@ EOS;
 
         try {
             $serialized = $obj->serializeParameters();
-            $this->fail("Did not raise error");
+            static::fail("Did not raise error");
         } catch (\InvalidArgumentException $e) {
-            $this->assertSame(
+            static::assertSame(
                 "Cannot save property `customer` containing an API resource of type Stripe\\Customer. " .
                 "It doesn't appear to be persisted and is not marked as `saveWithParent`.",
                 $e->getMessage()
             );
         } catch (\Exception $e) {
-            $this->fail("Unexpected exception: " . \get_class($e));
+            static::fail("Unexpected exception: " . \get_class($e));
         }
     }
 
@@ -394,7 +394,7 @@ EOS;
         ]);
 
         $serialized = $obj->serializeParameters(true);
-        $this->assertSame(['id' => 'id', 'metadata' => ['bar' => 'foo']], $serialized);
+        static::assertSame(['id' => 'id', 'metadata' => ['bar' => 'foo']], $serialized);
     }
 
     public function testDirty()
@@ -411,7 +411,7 @@ EOS;
         $obj->dirty();
 
         $serialized = $obj->serializeParameters();
-        $this->assertSame(['id' => 'id', 'metadata' => ['bar' => 'foo']], $serialized);
+        static::assertSame(['id' => 'id', 'metadata' => ['bar' => 'foo']], $serialized);
     }
 
     public function testDeepCopy()
@@ -439,66 +439,66 @@ EOS;
 
         // we can't compare the hashes directly because they have embedded
         // objects which are different from each other
-        $this->assertEquals($values["id"], $copyValues["id"]);
-        $this->assertEquals($values["name"], $copyValues["name"]);
-        $this->assertEquals(\count($values["arr"]), \count($copyValues["arr"]));
+        static::assertEquals($values["id"], $copyValues["id"]);
+        static::assertEquals($values["name"], $copyValues["name"]);
+        static::assertEquals(\count($values["arr"]), \count($copyValues["arr"]));
 
         // internal values of the copied StripeObject should be the same,
         // but the object itself should be new (hence the assertNotSame)
-        $this->assertEquals($values["arr"][0]["id"], $copyValues["arr"][0]["id"]);
-        $this->assertNotSame($values["arr"][0], $copyValues["arr"][0]);
+        static::assertEquals($values["arr"][0]["id"], $copyValues["arr"][0]["id"]);
+        static::assertNotSame($values["arr"][0], $copyValues["arr"][0]);
 
         // likewise, the Util\RequestOptions instance in _opts should have
         // copied values but be a new instance
-        $this->assertEquals(
+        static::assertEquals(
             $this->optsReflector->getValue($values["arr"][0]),
             $this->optsReflector->getValue($copyValues["arr"][0])
         );
-        $this->assertNotSame(
+        static::assertNotSame(
             $this->optsReflector->getValue($values["arr"][0]),
             $this->optsReflector->getValue($copyValues["arr"][0])
         );
 
         // scalars however, can be compared
-        $this->assertEquals($values["arr"][1], $copyValues["arr"][1]);
-        $this->assertEquals($values["arr"][2], $copyValues["arr"][2]);
+        static::assertEquals($values["arr"][1], $copyValues["arr"][1]);
+        static::assertEquals($values["arr"][2], $copyValues["arr"][2]);
 
         // and a similar story with the hash
-        $this->assertEquals($values["map"]["0"]["id"], $copyValues["map"]["0"]["id"]);
-        $this->assertNotSame($values["map"]["0"], $copyValues["map"]["0"]);
-        $this->assertNotSame(
+        static::assertEquals($values["map"]["0"]["id"], $copyValues["map"]["0"]["id"]);
+        static::assertNotSame($values["map"]["0"], $copyValues["map"]["0"]);
+        static::assertNotSame(
             $this->optsReflector->getValue($values["arr"][0]),
             $this->optsReflector->getValue($copyValues["arr"][0])
         );
-        $this->assertEquals(
+        static::assertEquals(
             $this->optsReflector->getValue($values["map"]["0"]),
             $this->optsReflector->getValue($copyValues["map"]["0"])
         );
-        $this->assertNotSame(
+        static::assertNotSame(
             $this->optsReflector->getValue($values["map"]["0"]),
             $this->optsReflector->getValue($copyValues["map"]["0"])
         );
-        $this->assertEquals($values["map"]["1"], $copyValues["map"]["1"]);
-        $this->assertEquals($values["map"]["2"], $copyValues["map"]["2"]);
+        static::assertEquals($values["map"]["1"], $copyValues["map"]["1"]);
+        static::assertEquals($values["map"]["2"], $copyValues["map"]["2"]);
     }
 
     public function testDeepCopyMaintainClass()
     {
         $charge = Charge::constructFrom(["id" => 1], null);
         $copyCharge = $this->deepCopyReflector->invoke(null, $charge);
-        $this->assertEquals(\get_class($charge), \get_class($copyCharge));
+        static::assertEquals(\get_class($charge), \get_class($copyCharge));
     }
 
     public function testIsDeleted()
     {
         $obj = StripeObject::constructFrom([]);
-        $this->assertFalse($obj->isDeleted());
+        static::assertFalse($obj->isDeleted());
 
         $obj = StripeObject::constructFrom(['deleted' => false]);
-        $this->assertFalse($obj->isDeleted());
+        static::assertFalse($obj->isDeleted());
 
         $obj = StripeObject::constructFrom(['deleted' => true]);
-        $this->assertTrue($obj->isDeleted());
+        static::assertTrue($obj->isDeleted());
     }
 
     public function testDeserializeEmptyMetadata()
@@ -507,7 +507,7 @@ EOS;
             'metadata' => [],
         ]);
 
-        $this->assertInstanceOf(\Stripe\StripeObject::class, $obj->metadata);
+        static::assertInstanceOf(\Stripe\StripeObject::class, $obj->metadata);
     }
 
     public function testDeserializeMetadataWithKeyNamedMetadata()
@@ -516,7 +516,7 @@ EOS;
             'metadata' => ['metadata' => 'value'],
         ]);
 
-        $this->assertInstanceOf(\Stripe\StripeObject::class, $obj->metadata);
-        $this->assertEquals("value", $obj->metadata->metadata);
+        static::assertInstanceOf(\Stripe\StripeObject::class, $obj->metadata);
+        static::assertEquals("value", $obj->metadata->metadata);
     }
 }

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -431,7 +431,7 @@ EOS;
             "map" => [
                 "0" => StripeObject::constructFrom(["id" => "index0"], $opts),
                 "1" => "index1",
-                "2" => 2
+                "2" => 2,
             ],
         ];
 

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -32,12 +32,12 @@ class StripeTelemetryTest extends TestCase
             ->setMethods(['request'])
             ->getMock();
 
-        $stub->expects($this->any())
+        $stub->expects(static::any())
             ->method("request")
             ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(function ($headers) use (&$requestheaders) {
+                static::anything(),
+                static::anything(),
+                static::callback(function ($headers) use (&$requestheaders) {
                     foreach ($headers as $index => $header) {
                         // capture the requested headers and format back to into an assoc array
                         $components = \explode(": ", $header, 2);
@@ -46,19 +46,19 @@ class StripeTelemetryTest extends TestCase
 
                     return true;
                 }),
-                $this->anything(),
-                $this->anything()
+                static::anything(),
+                static::anything()
             )->willReturn([self::FAKE_VALID_RESPONSE, 200, ["request-id" => "123"]]);
 
         ApiRequestor::setHttpClient($stub);
 
         // make one request to capture its result
         Charge::all();
-        $this->assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
+        static::assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
 
         // make another request and verify telemetry isn't sent
         Charge::all();
-        $this->assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
+        static::assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
 
         ApiRequestor::setHttpClient(null);
     }
@@ -74,12 +74,12 @@ class StripeTelemetryTest extends TestCase
             ->setMethods(['request'])
             ->getMock();
 
-        $stub->expects($this->any())
+        $stub->expects(static::any())
             ->method("request")
             ->with(
-                $this->anything(),
-                $this->anything(),
-                $this->callback(function ($headers) use (&$requestheaders) {
+                static::anything(),
+                static::anything(),
+                static::callback(function ($headers) use (&$requestheaders) {
                     // capture the requested headers and format back to into an assoc array
                     foreach ($headers as $index => $header) {
                         $components = \explode(": ", $header, 2);
@@ -88,23 +88,23 @@ class StripeTelemetryTest extends TestCase
 
                     return true;
                 }),
-                $this->anything(),
-                $this->anything()
+                static::anything(),
+                static::anything()
             )->willReturn([self::FAKE_VALID_RESPONSE, 200, ["request-id" => ["req_123"]]]);
 
         ApiRequestor::setHttpClient($stub);
 
         // make one request to capture its result
         Charge::all();
-        $this->assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
+        static::assertArrayNotHasKey('X-Stripe-Client-Telemetry', $requestheaders);
 
         // make another request to send the previous
         Charge::all();
-        $this->assertArrayHasKey('X-Stripe-Client-Telemetry', $requestheaders);
+        static::assertArrayHasKey('X-Stripe-Client-Telemetry', $requestheaders);
 
         $data = \json_decode($requestheaders['X-Stripe-Client-Telemetry'], true);
-        $this->assertEquals('req_123', $data['last_request_metrics']['request_id']);
-        $this->assertNotNull($data['last_request_metrics']['request_duration_ms']);
+        static::assertEquals('req_123', $data['last_request_metrics']['request_id']);
+        static::assertNotNull($data['last_request_metrics']['request_duration_ms']);
 
         ApiRequestor::setHttpClient(null);
     }

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -28,6 +28,6 @@ class StripeTest extends TestCase
     public function testCABundlePathAccessors()
     {
         Stripe::setCABundlePath('path/to/ca/bundle');
-        $this->assertEquals('path/to/ca/bundle', Stripe::getCABundlePath());
+        static::assertEquals('path/to/ca/bundle', Stripe::getCABundlePath());
     }
 }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -18,8 +18,8 @@ class SubscriptionItemTest extends TestCase
         $resources = SubscriptionItem::all([
             "subscription" => "sub_123"
         ]);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -29,7 +29,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . self::TEST_RESOURCE_ID
         );
         $resource = SubscriptionItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }
 
     public function testIsCreatable()
@@ -42,7 +42,7 @@ class SubscriptionItemTest extends TestCase
             "plan" => "plan",
             "subscription" => "sub_123"
         ]);
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }
 
     public function testIsSaveable()
@@ -54,7 +54,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -66,7 +66,7 @@ class SubscriptionItemTest extends TestCase
         $resource = SubscriptionItem::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }
 
     public function testIsDeletable()
@@ -77,7 +77,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }
 
     public function testCanCreateUsageRecord()
@@ -101,8 +101,8 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . $resource->id . "/usage_record_summaries"
         );
         $resources = $resource->usageRecordSummaries();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
     }
 
     public function testCanListUsageRecordSummaries()
@@ -112,7 +112,7 @@ class SubscriptionItemTest extends TestCase
             '/v1/subscription_items/' . self::TEST_RESOURCE_ID . "/usage_record_summaries"
         );
         $resources =SubscriptionItem::allUsageRecordSummaries(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -12,11 +12,11 @@ class SubscriptionItemTest extends TestCase
             'get',
             '/v1/subscription_items',
             [
-                "subscription" => "sub_123"
+                "subscription" => "sub_123",
             ]
         );
         $resources = SubscriptionItem::all([
-            "subscription" => "sub_123"
+            "subscription" => "sub_123",
         ]);
         static::assertInternalType('array', $resources->data);
         static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resources->data[0]);
@@ -40,7 +40,7 @@ class SubscriptionItemTest extends TestCase
         );
         $resource = SubscriptionItem::create([
             "plan" => "plan",
-            "subscription" => "sub_123"
+            "subscription" => "sub_123",
         ]);
         static::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
     }

--- a/tests/Stripe/SubscriptionScheduleTest.php
+++ b/tests/Stripe/SubscriptionScheduleTest.php
@@ -38,7 +38,7 @@ class SubscriptionScheduleTest extends TestCase
             "phases" => [
                 [
                     "plans" => [
-                        [ "plan" => "plan_123", "quantity" => 2],
+                        ["plan" => "plan_123", "quantity" => 2],
                     ],
                 ],
             ],

--- a/tests/Stripe/SubscriptionScheduleTest.php
+++ b/tests/Stripe/SubscriptionScheduleTest.php
@@ -14,8 +14,8 @@ class SubscriptionScheduleTest extends TestCase
             '/v1/subscription_schedules'
         );
         $resources = SubscriptionSchedule::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class SubscriptionScheduleTest extends TestCase
             '/v1/subscription_schedules/' . self::TEST_RESOURCE_ID
         );
         $resource = SubscriptionSchedule::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 
     public function testIsCreatable()
@@ -43,7 +43,7 @@ class SubscriptionScheduleTest extends TestCase
                 ],
             ],
         ]);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 
     public function testIsSaveable()
@@ -55,7 +55,7 @@ class SubscriptionScheduleTest extends TestCase
             '/v1/subscription_schedules/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -67,7 +67,7 @@ class SubscriptionScheduleTest extends TestCase
         $resource = SubscriptionSchedule::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 
     public function testIsCancelable()
@@ -79,7 +79,7 @@ class SubscriptionScheduleTest extends TestCase
             []
         );
         $resource->cancel([]);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 
     public function testIsReleaseable()
@@ -91,6 +91,6 @@ class SubscriptionScheduleTest extends TestCase
             []
         );
         $resource->release([]);
-        $this->assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
+        static::assertInstanceOf(\Stripe\SubscriptionSchedule::class, $resource);
     }
 }

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -13,8 +13,8 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions'
         );
         $resources = Subscription::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . self::TEST_RESOURCE_ID
         );
         $resource = Subscription::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testIsCreatable()
@@ -36,7 +36,7 @@ class SubscriptionTest extends TestCase
         $resource = Subscription::create([
             "customer" => "cus_123"
         ]);
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testIsSaveable()
@@ -48,7 +48,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -60,7 +60,7 @@ class SubscriptionTest extends TestCase
         $resource = Subscription::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testIsCancelable()
@@ -72,7 +72,7 @@ class SubscriptionTest extends TestCase
             []
         );
         $resource->cancel([]);
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testCanDeleteDiscount()
@@ -83,7 +83,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions/' . $resource->id . '/discount'
         );
         $resource->deleteDiscount();
-        $this->assertInstanceOf(\Stripe\Subscription::class, $resource);
+        static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }
 
     public function testSerializeParametersItems()
@@ -105,6 +105,6 @@ class SubscriptionTest extends TestCase
                 1 => ['plan' => 'plan_bar'],
             ],
         ];
-        $this->assertSame($expected, $obj->serializeParameters());
+        static::assertSame($expected, $obj->serializeParameters());
     }
 }

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -34,7 +34,7 @@ class SubscriptionTest extends TestCase
             '/v1/subscriptions'
         );
         $resource = Subscription::create([
-            "customer" => "cus_123"
+            "customer" => "cus_123",
         ]);
         static::assertInstanceOf(\Stripe\Subscription::class, $resource);
     }

--- a/tests/Stripe/TaxIdTest.php
+++ b/tests/Stripe/TaxIdTest.php
@@ -10,7 +10,7 @@ class TaxIdTest extends TestCase
     public function testHasCorrectUrl()
     {
         $resource = \Stripe\Customer::retrieveTaxId(self::TEST_CUSTOMER_ID, self::TEST_RESOURCE_ID);
-        $this->assertSame(
+        static::assertSame(
             "/v1/customers/" . self::TEST_CUSTOMER_ID . "/tax_ids/" . self::TEST_RESOURCE_ID,
             $resource->instanceUrl()
         );
@@ -24,6 +24,6 @@ class TaxIdTest extends TestCase
             '/v1/customers/' . self::TEST_CUSTOMER_ID . '/tax_ids/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\TaxId::class, $resource);
+        static::assertInstanceOf(\Stripe\TaxId::class, $resource);
     }
 }

--- a/tests/Stripe/TaxRateTest.php
+++ b/tests/Stripe/TaxRateTest.php
@@ -13,8 +13,8 @@ class TaxRateTest extends TestCase
             '/v1/tax_rates'
         );
         $resources = TaxRate::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\TaxRate::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class TaxRateTest extends TestCase
             '/v1/tax_rates/' . self::TEST_RESOURCE_ID
         );
         $resource = TaxRate::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\TaxRate::class, $resource);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
     }
 
     public function testIsCreatable()
@@ -38,7 +38,7 @@ class TaxRateTest extends TestCase
             "inclusive" => false,
             "percentage" => 10.15,
         ]);
-        $this->assertInstanceOf(\Stripe\TaxRate::class, $resource);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
     }
 
     public function testIsSaveable()
@@ -50,7 +50,7 @@ class TaxRateTest extends TestCase
             '/v1/tax_rates/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\TaxRate::class, $resource);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -62,6 +62,6 @@ class TaxRateTest extends TestCase
         $resource = TaxRate::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\TaxRate::class, $resource);
+        static::assertInstanceOf(\Stripe\TaxRate::class, $resource);
     }
 }

--- a/tests/Stripe/Terminal/ConnectionTokenTest.php
+++ b/tests/Stripe/Terminal/ConnectionTokenTest.php
@@ -11,6 +11,6 @@ class ConnectionTokenTest extends \Stripe\TestCase
             '/v1/terminal/connection_tokens'
         );
         $resource = ConnectionToken::create();
-        $this->assertInstanceOf(\Stripe\Terminal\ConnectionToken::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\ConnectionToken::class, $resource);
     }
 }

--- a/tests/Stripe/Terminal/LocationTest.php
+++ b/tests/Stripe/Terminal/LocationTest.php
@@ -13,8 +13,8 @@ class LocationTest extends \Stripe\TestCase
             '/v1/terminal/locations'
         );
         $resources = Location::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class LocationTest extends \Stripe\TestCase
             '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
         );
         $resource = Location::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class LocationTest extends \Stripe\TestCase
             '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -50,7 +50,7 @@ class LocationTest extends \Stripe\TestCase
         $resource = Location::update(self::TEST_RESOURCE_ID, [
             "display_name" => "new-name",
         ]);
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }
 
     public function testIsCreatable()
@@ -79,7 +79,7 @@ class LocationTest extends \Stripe\TestCase
                 "city" => "San Francisco"
             ]
         ]);
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }
 
     public function testIsDeletable()
@@ -90,6 +90,6 @@ class LocationTest extends \Stripe\TestCase
             '/v1/terminal/locations/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }
 }

--- a/tests/Stripe/Terminal/LocationTest.php
+++ b/tests/Stripe/Terminal/LocationTest.php
@@ -65,8 +65,8 @@ class LocationTest extends \Stripe\TestCase
                     "country" => "US",
                     "state" => "CA",
                     "postal_code" => "12345",
-                    "city" => "San Francisco"
-                ]
+                    "city" => "San Francisco",
+                ],
             ]
         );
         $resource = Location::create([
@@ -76,8 +76,8 @@ class LocationTest extends \Stripe\TestCase
                 "country" => "US",
                 "state" => "CA",
                 "postal_code" => "12345",
-                "city" => "San Francisco"
-            ]
+                "city" => "San Francisco",
+            ],
         ]);
         static::assertInstanceOf(\Stripe\Terminal\Location::class, $resource);
     }

--- a/tests/Stripe/Terminal/ReaderTest.php
+++ b/tests/Stripe/Terminal/ReaderTest.php
@@ -13,8 +13,8 @@ class ReaderTest extends \Stripe\TestCase
             '/v1/terminal/readers'
         );
         $resources = Reader::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class ReaderTest extends \Stripe\TestCase
             '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
         );
         $resource = Reader::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
     }
 
     public function testIsSaveable()
@@ -37,7 +37,7 @@ class ReaderTest extends \Stripe\TestCase
             '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -50,7 +50,7 @@ class ReaderTest extends \Stripe\TestCase
         $resource = Reader::update(self::TEST_RESOURCE_ID, [
             "label" => "new-name",
         ]);
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
     }
 
     public function testIsCreatable()
@@ -61,7 +61,7 @@ class ReaderTest extends \Stripe\TestCase
             ["registration_code" => "a-b-c"]
         );
         $resource = Reader::create(['registration_code' => 'a-b-c']);
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class ReaderTest extends \Stripe\TestCase
             '/v1/terminal/readers/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
+        static::assertInstanceOf(\Stripe\Terminal\Reader::class, $resource);
     }
 }

--- a/tests/Stripe/ThreeDSecureTest.php
+++ b/tests/Stripe/ThreeDSecureTest.php
@@ -13,7 +13,7 @@ class ThreeDSecureTest extends TestCase
             '/v1/3d_secure/' . self::TEST_RESOURCE_ID
         );
         $resource = ThreeDSecure::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\ThreeDSecure::class, $resource);
+        static::assertInstanceOf(\Stripe\ThreeDSecure::class, $resource);
     }
 
     public function testIsCreatable()
@@ -27,6 +27,6 @@ class ThreeDSecureTest extends TestCase
             "currency" => "usd",
             "return_url" => "url"
         ]);
-        $this->assertInstanceOf(\Stripe\ThreeDSecure::class, $resource);
+        static::assertInstanceOf(\Stripe\ThreeDSecure::class, $resource);
     }
 }

--- a/tests/Stripe/ThreeDSecureTest.php
+++ b/tests/Stripe/ThreeDSecureTest.php
@@ -25,7 +25,7 @@ class ThreeDSecureTest extends TestCase
         $resource = ThreeDSecure::create([
             "amount" => 100,
             "currency" => "usd",
-            "return_url" => "url"
+            "return_url" => "url",
         ]);
         static::assertInstanceOf(\Stripe\ThreeDSecure::class, $resource);
     }

--- a/tests/Stripe/TokenTest.php
+++ b/tests/Stripe/TokenTest.php
@@ -13,7 +13,7 @@ class TokenTest extends TestCase
             '/v1/tokens/' . self::TEST_RESOURCE_ID
         );
         $resource = Token::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Token::class, $resource);
+        static::assertInstanceOf(\Stripe\Token::class, $resource);
     }
 
     public function testIsCreatable()
@@ -23,6 +23,6 @@ class TokenTest extends TestCase
             '/v1/tokens'
         );
         $resource = Token::create(["card" => "tok_visa"]);
-        $this->assertInstanceOf(\Stripe\Token::class, $resource);
+        static::assertInstanceOf(\Stripe\Token::class, $resource);
     }
 }

--- a/tests/Stripe/TopupTest.php
+++ b/tests/Stripe/TopupTest.php
@@ -13,8 +13,8 @@ class TopupTest extends TestCase
             '/v1/topups'
         );
         $resources = Topup::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Topup::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Topup::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class TopupTest extends TestCase
             '/v1/topups/' . self::TEST_RESOURCE_ID
         );
         $resource = Topup::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Topup::class, $resource);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }
 
     public function testIsCreatable()
@@ -40,7 +40,7 @@ class TopupTest extends TestCase
             "description" => "description",
             "statement_descriptor" => "statement descriptor"
         ]);
-        $this->assertInstanceOf(\Stripe\Topup::class, $resource);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }
 
     public function testIsSaveable()
@@ -52,7 +52,7 @@ class TopupTest extends TestCase
             '/v1/topups/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Topup::class, $resource);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -64,7 +64,7 @@ class TopupTest extends TestCase
         $resource = Topup::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Topup::class, $resource);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }
 
     public function testIsCancelable()
@@ -75,6 +75,6 @@ class TopupTest extends TestCase
             '/v1/topups/' . self::TEST_RESOURCE_ID . '/cancel'
         );
         $resource = $resource->cancel();
-        $this->assertInstanceOf(\Stripe\Topup::class, $resource);
+        static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }
 }

--- a/tests/Stripe/TopupTest.php
+++ b/tests/Stripe/TopupTest.php
@@ -38,7 +38,7 @@ class TopupTest extends TestCase
             "currency" => "usd",
             "source" => "tok_123",
             "description" => "description",
-            "statement_descriptor" => "statement descriptor"
+            "statement_descriptor" => "statement descriptor",
         ]);
         static::assertInstanceOf(\Stripe\Topup::class, $resource);
     }

--- a/tests/Stripe/TransferReversalTest.php
+++ b/tests/Stripe/TransferReversalTest.php
@@ -16,6 +16,6 @@ class TransferReversalTest extends TestCase
             '/v1/transfers/' . $resource->transfer . '/reversals/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
     }
 }

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -37,7 +37,7 @@ class TransferTest extends TestCase
         $resource = Transfer::create([
             "amount" => 100,
             "currency" => "usd",
-            "destination" => "acct_123"
+            "destination" => "acct_123",
         ]);
         static::assertInstanceOf(\Stripe\Transfer::class, $resource);
     }

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -14,8 +14,8 @@ class TransferTest extends TestCase
             '/v1/transfers'
         );
         $resources = Transfer::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -25,7 +25,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID
         );
         $resource = Transfer::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resource);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
     }
 
     public function testIsCreatable()
@@ -39,7 +39,7 @@ class TransferTest extends TestCase
             "currency" => "usd",
             "destination" => "acct_123"
         ]);
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resource);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
     }
 
     public function testIsSaveable()
@@ -51,7 +51,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . $resource->id
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resource);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -63,7 +63,7 @@ class TransferTest extends TestCase
         $resource = Transfer::update(self::TEST_RESOURCE_ID, [
             "metadata" => ["key" => "value"],
         ]);
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resource);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
     }
 
     public function testIsCancelable()
@@ -76,8 +76,8 @@ class TransferTest extends TestCase
             '/v1/transfers/' . $transfer->id . '/cancel'
         );
         $resource = $transfer->cancel();
-        $this->assertInstanceOf(\Stripe\Transfer::class, $resource);
-        $this->assertSame($resource, $transfer);
+        static::assertInstanceOf(\Stripe\Transfer::class, $resource);
+        static::assertSame($resource, $transfer);
     }
 
     public function testCanCreateReversal()
@@ -87,7 +87,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
         );
         $resource = Transfer::createReversal(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
     }
 
     public function testCanRetrieveReversal()
@@ -97,7 +97,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals/' . self::TEST_REVERSAL_ID
         );
         $resource = Transfer::retrieveReversal(self::TEST_RESOURCE_ID, self::TEST_REVERSAL_ID);
-        $this->assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
     }
 
     public function testCanUpdateReversal()
@@ -113,7 +113,7 @@ class TransferTest extends TestCase
                 "metadata" => ["key" => "value"],
             ]
         );
-        $this->assertInstanceOf(\Stripe\TransferReversal::class, $resource);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resource);
     }
 
     public function testCanListReversal()
@@ -123,7 +123,7 @@ class TransferTest extends TestCase
             '/v1/transfers/' . self::TEST_RESOURCE_ID . '/reversals'
         );
         $resources = Transfer::allReversals(self::TEST_RESOURCE_ID);
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\TransferReversal::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\TransferReversal::class, $resources->data[0]);
     }
 }

--- a/tests/Stripe/Util/CaseInsensitiveArrayTest.php
+++ b/tests/Stripe/Util/CaseInsensitiveArrayTest.php
@@ -10,24 +10,24 @@ class CaseInsensitiveArrayTest extends \Stripe\TestCase
 
         $arr["thrEE"] = "3";
 
-        $this->assertSame("1", $arr["one"]);
-        $this->assertSame("1", $arr["One"]);
-        $this->assertSame("1", $arr["ONE"]);
+        static::assertSame("1", $arr["one"]);
+        static::assertSame("1", $arr["One"]);
+        static::assertSame("1", $arr["ONE"]);
 
-        $this->assertSame("2", $arr["two"]);
-        $this->assertSame("2", $arr["twO"]);
-        $this->assertSame("2", $arr["TWO"]);
+        static::assertSame("2", $arr["two"]);
+        static::assertSame("2", $arr["twO"]);
+        static::assertSame("2", $arr["TWO"]);
 
-        $this->assertSame("3", $arr["three"]);
-        $this->assertSame("3", $arr["ThReE"]);
-        $this->assertSame("3", $arr["THREE"]);
+        static::assertSame("3", $arr["three"]);
+        static::assertSame("3", $arr["ThReE"]);
+        static::assertSame("3", $arr["THREE"]);
     }
 
     public function testCount()
     {
         $arr = new CaseInsensitiveArray(["One" => "1", "TWO" => "2"]);
 
-        $this->assertCount(2, $arr);
+        static::assertCount(2, $arr);
     }
 
     public function testIterable()
@@ -40,7 +40,7 @@ class CaseInsensitiveArrayTest extends \Stripe\TestCase
             $seen[$k] = $v;
         }
 
-        $this->assertSame("1", $seen["one"]);
-        $this->assertSame("2", $seen["two"]);
+        static::assertSame("1", $seen["one"]);
+        static::assertSame("2", $seen["two"]);
     }
 }

--- a/tests/Stripe/Util/DefaultLoggerTest.php
+++ b/tests/Stripe/Util/DefaultLoggerTest.php
@@ -16,7 +16,7 @@ class DefaultLoggerTest extends \Stripe\TestCase
             $logger = new DefaultLogger();
             $logger->error("This is a test message");
 
-            $this->assertRegExp("/This is a test message/", \stream_get_contents($capture));
+            static::assertRegExp("/This is a test message/", \stream_get_contents($capture));
         } finally {
             \ini_set('error_log', $origErrorLog);
             \fclose($capture);

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -52,7 +52,7 @@ class RequestOptionsTest extends \Stripe\TestCase
         $opts = RequestOptions::parse(
             [
                 'idempotency_key' => 'foo',
-                'api_key' => 'foo'
+                'api_key' => 'foo',
             ]
         );
         static::assertSame('foo', $opts->apiKey);

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -7,22 +7,22 @@ class RequestOptionsTest extends \Stripe\TestCase
     public function testStringAPIKey()
     {
         $opts = RequestOptions::parse("foo");
-        $this->assertSame("foo", $opts->apiKey);
-        $this->assertSame([], $opts->headers);
+        static::assertSame("foo", $opts->apiKey);
+        static::assertSame([], $opts->headers);
     }
 
     public function testNull()
     {
         $opts = RequestOptions::parse(null);
-        $this->assertNull($opts->apiKey);
-        $this->assertSame([], $opts->headers);
+        static::assertNull($opts->apiKey);
+        static::assertSame([], $opts->headers);
     }
 
     public function testEmptyArray()
     {
         $opts = RequestOptions::parse([]);
-        $this->assertNull($opts->apiKey);
-        $this->assertSame([], $opts->headers);
+        static::assertNull($opts->apiKey);
+        static::assertSame([], $opts->headers);
     }
 
     public function testAPIKeyArray()
@@ -32,8 +32,8 @@ class RequestOptionsTest extends \Stripe\TestCase
                 'api_key' => 'foo',
             ]
         );
-        $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame([], $opts->headers);
+        static::assertSame('foo', $opts->apiKey);
+        static::assertSame([], $opts->headers);
     }
 
     public function testIdempotentKeyArray()
@@ -43,8 +43,8 @@ class RequestOptionsTest extends \Stripe\TestCase
                 'idempotency_key' => 'foo',
             ]
         );
-        $this->assertNull($opts->apiKey);
-        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
+        static::assertNull($opts->apiKey);
+        static::assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     public function testKeyArray()
@@ -55,8 +55,8 @@ class RequestOptionsTest extends \Stripe\TestCase
                 'api_key' => 'foo'
             ]
         );
-        $this->assertSame('foo', $opts->apiKey);
-        $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
+        static::assertSame('foo', $opts->apiKey);
+        static::assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 
     public function testWrongType()
@@ -75,21 +75,21 @@ class RequestOptionsTest extends \Stripe\TestCase
             ]
         );
         $opts->discardNonPersistentHeaders();
-        $this->assertSame(['Stripe-Account' => 'foo'], $opts->headers);
+        static::assertSame(['Stripe-Account' => 'foo'], $opts->headers);
     }
 
     public function testDebugInfo()
     {
         $opts = RequestOptions::parse(['api_key' => 'sk_test_1234567890abcdefghijklmn']);
         $debugInfo = \print_r($opts, true);
-        $this->assertContains("[apiKey] => sk_test_********************klmn", $debugInfo);
+        static::assertContains("[apiKey] => sk_test_********************klmn", $debugInfo);
 
         $opts = RequestOptions::parse(['api_key' => 'sk_1234567890abcdefghijklmn']);
         $debugInfo = \print_r($opts, true);
-        $this->assertContains("[apiKey] => sk_********************klmn", $debugInfo);
+        static::assertContains("[apiKey] => sk_********************klmn", $debugInfo);
 
         $opts = RequestOptions::parse(['api_key' => '1234567890abcdefghijklmn']);
         $debugInfo = \print_r($opts, true);
-        $this->assertContains("[apiKey] => ********************klmn", $debugInfo);
+        static::assertContains("[apiKey] => ********************klmn", $debugInfo);
     }
 }

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -14,14 +14,14 @@ class RequestOptionsTest extends \Stripe\TestCase
     public function testNull()
     {
         $opts = RequestOptions::parse(null);
-        $this->assertSame(null, $opts->apiKey);
+        $this->assertNull($opts->apiKey);
         $this->assertSame([], $opts->headers);
     }
 
     public function testEmptyArray()
     {
         $opts = RequestOptions::parse([]);
-        $this->assertSame(null, $opts->apiKey);
+        $this->assertNull($opts->apiKey);
         $this->assertSame([], $opts->headers);
     }
 
@@ -43,7 +43,7 @@ class RequestOptionsTest extends \Stripe\TestCase
                 'idempotency_key' => 'foo',
             ]
         );
-        $this->assertSame(null, $opts->apiKey);
+        $this->assertNull($opts->apiKey);
         $this->assertSame(['Idempotency-Key' => 'foo'], $opts->headers);
     }
 

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -7,10 +7,10 @@ class UtilTest extends \Stripe\TestCase
     public function testIsList()
     {
         $list = [5, 'nstaoush', []];
-        $this->assertTrue(Util::isList($list));
+        static::assertTrue(Util::isList($list));
 
         $notlist = [5, 'nstaoush', [], 'bar' => 'baz'];
-        $this->assertFalse(Util::isList($notlist));
+        static::assertFalse(Util::isList($notlist));
     }
 
     public function testThatPHPHasValueSemanticsForArrays()
@@ -19,7 +19,7 @@ class UtilTest extends \Stripe\TestCase
         $derived = $original;
         $derived['php-arrays'] = 'reference-semantics';
 
-        $this->assertSame('value-semantics', $original['php-arrays']);
+        static::assertSame('value-semantics', $original['php-arrays']);
     }
 
     public function testConvertStripeObjectToArrayIncludesId()
@@ -31,22 +31,22 @@ class UtilTest extends \Stripe\TestCase
             ],
             null
         );
-        $this->assertArrayHasKey("id", $customer->toArray());
+        static::assertArrayHasKey("id", $customer->toArray());
     }
 
     public function testUtf8()
     {
         // UTF-8 string
         $x = "\xc3\xa9";
-        $this->assertSame(Util::utf8($x), $x);
+        static::assertSame(Util::utf8($x), $x);
 
         // Latin-1 string
         $x = "\xe9";
-        $this->assertSame(Util::utf8($x), "\xc3\xa9");
+        static::assertSame(Util::utf8($x), "\xc3\xa9");
 
         // Not a string
         $x = true;
-        $this->assertSame(Util::utf8($x), $x);
+        static::assertSame(Util::utf8($x), $x);
     }
 
     public function testObjectsToIds()
@@ -63,7 +63,7 @@ class UtilTest extends \Stripe\TestCase
             'null_value' => null,
         ];
 
-        $this->assertSame(
+        static::assertSame(
             [
                 'foo' => 'bar',
                 'customer' => 'cus_123',
@@ -86,7 +86,7 @@ class UtilTest extends \Stripe\TestCase
             'g' => [],
         ];
 
-        $this->assertSame(
+        static::assertSame(
             "a=3&b=%2Bfoo%3F&c=bar%26baz&d[a]=a&d[b]=b&e[0]=0&e[1]=1&f=",
             Util::encodeParameters($params)
         );
@@ -94,10 +94,10 @@ class UtilTest extends \Stripe\TestCase
 
     public function testUrlEncode()
     {
-        $this->assertSame("foo", Util::urlEncode("foo"));
-        $this->assertSame("foo%2B", Util::urlEncode("foo+"));
-        $this->assertSame("foo%26", Util::urlEncode("foo&"));
-        $this->assertSame("foo[bar]", Util::urlEncode("foo[bar]"));
+        static::assertSame("foo", Util::urlEncode("foo"));
+        static::assertSame("foo%2B", Util::urlEncode("foo+"));
+        static::assertSame("foo%26", Util::urlEncode("foo&"));
+        static::assertSame("foo[bar]", Util::urlEncode("foo[bar]"));
     }
 
     public function testFlattenParams()
@@ -114,7 +114,7 @@ class UtilTest extends \Stripe\TestCase
             ],
         ];
 
-        $this->assertSame(
+        static::assertSame(
             [
                 ['a', 3],
                 ['b', '+foo?'],

--- a/tests/Stripe/WebhookEndpointTest.php
+++ b/tests/Stripe/WebhookEndpointTest.php
@@ -13,8 +13,8 @@ class WebhookEndpointTest extends TestCase
             '/v1/webhook_endpoints'
         );
         $resources = WebhookEndpoint::all();
-        $this->assertInternalType('array', $resources->data);
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resources->data[0]);
+        static::assertInternalType('array', $resources->data);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resources->data[0]);
     }
 
     public function testIsRetrievable()
@@ -24,7 +24,7 @@ class WebhookEndpointTest extends TestCase
             '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
         );
         $resource = WebhookEndpoint::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
     }
 
     public function testIsCreatable()
@@ -37,7 +37,7 @@ class WebhookEndpointTest extends TestCase
             'enabled_events' => ['charge.succeeded'],
             'url' => 'https://stripe.com',
         ]);
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
     }
 
     public function testIsSaveable()
@@ -49,7 +49,7 @@ class WebhookEndpointTest extends TestCase
             '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
         );
         $resource->save();
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
     }
 
     public function testIsUpdatable()
@@ -61,7 +61,7 @@ class WebhookEndpointTest extends TestCase
         $resource = WebhookEndpoint::update(self::TEST_RESOURCE_ID, [
             'enabled_events' => ['charge.succeeded'],
         ]);
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
     }
 
     public function testIsDeletable()
@@ -72,6 +72,6 @@ class WebhookEndpointTest extends TestCase
             '/v1/webhook_endpoints/' . self::TEST_RESOURCE_ID
         );
         $resource->delete();
-        $this->assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
+        static::assertInstanceOf(\Stripe\WebhookEndpoint::class, $resource);
     }
 }

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -18,10 +18,10 @@ class WebhookTest extends TestCase
         $scheme = \array_key_exists('scheme', $opts) ? $opts['scheme'] : WebhookSignature::EXPECTED_SCHEME;
         $signature = \array_key_exists('signature', $opts) ? $opts['signature'] : null;
         if ($signature === null) {
-            $signedPayload = "${timestamp}.${payload}";
+            $signedPayload = "{$timestamp}.{$payload}";
             $signature = \hash_hmac("sha256", $signedPayload, $secret);
         }
-        return "t=${timestamp},${scheme}=${signature}";
+        return "t={$timestamp},{$scheme}={$signature}";
     }
 
     public function testValidJsonAndHeader()

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -17,7 +17,7 @@ class WebhookTest extends TestCase
         $secret = \array_key_exists('secret', $opts) ? $opts['secret'] : self::SECRET;
         $scheme = \array_key_exists('scheme', $opts) ? $opts['scheme'] : WebhookSignature::EXPECTED_SCHEME;
         $signature = \array_key_exists('signature', $opts) ? $opts['signature'] : null;
-        if ($signature === null) {
+        if (null === $signature) {
             $signedPayload = "{$timestamp}.{$payload}";
             $signature = \hash_hmac("sha256", $signedPayload, $secret);
         }

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -28,7 +28,7 @@ class WebhookTest extends TestCase
     {
         $sigHeader = $this->generateHeader();
         $event = Webhook::constructEvent(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
-        $this->assertEquals("evt_test_webhook", $event->id);
+        static::assertEquals("evt_test_webhook", $event->id);
     }
 
     public function testInvalidJson()
@@ -96,18 +96,18 @@ class WebhookTest extends TestCase
     public function testValidHeaderAndSignature()
     {
         $sigHeader = $this->generateHeader();
-        $this->assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
+        static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
     }
 
     public function testHeaderContainsValidSignature()
     {
         $sigHeader = $this->generateHeader() . ",v1=bad_signature";
-        $this->assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
+        static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
     }
 
     public function testTimestampOffButNoTolerance()
     {
         $sigHeader = $this->generateHeader(["timestamp" => 12345]);
-        $this->assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET));
+        static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET));
     }
 }

--- a/tests/StripeMock.php
+++ b/tests/StripeMock.php
@@ -32,7 +32,7 @@ class StripeMock
 
         echo "Starting stripe-mock on port " . static::$port . "...\n";
 
-        static::$process = new Process(\join(' ', [
+        static::$process = new Process(\implode(' ', [
             'stripe-mock',
             '-http-port',
             static::$port,

--- a/tests/StripeMock.php
+++ b/tests/StripeMock.php
@@ -2,7 +2,7 @@
 
 namespace Stripe;
 
-use \Symfony\Component\Process\Process;
+use Symfony\Component\Process\Process;
 
 class StripeMock
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -158,14 +158,14 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $absUrl = $base . $path;
 
         return $this->clientMock
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('request')
             ->with(
-                $this->identicalTo(\strtolower($method)),
-                $this->identicalTo($absUrl),
+                static::identicalTo(\strtolower($method)),
+                static::identicalTo($absUrl),
                 // for headers, we only check that all of the headers provided in $headers are
                 // present in the list of headers of the actual request
-                $headers === null ? $this->anything() : $this->callback(function ($array) use ($headers) {
+                $headers === null ? static::anything() : static::callback(function ($array) use ($headers) {
                     foreach ($headers as $header) {
                         if (!\in_array($header, $array)) {
                             return false;
@@ -173,8 +173,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
                     }
                     return true;
                 }),
-                $params === null ? $this->anything() : $this->identicalTo($params),
-                $this->identicalTo($hasFile)
+                $params === null ? static::anything() : static::identicalTo($params),
+                static::identicalTo($hasFile)
             );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -167,7 +167,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 // present in the list of headers of the actual request
                 $headers === null ? static::anything() : static::callback(function ($array) use ($headers) {
                     foreach ($headers as $header) {
-                        if (!\in_array($header, $array)) {
+                        if (!\in_array($header, $array, true)) {
                             return false;
                         }
                     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -152,7 +152,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     ) {
         ApiRequestor::setHttpClient($this->clientMock);
 
-        if ($base === null) {
+        if (null === $base) {
             $base = Stripe::$apiBase;
         }
         $absUrl = $base . $path;
@@ -165,7 +165,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 static::identicalTo($absUrl),
                 // for headers, we only check that all of the headers provided in $headers are
                 // present in the list of headers of the actual request
-                $headers === null ? static::anything() : static::callback(function ($array) use ($headers) {
+                null === $headers ? static::anything() : static::callback(function ($array) use ($headers) {
                     foreach ($headers as $header) {
                         if (!\in_array($header, $array, true)) {
                             return false;
@@ -173,7 +173,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
                     }
                     return true;
                 }),
-                $params === null ? static::anything() : static::identicalTo($params),
+                null === $params ? static::anything() : static::identicalTo($params),
                 static::identicalTo($hasFile)
             );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,13 +82,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $base = null
     ) {
         $this->prepareRequestMock($method, $path, $params, $headers, $hasFile, $base)
-            ->will($this->returnCallback(
+            ->willReturnCallback(
                 function ($method, $absUrl, $headers, $params, $hasFile) {
                     $curlClient = HttpClient\CurlClient::instance();
                     ApiRequestor::setHttpClient($curlClient);
                     return $curlClient->request($method, $absUrl, $headers, $params, $hasFile);
                 }
-            ));
+            );
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,7 +34,7 @@ $version = null;
 $headers = \explode("\n", $resp);
 foreach ($headers as $header) {
     $pair = \explode(":", $header, 2);
-    if ($pair[0] == "Stripe-Mock-Version") {
+    if ($pair[0] === "Stripe-Mock-Version") {
         $version = \trim($pair[1]);
     }
 }
@@ -46,7 +46,7 @@ if ($version === null) {
     exit(1);
 }
 
-if ($version != "master" && \version_compare($version, MOCK_MINIMUM_VERSION) == -1) {
+if ($version !== "master" && \version_compare($version, MOCK_MINIMUM_VERSION) === -1) {
     echo "Your version of stripe-mock (" . $version . ") is too old. The minimum " .
          "version to run this test suite is " . MOCK_MINIMUM_VERSION . ". " .
          "Please see its repository for upgrade instructions.\n";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,19 +34,19 @@ $version = null;
 $headers = \explode("\n", $resp);
 foreach ($headers as $header) {
     $pair = \explode(":", $header, 2);
-    if ($pair[0] === "Stripe-Mock-Version") {
+    if ("Stripe-Mock-Version" === $pair[0]) {
         $version = \trim($pair[1]);
     }
 }
 
-if ($version === null) {
+if (null === $version) {
     echo "Could not retrieve Stripe-Mock-Version header. Are you sure " .
          "that the server at `" . MOCK_HOST . ":" . MOCK_PORT . "` is a stripe-mock " .
          "instance?";
     exit(1);
 }
 
-if ($version !== "master" && \version_compare($version, MOCK_MINIMUM_VERSION) === -1) {
+if ("master" !== $version && -1 === \version_compare($version, MOCK_MINIMUM_VERSION)) {
     echo "Your version of stripe-mock (" . $version . ") is too old. The minimum " .
          "version to run this test suite is " . MOCK_MINIMUM_VERSION . ". " .
          "Please see its repository for upgrade instructions.\n";


### PR DESCRIPTION
r? @richardm-stripe @cjavilla-stripe 
cc @stripe/api-libraries 

This PR enables a lot PHP-CS-Fixer rules. The goal is to get as close as possible to the `@PhpCsFixer` standard ruleset, which enforces fairly opinionated style rules.

There are still a few rules that are not enabled, or are enabled with a custom configuration, because they cause too many changes in codegen'd files and I'd rather we generate compliant code in the first place instead of relying too heavily on PHP-CS-Fixer to reformat everything.

Once all those issues are fixed, we should be able to remove the long list of rules from `.php_cs.dist` and just enable the `@PhpCsFixer` ruleset instead.

I recommend reviewing the PR commit by commit. There are lot of commits, but most of them simply add a rule to `.php_cs.dist` and don't do anything else because we were already compliant with that rule.
