### PR TITLE
Add support for phpDocumentor in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore build files
+build/*
+
 # Mac OS X dumps these all over the place.
 .DS_Store
 
@@ -22,3 +25,7 @@ clover.xml
 
 # Ignore PHPStan local config
 .phpstan.neon
+
+# Ignore phpDocumentor's local config and artifacts
+.phpdoc/*
+phpdoc.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_install:
 
 script:
   - ./build.php ${AUTOLOAD}
-  - ./vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
+  - make fmtcheck
   - if [[ `php -r "echo \version_compare(PHP_VERSION, '7.1', '>=');"` && $AUTOLOAD == 1 ]]; then make phpstan; fi
 
 after_script: ./vendor/bin/php-coveralls -v

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
+export PHPDOCUMENTOR_VERSION := v3.0.0-rc
 export PHPSTAN_VERSION := 0.12.8
 
 vendor: composer.json
 	composer install
+
+vendor/bin/phpstan: vendor
 	curl -sfL https://github.com/phpstan/phpstan/releases/download/$(PHPSTAN_VERSION)/phpstan.phar -o vendor/bin/phpstan
 	chmod +x vendor/bin/phpstan
+
+vendor/bin/phpdoc: vendor
+	curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar -o vendor/bin/phpdoc
+	chmod +x vendor/bin/phpdoc
 
 test: vendor
 	vendor/bin/phpunit
@@ -13,10 +20,17 @@ fmt: vendor
 	vendor/bin/php-cs-fixer fix -v --using-cache=no .
 .PHONY: fmt
 
-phpstan: vendor
+fmtcheck: vendor
+	vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
+.PHONY: fmtcheck
+
+phpdoc: vendor/bin/phpdoc
+	vendor/bin/phpdoc
+
+phpstan: vendor/bin/phpstan
 	vendor/bin/phpstan analyse lib tests
 .PHONY: phpstan
 
-phpstan-baseline: vendor
+phpstan-baseline: vendor/bin/phpstan
 	vendor/bin/phpstan analyse --error-format baselineNeon lib tests > phpstan-baseline.neon
 .PHONY: phpstan-baseline

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="data/xsd/phpdoc.xsd"
+>
+    <paths>
+        <output>build/phpdoc</output>
+    </paths>
+    <version number="3.0.0">
+        <folder>latest</folder>
+        <api>
+            <source dsn=".">
+                <path>lib</path>
+            </source>
+            <output>api</output>
+            <ignore hidden="true" symlinks="true">
+                <path>build/**/*</path>
+                <path>examples/**/*</path>
+                <path>tests/**/*</path>
+                <path>vendor/**/*</path>
+            </ignore>
+            <extensions>
+                <extension>php</extension>
+            </extensions>
+            <default-package-name>stripe-php</default-package-name>
+        </api>
+    </version>
+    <template name="default"/>
+</phpdocumentor>


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 
cc @stripe/api-libraries 

Add support for generating a static doc site using [phpDocumentor](https://github.com/phpDocumentor/phpDocumentor) in our Makefile.

The intent is to eventually public the site with every release, like we now do for stripe-java. I don't think the state of the documentation is quite good enough for that though, but this lets us generate the site locally:

```sh
$ make phpdoc
$ open build/phpdoc/index.html
```
