### PR TITLE
Enable php_unit_internal_class rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,7 +15,6 @@ return PhpCsFixer\Config::create()
             'spacing' => 'one',
         ],
         'ordered_class_elements' => false,
-        'php_unit_internal_class' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_align' => false,
         'protected_to_private' => false,

--- a/tests/Stripe/AccountLinkTest.php
+++ b/tests/Stripe/AccountLinkTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class AccountLinkTest extends TestCase
+/**
+ * @internal
+ */
+final class AccountLinkTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testIsCreatable()
     {
         $this->expectsRequest(

--- a/tests/Stripe/AccountTest.php
+++ b/tests/Stripe/AccountTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class AccountTest extends TestCase
+/**
+ * @internal
+ */
+final class AccountTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'acct_123';
     const TEST_CAPABILITY_ID = 'acap_123';
     const TEST_EXTERNALACCOUNT_ID = 'ba_123';

--- a/tests/Stripe/AlipayAccountTest.php
+++ b/tests/Stripe/AlipayAccountTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class AlipayAccountTest extends TestCase
+/**
+ * @internal
+ */
+final class AlipayAccountTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'aliacc_123';
 
     // Because of the wildcard nature of sources, stripe-mock cannot currently

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -4,8 +4,13 @@ namespace Stripe;
 
 use Stripe\HttpClient\CurlClient;
 
-class ApiRequestorTest extends TestCase
+/**
+ * @internal
+ */
+final class ApiRequestorTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testEncodeObjects()
     {
         $reflector = new \ReflectionClass(\Stripe\ApiRequestor::class);

--- a/tests/Stripe/ApplePayDomainTest.php
+++ b/tests/Stripe/ApplePayDomainTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ApplePayDomainTest extends TestCase
+/**
+ * @internal
+ */
+final class ApplePayDomainTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'apwc_123';
 
     public function testIsListable()

--- a/tests/Stripe/ApplicationFeeRefundTest.php
+++ b/tests/Stripe/ApplicationFeeRefundTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ApplicationFeeRefundTest extends TestCase
+/**
+ * @internal
+ */
+final class ApplicationFeeRefundTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'fr_123';
     const TEST_FEE_ID = 'fee_123';
 

--- a/tests/Stripe/ApplicationFeeTest.php
+++ b/tests/Stripe/ApplicationFeeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ApplicationFeeTest extends TestCase
+/**
+ * @internal
+ */
+final class ApplicationFeeTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'fee_123';
     const TEST_FEEREFUND_ID = 'fr_123';
 

--- a/tests/Stripe/BalanceTest.php
+++ b/tests/Stripe/BalanceTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class BalanceTest extends TestCase
+/**
+ * @internal
+ */
+final class BalanceTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testIsRetrievable()
     {
         $this->expectsRequest(

--- a/tests/Stripe/BalanceTransactionTest.php
+++ b/tests/Stripe/BalanceTransactionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class BalanceTransactionTest extends TestCase
+/**
+ * @internal
+ */
+final class BalanceTransactionTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'txn_123';
 
     public function testIsListable()

--- a/tests/Stripe/BankAccountTest.php
+++ b/tests/Stripe/BankAccountTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class BankAccountTest extends TestCase
+/**
+ * @internal
+ */
+final class BankAccountTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'ba_123';
 
     // Because of the wildcard nature of sources, stripe-mock cannot currently

--- a/tests/Stripe/BitcoinReceiverTest.php
+++ b/tests/Stripe/BitcoinReceiverTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class BitcoinReceiverTest extends TestCase
+/**
+ * @internal
+ */
+final class BitcoinReceiverTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'btcrcv_123';
 
     // Because of the wildcard nature of sources, stripe-mock cannot currently

--- a/tests/Stripe/CapabilityTest.php
+++ b/tests/Stripe/CapabilityTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CapabilityTest extends TestCase
+/**
+ * @internal
+ */
+final class CapabilityTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_ACCOUNT_ID = 'acct_123';
     const TEST_RESOURCE_ID = 'acap_123';
 

--- a/tests/Stripe/CardTest.php
+++ b/tests/Stripe/CardTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CardTest extends TestCase
+/**
+ * @internal
+ */
+final class CardTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'card_123';
 
     // Because of the wildcard nature of sources, stripe-mock cannot currently

--- a/tests/Stripe/ChargeTest.php
+++ b/tests/Stripe/ChargeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ChargeTest extends TestCase
+/**
+ * @internal
+ */
+final class ChargeTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'ch_123';
 
     public function testIsListable()

--- a/tests/Stripe/Checkout/SessionTest.php
+++ b/tests/Stripe/Checkout/SessionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Checkout;
 
-class SessionTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class SessionTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'cs_123';
 
     public function testIsCreatable()

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CollectionTest extends TestCase
+/**
+ * @internal
+ */
+final class CollectionTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     /** @var \Stripe\Collection */
     private $fixture;
 

--- a/tests/Stripe/CountrySpecTest.php
+++ b/tests/Stripe/CountrySpecTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CountrySpecTest extends TestCase
+/**
+ * @internal
+ */
+final class CountrySpecTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'US';
 
     public function testIsListable()

--- a/tests/Stripe/CouponTest.php
+++ b/tests/Stripe/CouponTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CouponTest extends TestCase
+/**
+ * @internal
+ */
+final class CouponTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = '25OFF';
 
     public function testIsListable()

--- a/tests/Stripe/CreditNoteTest.php
+++ b/tests/Stripe/CreditNoteTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CreditNoteTest extends TestCase
+/**
+ * @internal
+ */
+final class CreditNoteTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'cn_123';
 
     public function testIsListable()

--- a/tests/Stripe/CustomerBalanceTransactionTest.php
+++ b/tests/Stripe/CustomerBalanceTransactionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CustomerBalanceTransactionTest extends TestCase
+/**
+ * @internal
+ */
+final class CustomerBalanceTransactionTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_CUSTOMER_ID = 'cus_123';
     const TEST_RESOURCE_ID = 'cbtxn_123';
 

--- a/tests/Stripe/CustomerTest.php
+++ b/tests/Stripe/CustomerTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class CustomerTest extends TestCase
+/**
+ * @internal
+ */
+final class CustomerTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'cus_123';
     const TEST_SOURCE_ID = 'ba_123';
     const TEST_TAX_ID_ID = 'txi_123';

--- a/tests/Stripe/DisputeTest.php
+++ b/tests/Stripe/DisputeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class DisputeTest extends TestCase
+/**
+ * @internal
+ */
+final class DisputeTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'dp_123';
 
     public function testIsListable()

--- a/tests/Stripe/EphemeralKeyTest.php
+++ b/tests/Stripe/EphemeralKeyTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class EphemeralKeyTest extends TestCase
+/**
+ * @internal
+ */
+final class EphemeralKeyTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testIsCreatable()
     {
         $this->expectsRequest(

--- a/tests/Stripe/ErrorObjectTest.php
+++ b/tests/Stripe/ErrorObjectTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ErrorObjectTest extends TestCase
+/**
+ * @internal
+ */
+final class ErrorObjectTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testDefaultValues()
     {
         $error = ErrorObject::constructFrom([]);

--- a/tests/Stripe/EventTest.php
+++ b/tests/Stripe/EventTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class EventTest extends TestCase
+/**
+ * @internal
+ */
+final class EventTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'evt_123';
 
     public function testIsListable()

--- a/tests/Stripe/Exception/ApiErrorExceptionTest.php
+++ b/tests/Stripe/Exception/ApiErrorExceptionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Exception;
 
-class ApiErrorExceptionTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ApiErrorExceptionTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function createFixture()
     {
         $mock = $this->getMockForAbstractClass(ApiErrorException::class);

--- a/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
+++ b/tests/Stripe/Exception/OAuth/OAuthErrorExceptionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Exception\OAuth;
 
-class OAuthErrorExceptionTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class OAuthErrorExceptionTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function createFixture()
     {
         $mock = $this->getMockForAbstractClass(OAuthErrorException::class);

--- a/tests/Stripe/Exception/SignatureVerificationExceptionTest.php
+++ b/tests/Stripe/Exception/SignatureVerificationExceptionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Exception;
 
-class SignatureVerificationExceptionTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class SignatureVerificationExceptionTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testGetters()
     {
         $e = SignatureVerificationException::factory('message', 'payload', 'sig_header');

--- a/tests/Stripe/ExchangeRateTest.php
+++ b/tests/Stripe/ExchangeRateTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ExchangeRateTest extends TestCase
+/**
+ * @internal
+ */
+final class ExchangeRateTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testIsListable()
     {
         $this->stubRequest(

--- a/tests/Stripe/FileCreationTest.php
+++ b/tests/Stripe/FileCreationTest.php
@@ -6,24 +6,30 @@ namespace Stripe;
  * These tests should really be part of `FileTest`, but because the file creation requests use a
  * different host, the tests for these methods need their own setup and teardown methods.
  */
-class FileCreationTest extends TestCase
+/**
+ * @internal
+ */
+final class FileCreationTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @before
-     */
+    use TestHelper;
+
+    private $origApiUploadBase;
+
+    /** @before */
     public function setUpUploadBase()
     {
-        Stripe::$apiUploadBase = Stripe::$apiBase;
+        $this->origApiBase = Stripe::$apiBase;
+        $this->origApiUploadBase = Stripe::$apiUploadBase;
+
+        Stripe::$apiUploadBase = \defined('MOCK_URL') ? MOCK_URL : 'http://localhost:12111';
         Stripe::$apiBase = null;
     }
 
-    /**
-     * @after
-     */
+    /** @after */
     public function tearDownUploadBase()
     {
-        Stripe::$apiBase = Stripe::$apiUploadBase;
-        Stripe::$apiUploadBase = 'https://files.stripe.com';
+        Stripe::$apiBase = $this->origApiBase;
+        Stripe::$apiUploadBase = $this->origApiUploadBase;
     }
 
     public function testIsCreatableWithFileHandle()

--- a/tests/Stripe/FileLinkTest.php
+++ b/tests/Stripe/FileLinkTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class FileLinkTest extends TestCase
+/**
+ * @internal
+ */
+final class FileLinkTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'link_123';
 
     public function testIsListable()

--- a/tests/Stripe/FileTest.php
+++ b/tests/Stripe/FileTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class FileTest extends TestCase
+/**
+ * @internal
+ */
+final class FileTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'file_123';
 
     public function testIsListable()

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\HttpClient;
 
-class CurlClientTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class CurlClientTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     /** @var \ReflectionProperty */
     private $initialNetworkRetryDelayProperty;
 

--- a/tests/Stripe/InvoiceItemTest.php
+++ b/tests/Stripe/InvoiceItemTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class InvoiceItemTest extends TestCase
+/**
+ * @internal
+ */
+final class InvoiceItemTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'ii_123';
 
     public function testIsListable()

--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class InvoiceTest extends TestCase
+/**
+ * @internal
+ */
+final class InvoiceTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'in_123';
     const TEST_LINE_ID = 'ii_123';
 

--- a/tests/Stripe/Issuing/AuthorizationTest.php
+++ b/tests/Stripe/Issuing/AuthorizationTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Issuing;
 
-class AuthorizationTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class AuthorizationTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'iauth_123';
 
     public function testIsListable()

--- a/tests/Stripe/Issuing/CardTest.php
+++ b/tests/Stripe/Issuing/CardTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Issuing;
 
-class CardTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class CardTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'ic_123';
 
     public function testIsListable()

--- a/tests/Stripe/Issuing/CardholderTest.php
+++ b/tests/Stripe/Issuing/CardholderTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Issuing;
 
-class CardholderTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class CardholderTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'ich_123';
 
     public function testIsCreatable()

--- a/tests/Stripe/Issuing/DisputeTest.php
+++ b/tests/Stripe/Issuing/DisputeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Issuing;
 
-class DisputeTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class DisputeTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'idp_123';
 
     public function testIsCreatable()

--- a/tests/Stripe/Issuing/TransactionTest.php
+++ b/tests/Stripe/Issuing/TransactionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Issuing;
 
-class TransactionTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class TransactionTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'ipi_123';
 
     public function testIsListable()

--- a/tests/Stripe/MandateTest.php
+++ b/tests/Stripe/MandateTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class MandateTest extends TestCase
+/**
+ * @internal
+ */
+final class MandateTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'mandate_123';
 
     public function testIsRetrievable()

--- a/tests/Stripe/OAuthErrorObjectTest.php
+++ b/tests/Stripe/OAuthErrorObjectTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class OAuthErrorObjectTest extends TestCase
+/**
+ * @internal
+ */
+final class OAuthErrorObjectTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testDefaultValues()
     {
         $error = OAuthErrorObject::constructFrom([]);

--- a/tests/Stripe/OAuthTest.php
+++ b/tests/Stripe/OAuthTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class OAuthTest extends TestCase
+/**
+ * @internal
+ */
+final class OAuthTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     public function testAuthorizeUrl()
     {
         $uriStr = OAuth::authorizeUrl([

--- a/tests/Stripe/OrderReturnTest.php
+++ b/tests/Stripe/OrderReturnTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class OrderReturnTest extends TestCase
+/**
+ * @internal
+ */
+final class OrderReturnTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'orret_123';
 
     public function testIsListable()

--- a/tests/Stripe/OrderTest.php
+++ b/tests/Stripe/OrderTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class OrderTest extends TestCase
+/**
+ * @internal
+ */
+final class OrderTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'or_123';
 
     public function testIsListable()

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class PaymentIntentTest extends TestCase
+/**
+ * @internal
+ */
+final class PaymentIntentTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'pi_123';
 
     public function testIsListable()

--- a/tests/Stripe/PaymentMethodTest.php
+++ b/tests/Stripe/PaymentMethodTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class PaymentMethodTest extends TestCase
+/**
+ * @internal
+ */
+final class PaymentMethodTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'pm_123';
 
     public function testIsListable()

--- a/tests/Stripe/PayoutTest.php
+++ b/tests/Stripe/PayoutTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class PayoutTest extends TestCase
+/**
+ * @internal
+ */
+final class PayoutTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'po_123';
 
     public function testIsListable()

--- a/tests/Stripe/PersonTest.php
+++ b/tests/Stripe/PersonTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class PersonTest extends TestCase
+/**
+ * @internal
+ */
+final class PersonTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_ACCOUNT_ID = 'acct_123';
     const TEST_RESOURCE_ID = 'person_123';
 

--- a/tests/Stripe/PlanTest.php
+++ b/tests/Stripe/PlanTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class PlanTest extends TestCase
+/**
+ * @internal
+ */
+final class PlanTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'plan';
 
     public function testIsListable()

--- a/tests/Stripe/ProductTest.php
+++ b/tests/Stripe/ProductTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ProductTest extends TestCase
+/**
+ * @internal
+ */
+final class ProductTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'prod_123';
 
     public function testIsListable()

--- a/tests/Stripe/Radar/EarlyFraudWarningTest.php
+++ b/tests/Stripe/Radar/EarlyFraudWarningTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Radar;
 
-class EarlyFraudWarningTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class EarlyFraudWarningTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'issfr_123';
 
     public function testIsListable()

--- a/tests/Stripe/Radar/ValueListItemTest.php
+++ b/tests/Stripe/Radar/ValueListItemTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Radar;
 
-class ValueListItemTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ValueListItemTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'rsli_123';
 
     public function testIsListable()

--- a/tests/Stripe/Radar/ValueListTest.php
+++ b/tests/Stripe/Radar/ValueListTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Radar;
 
-class ValueListTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ValueListTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'rsl_123';
 
     public function testIsListable()

--- a/tests/Stripe/RecipientTest.php
+++ b/tests/Stripe/RecipientTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class RecipientTest extends TestCase
+/**
+ * @internal
+ */
+final class RecipientTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'rp_123';
 
     public function testIsListable()

--- a/tests/Stripe/RefundTest.php
+++ b/tests/Stripe/RefundTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class RefundTest extends TestCase
+/**
+ * @internal
+ */
+final class RefundTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 're_123';
 
     public function testIsListable()

--- a/tests/Stripe/Reporting/ReportRunTest.php
+++ b/tests/Stripe/Reporting/ReportRunTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Reporting;
 
-class ReportRunTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ReportRunTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'frr_123';
 
     public function testIsCreatable()

--- a/tests/Stripe/Reporting/ReportTypeTest.php
+++ b/tests/Stripe/Reporting/ReportTypeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Reporting;
 
-class ReportTypeTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ReportTypeTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'activity.summary.1';
 
     public function testIsListable()

--- a/tests/Stripe/ReviewTest.php
+++ b/tests/Stripe/ReviewTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ReviewTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ReviewTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'prv_123';
 
     public function testIsApprovable()

--- a/tests/Stripe/SKUTest.php
+++ b/tests/Stripe/SKUTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SKUTest extends TestCase
+/**
+ * @internal
+ */
+final class SKUTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'sku_123';
 
     public function testIsListable()

--- a/tests/Stripe/SetupIntentTest.php
+++ b/tests/Stripe/SetupIntentTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SetupIntentTest extends TestCase
+/**
+ * @internal
+ */
+final class SetupIntentTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'seti_123';
 
     public function testIsListable()

--- a/tests/Stripe/Sigma/ScheduledQueryRunTest.php
+++ b/tests/Stripe/Sigma/ScheduledQueryRunTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Sigma;
 
-class ScheduledQueryRunTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ScheduledQueryRunTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'sqr_123';
 
     public function testIsListable()

--- a/tests/Stripe/SourceTest.php
+++ b/tests/Stripe/SourceTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SourceTest extends TestCase
+/**
+ * @internal
+ */
+final class SourceTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'src_123';
 
     public function testIsRetrievable()

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class StripeObjectTest extends TestCase
+/**
+ * @internal
+ */
+final class StripeObjectTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     /** @var \ReflectionMethod */
     private $deepCopyReflector;
 

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class StripeTelemetryTest extends TestCase
+/**
+ * @internal
+ */
+final class StripeTelemetryTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'acct_123';
     const TEST_EXTERNALACCOUNT_ID = 'ba_123';
     const TEST_PERSON_ID = 'person_123';
@@ -17,8 +22,6 @@ class StripeTelemetryTest extends TestCase
 
     protected function setUp()
     {
-        parent::setUp();
-
         // clear static telemetry data
         ApiRequestor::resetTelemetry();
     }

--- a/tests/Stripe/StripeTest.php
+++ b/tests/Stripe/StripeTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class StripeTest extends TestCase
+/**
+ * @internal
+ */
+final class StripeTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     /** @var array */
     protected $orig;
 

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SubscriptionItemTest extends TestCase
+/**
+ * @internal
+ */
+final class SubscriptionItemTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'si_123';
 
     public function testIsListable()

--- a/tests/Stripe/SubscriptionScheduleTest.php
+++ b/tests/Stripe/SubscriptionScheduleTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SubscriptionScheduleTest extends TestCase
+/**
+ * @internal
+ */
+final class SubscriptionScheduleTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'sub_sched_123';
     const TEST_REVISION_ID = 'sub_sched_rev_123';
 

--- a/tests/Stripe/SubscriptionTest.php
+++ b/tests/Stripe/SubscriptionTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class SubscriptionTest extends TestCase
+/**
+ * @internal
+ */
+final class SubscriptionTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'sub_123';
 
     public function testIsListable()

--- a/tests/Stripe/TaxIdTest.php
+++ b/tests/Stripe/TaxIdTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TaxIdTest extends TestCase
+/**
+ * @internal
+ */
+final class TaxIdTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_CUSTOMER_ID = 'cus_123';
     const TEST_RESOURCE_ID = 'txi_123';
 

--- a/tests/Stripe/TaxRateTest.php
+++ b/tests/Stripe/TaxRateTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TaxRateTest extends TestCase
+/**
+ * @internal
+ */
+final class TaxRateTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'txr_123';
 
     public function testIsListable()

--- a/tests/Stripe/Terminal/ConnectionTokenTest.php
+++ b/tests/Stripe/Terminal/ConnectionTokenTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Terminal;
 
-class ConnectionTokenTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ConnectionTokenTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testIsCreatable()
     {
         $this->expectsRequest(

--- a/tests/Stripe/Terminal/LocationTest.php
+++ b/tests/Stripe/Terminal/LocationTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Terminal;
 
-class LocationTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class LocationTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'loc_123';
 
     public function testIsListable()

--- a/tests/Stripe/Terminal/ReaderTest.php
+++ b/tests/Stripe/Terminal/ReaderTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Terminal;
 
-class ReaderTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class ReaderTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     const TEST_RESOURCE_ID = 'rdr_123';
 
     public function testIsListable()

--- a/tests/Stripe/ThreeDSecureTest.php
+++ b/tests/Stripe/ThreeDSecureTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class ThreeDSecureTest extends TestCase
+/**
+ * @internal
+ */
+final class ThreeDSecureTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'tdsrc_123';
 
     public function testIsRetrievable()

--- a/tests/Stripe/TokenTest.php
+++ b/tests/Stripe/TokenTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TokenTest extends TestCase
+/**
+ * @internal
+ */
+final class TokenTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'tok_123';
 
     public function testIsRetrievable()

--- a/tests/Stripe/TopupTest.php
+++ b/tests/Stripe/TopupTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TopupTest extends TestCase
+/**
+ * @internal
+ */
+final class TopupTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'tu_123';
 
     public function testIsListable()

--- a/tests/Stripe/TransferReversalTest.php
+++ b/tests/Stripe/TransferReversalTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TransferReversalTest extends TestCase
+/**
+ * @internal
+ */
+final class TransferReversalTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'trr_123';
     const TEST_TRANSFER_ID = 'tr_123';
 

--- a/tests/Stripe/TransferTest.php
+++ b/tests/Stripe/TransferTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class TransferTest extends TestCase
+/**
+ * @internal
+ */
+final class TransferTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'tr_123';
     const TEST_REVERSAL_ID = 'trr_123';
 

--- a/tests/Stripe/Util/CaseInsensitiveArrayTest.php
+++ b/tests/Stripe/Util/CaseInsensitiveArrayTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Util;
 
-class CaseInsensitiveArrayTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class CaseInsensitiveArrayTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testArrayAccess()
     {
         $arr = new CaseInsensitiveArray(['One' => '1', 'TWO' => '2']);

--- a/tests/Stripe/Util/DefaultLoggerTest.php
+++ b/tests/Stripe/Util/DefaultLoggerTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Util;
 
-class DefaultLoggerTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class DefaultLoggerTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testDefaultLogger()
     {
         // DefaultLogger uses PHP's `error_log` function. In order to capture

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Util;
 
-class RequestOptionsTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class RequestOptionsTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testStringAPIKey()
     {
         $opts = RequestOptions::parse('foo');

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe\Util;
 
-class UtilTest extends \Stripe\TestCase
+/**
+ * @internal
+ */
+final class UtilTest extends \PHPUnit\Framework\TestCase
 {
+    use \Stripe\TestHelper;
+
     public function testIsList()
     {
         $list = [5, 'nstaoush', []];

--- a/tests/Stripe/WebhookEndpointTest.php
+++ b/tests/Stripe/WebhookEndpointTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class WebhookEndpointTest extends TestCase
+/**
+ * @internal
+ */
+final class WebhookEndpointTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const TEST_RESOURCE_ID = 'we_123';
 
     public function testIsListable()

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -2,8 +2,13 @@
 
 namespace Stripe;
 
-class WebhookTest extends TestCase
+/**
+ * @internal
+ */
+final class WebhookTest extends \PHPUnit\Framework\TestCase
 {
+    use TestHelper;
+
     const EVENT_PAYLOAD = '{
   "id": "evt_test_webhook",
   "object": "event"

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -3,9 +3,9 @@
 namespace Stripe;
 
 /**
- * Base class for Stripe test cases.
+ * Helper trait for Stripe test cases.
  */
-class TestCase extends \PHPUnit\Framework\TestCase
+trait TestHelper
 {
     /** @var string original API base URL */
     protected $origApiBase;
@@ -25,7 +25,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /** @var object HTTP client mocker */
     protected $clientMock;
 
-    protected function setUp()
+    /** @before */
+    protected function setUpConfig()
     {
         // Save original values so that we can restore them after running tests
         $this->origApiBase = Stripe::$apiBase;
@@ -48,7 +49,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
         ApiRequestor::setHttpClient(HttpClient\CurlClient::instance());
     }
 
-    protected function tearDown()
+    /** @after */
+    protected function tearDownConfig()
     {
         // Restore original values
         Stripe::$apiBase = $this->origApiBase;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,4 +53,4 @@ if ('master' !== $version && -1 === \version_compare($version, MOCK_MINIMUM_VERS
     exit(1);
 }
 
-require_once __DIR__ . '/TestCase.php';
+require_once __DIR__ . '/TestHelper.php';


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 

One more rule down. This enables the `php_unit_internal_class` rule, which requires that all test classes be final.

This didn't work initially because we had a base `\Stripe\TestCase` class that was also made final by the formatter and thus could no longer be extended by actual test classes.

I refactored it to be a trait instead of a base class (and renamed it to `\Stripe\TestHelper`), which is arguably better design (traits are better suited for code reuse than inheritance).