### PR TITLE
Last set of PHP-CS-Fixer updates

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,7 +17,6 @@ return PhpCsFixer\Config::create()
         'ordered_class_elements' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_align' => false,
-        'protected_to_private' => false,
         'self_accessor' => false,
 
         // Additional rules

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,18 +10,33 @@ return PhpCsFixer\Config::create()
         '@PHP56Migration:risky' => true,
         '@PHPUnit57Migration:risky' => true,
 
-        // Diffs from @PhpCsFixer / @PhpCsFixer:risky
-        'concat_space' => [
-            'spacing' => 'one',
-        ],
-        'ordered_class_elements' => false,
-        'php_unit_test_class_requires_covers' => false,
-        'phpdoc_align' => false,
-        'self_accessor' => false,
-
         // Additional rules
         'fopen_flags' => true,
         'linebreak_after_opening_tag' => true,
         'native_function_invocation' => true,
+
+        // --- Diffs from @PhpCsFixer / @PhpCsFixer:risky ---
+
+        // This is just prettier / easier to read.
+        'concat_space' => ['spacing' => 'one'],
+
+        // This causes strange ordering with codegen'd classes. We might be
+        // able to enable this if we update codegen to output class elements
+        // in the correct order.
+        'ordered_class_elements' => false,
+
+        // This can be enabled once we update every test class and method with
+        // the correct `@covers` annotations.
+        'php_unit_test_class_requires_covers' => false,
+
+        // Keep this disabled to avoid unnecessary diffs in PHPDoc comments of
+        // codegen'd classes.
+        'phpdoc_align' => false,
+
+        // This is a "risky" rule that causes a bug in our codebase.
+        // Specifically, in `StripeObject.updateAttributes` we construct new
+        // `StripeObject`s for metadata. We can't use `self` there because it
+        // needs to be a raw `StripeObject`.
+        'self_accessor' => false,
     ])
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,10 +22,10 @@ return PhpCsFixer\Config::create()
 
         // Should be included in @PhpCsFixer / @PhpCsFixer:risky according to doc, but need to be
         // enabled manually for some reason.
-        'fopen_flags' => true,
         'multiline_whitespace_before_semicolons' => true,
-        'native_function_invocation' => true,
 
         // Additional rules
+        'fopen_flags' => true,
         'linebreak_after_opening_tag' => true,
+        'native_function_invocation' => true,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -20,12 +20,9 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'self_accessor' => false,
 
-        // Should be included in @PhpCsFixer / @PhpCsFixer:risky according to doc, but need to be
-        // enabled manually for some reason.
-        'multiline_whitespace_before_semicolons' => true,
-
         // Additional rules
         'fopen_flags' => true,
         'linebreak_after_opening_tag' => true,
         'native_function_invocation' => true,
-    ]);
+    ])
+;

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -33,7 +33,8 @@ final class StripeTelemetryTest extends \PHPUnit\Framework\TestCase
         $stub = $this
             ->getMockBuilder('HttpClient\\ClientInterface')
             ->setMethods(['request'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $stub->expects(static::any())
             ->method('request')
@@ -75,7 +76,8 @@ final class StripeTelemetryTest extends \PHPUnit\Framework\TestCase
         $stub = $this
             ->getMockBuilder('HttpClient\\ClientInterface')
             ->setMethods(['request'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $stub->expects(static::any())
             ->method('request')

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -91,7 +91,8 @@ trait TestHelper
 
                     return $curlClient->request($method, $absUrl, $headers, $params, $hasFile);
                 }
-            );
+            )
+        ;
     }
 
     /**
@@ -124,7 +125,8 @@ trait TestHelper
         $base = null
     ) {
         $this->prepareRequestMock($method, $path, $params, $headers, $hasFile, $base)
-            ->willReturn([\json_encode($response), $rcode, []]);
+            ->willReturn([\json_encode($response), $rcode, []])
+        ;
     }
 
     /**
@@ -179,6 +181,7 @@ trait TestHelper
                 }),
                 null === $params ? static::anything() : static::identicalTo($params),
                 static::identicalTo($hasFile)
-            );
+            )
+        ;
     }
 }


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 

Okay, this should be the last PR for PHP-CS-Fixer rules for a while. Thanks for bearing with me!

This PR enables a few more rules, and updates `.php_cs.dist` to document why we differ from the `@PhpCsFixer` ruleset.
