### PR TITLE
Use codegen for enum constants

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -36,45 +36,27 @@ class Account extends ApiResource
     use ApiOperations\NestedResource;
     use ApiOperations\Update;
 
-    use ApiOperations\Retrieve {
-        retrieve as protected _retrieve;
-    }
-
-    /**
-     * Possible string representations of an account's business type.
-     *
-     * @see https://stripe.com/docs/api/accounts/object#account_object-business_type
-     */
     const BUSINESS_TYPE_COMPANY = 'company';
+    const BUSINESS_TYPE_GOVERNMENT_ENTITY = 'government_entity';
     const BUSINESS_TYPE_INDIVIDUAL = 'individual';
+    const BUSINESS_TYPE_NON_PROFIT = 'non_profit';
 
-    /**
-     * Possible string representations of an account's capabilities.
-     *
-     * @see https://stripe.com/docs/api/accounts/object#account_object-capabilities
-     */
     const CAPABILITY_CARD_PAYMENTS = 'card_payments';
     const CAPABILITY_LEGACY_PAYMENTS = 'legacy_payments';
     const CAPABILITY_PLATFORM_PAYMENTS = 'platform_payments';
     const CAPABILITY_TRANSFERS = 'transfers';
 
-    /**
-     * Possible string representations of an account's capability status.
-     *
-     * @see https://stripe.com/docs/api/accounts/object#account_object-capabilities
-     */
     const CAPABILITY_STATUS_ACTIVE = 'active';
     const CAPABILITY_STATUS_INACTIVE = 'inactive';
     const CAPABILITY_STATUS_PENDING = 'pending';
 
-    /**
-     * Possible string representations of an account's type.
-     *
-     * @see https://stripe.com/docs/api/accounts/object#account_object-type
-     */
     const TYPE_CUSTOM = 'custom';
     const TYPE_EXPRESS = 'express';
     const TYPE_STANDARD = 'standard';
+
+    use ApiOperations\Retrieve {
+        retrieve as protected _retrieve;
+    }
 
     public static function getSavedNestedResources()
     {

--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -28,11 +28,6 @@ class BalanceTransaction extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Retrieve;
 
-    /**
-     * Possible string representations of the type of balance transaction.
-     *
-     * @see https://stripe.com/docs/api/balance/balance_transaction#balance_transaction_object-type
-     */
     const TYPE_ADJUSTMENT = 'adjustment';
     const TYPE_ADVANCE = 'advance';
     const TYPE_ADVANCE_FUNDING = 'advance_funding';

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -60,6 +60,10 @@ class Charge extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
+    const STATUS_FAILED = 'failed';
+    const STATUS_PENDING = 'pending';
+    const STATUS_SUCCEEDED = 'succeeded';
+
     /**
      * Possible string representations of decline codes.
      * These strings are applicable to the decline_code property of the \Stripe\Exception\CardException exception.
@@ -112,15 +116,6 @@ class Charge extends ApiResource
     const DECLINED_TRANSACTION_NOT_ALLOWED = 'transaction_not_allowed';
     const DECLINED_TRY_AGAIN_LATER = 'try_again_later';
     const DECLINED_WITHDRAWAL_COUNT_LIMIT_EXCEEDED = 'withdrawal_count_limit_exceeded';
-
-    /**
-     * Possible string representations of the status of the charge.
-     *
-     * @see https://stripe.com/docs/api/charges/object#charge_object-status
-     */
-    const STATUS_FAILED = 'failed';
-    const STATUS_PENDING = 'pending';
-    const STATUS_SUCCEEDED = 'succeeded';
 
     /**
      * @param null|array $params

--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -31,11 +31,6 @@ class Session extends \Stripe\ApiResource
     use \Stripe\ApiOperations\Create;
     use \Stripe\ApiOperations\Retrieve;
 
-    /**
-     * Possible string representations of submit type.
-     *
-     * @see https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-submit_type
-     */
     const SUBMIT_TYPE_AUTO = 'auto';
     const SUBMIT_TYPE_BOOK = 'book';
     const SUBMIT_TYPE_DONATE = 'donate';

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -40,29 +40,14 @@ class CreditNote extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the credit note reason.
-     *
-     * @see https://stripe.com/docs/api/credit_notes/object#credit_note_object-reason
-     */
     const REASON_DUPLICATE = 'duplicate';
     const REASON_FRAUDULENT = 'fraudulent';
     const REASON_ORDER_CHANGE = 'order_change';
     const REASON_PRODUCT_UNSATISFACTORY = 'product_unsatisfactory';
 
-    /**
-     * Possible string representations of the credit note status.
-     *
-     * @see https://stripe.com/docs/api/credit_notes/object#credit_note_object-status
-     */
     const STATUS_ISSUED = 'issued';
     const STATUS_VOID = 'void';
 
-    /**
-     * Possible string representations of the credit note type.
-     *
-     * @see https://stripe.com/docs/api/credit_notes/object#credit_note_object-status
-     */
     const TYPE_POST_PAYMENT = 'post_payment';
     const TYPE_PRE_PAYMENT = 'pre_payment';
 

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -40,13 +40,8 @@ class Customer extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the customer's type of tax exemption.
-     *
-     * @see https://stripe.com/docs/api/customers/object#customer_object-tax_exempt
-     */
-    const TAX_EXEMPT_NONE = 'none';
     const TAX_EXEMPT_EXEMPT = 'exempt';
+    const TAX_EXEMPT_NONE = 'none';
     const TAX_EXEMPT_REVERSE = 'reverse';
 
     public static function getSavedNestedResources()

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -30,11 +30,6 @@ class Dispute extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of dispute reasons.
-     *
-     * @see https://stripe.com/docs/api#dispute_object
-     */
     const REASON_BANK_CANNOT_PROCESS = 'bank_cannot_process';
     const REASON_CHECK_RETURNED = 'check_returned';
     const REASON_CREDIT_NOT_PROCESSED = 'credit_not_processed';
@@ -50,11 +45,6 @@ class Dispute extends ApiResource
     const REASON_SUBSCRIPTION_CANCELED = 'subscription_canceled';
     const REASON_UNRECOGNIZED = 'unrecognized';
 
-    /**
-     * Possible string representations of dispute statuses.
-     *
-     * @see https://stripe.com/docs/api#dispute_object
-     */
     const STATUS_CHARGE_REFUNDED = 'charge_refunded';
     const STATUS_LOST = 'lost';
     const STATUS_NEEDS_RESPONSE = 'needs_response';

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -79,7 +79,6 @@ class Invoice extends ApiResource
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const BILLING_SEND_INVOICE = 'send_invoice';
 
-    const BILLING_REASON_AUTOMATIC_PENDING_INVOICE_ITEM_INVOICE = 'automatic_pending_invoice_item_invoice';
     const BILLING_REASON_MANUAL = 'manual';
     const BILLING_REASON_SUBSCRIPTION = 'subscription';
     const BILLING_REASON_SUBSCRIPTION_CREATE = 'subscription_create';

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -76,13 +76,10 @@ class Invoice extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    use ApiOperations\NestedResource;
+    const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
+    const BILLING_SEND_INVOICE = 'send_invoice';
 
-    /**
-     * Possible string representations of the billing reason.
-     *
-     * @see https://stripe.com/docs/api/invoices/object#invoice_object-billing_reason
-     */
+    const BILLING_REASON_AUTOMATIC_PENDING_INVOICE_ITEM_INVOICE = 'automatic_pending_invoice_item_invoice';
     const BILLING_REASON_MANUAL = 'manual';
     const BILLING_REASON_SUBSCRIPTION = 'subscription';
     const BILLING_REASON_SUBSCRIPTION_CREATE = 'subscription_create';
@@ -91,33 +88,17 @@ class Invoice extends ApiResource
     const BILLING_REASON_SUBSCRIPTION_UPDATE = 'subscription_update';
     const BILLING_REASON_UPCOMING = 'upcoming';
 
-    /**
-     * Possible string representations of the `collection_method` property.
-     *
-     * @see https://stripe.com/docs/api/invoices/object#invoice_object-collection_method
-     */
     const COLLECTION_METHOD_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const COLLECTION_METHOD_SEND_INVOICE = 'send_invoice';
 
-    /**
-     * Possible string representations of the invoice status.
-     *
-     * @see https://stripe.com/docs/api/invoices/object#invoice_object-status
-     */
+    const STATUS_DELETED = 'deleted';
     const STATUS_DRAFT = 'draft';
     const STATUS_OPEN = 'open';
     const STATUS_PAID = 'paid';
     const STATUS_UNCOLLECTIBLE = 'uncollectible';
     const STATUS_VOID = 'void';
 
-    /**
-     * Possible string representations of the `billing` property.
-     *
-     * @deprecated use `collection_method` instead
-     * @see https://stripe.com/docs/api/invoices/object#invoice_object-billing
-     */
-    const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
-    const BILLING_SEND_INVOICE = 'send_invoice';
+    use ApiOperations\NestedResource;
 
     const PATH_LINES = '/lines';
 

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -51,11 +51,6 @@ class PaymentIntent extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * These constants are possible representations of the status field.
-     *
-     * @see https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
-     */
     const STATUS_CANCELED = 'canceled';
     const STATUS_PROCESSING = 'processing';
     const STATUS_REQUIRES_ACTION = 'requires_action';

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -35,11 +35,6 @@ class Payout extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Types of payout failure codes.
-     *
-     * @see https://stripe.com/docs/api#payout_failures
-     */
     const FAILURE_ACCOUNT_CLOSED = 'account_closed';
     const FAILURE_ACCOUNT_FROZEN = 'account_frozen';
     const FAILURE_BANK_ACCOUNT_RESTRICTED = 'bank_account_restricted';
@@ -54,30 +49,15 @@ class Payout extends ApiResource
     const FAILURE_NO_ACCOUNT = 'no_account';
     const FAILURE_UNSUPPORTED_CARD = 'unsupported_card';
 
-    /**
-     * Possible string representations of the payout methods.
-     *
-     * @see https://stripe.com/docs/api/payouts/object#payout_object-method
-     */
-    const METHOD_STANDARD = 'standard';
     const METHOD_INSTANT = 'instant';
+    const METHOD_STANDARD = 'standard';
 
-    /**
-     * Possible string representations of the status of the payout.
-     *
-     * @see https://stripe.com/docs/api/payouts/object#payout_object-status
-     */
     const STATUS_CANCELED = 'canceled';
-    const STATUS_IN_TRANSIT = 'in_transit';
     const STATUS_FAILED = 'failed';
+    const STATUS_IN_TRANSIT = 'in_transit';
     const STATUS_PAID = 'paid';
     const STATUS_PENDING = 'pending';
 
-    /**
-     * Possible string representations of the type of payout.
-     *
-     * @see https://stripe.com/docs/api/payouts/object#payout_object-type
-     */
     const TYPE_BANK_ACCOUNT = 'bank_account';
     const TYPE_CARD = 'card';
 

--- a/lib/Product.php
+++ b/lib/Product.php
@@ -35,11 +35,6 @@ class Product extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the type of product.
-     *
-     * @see https://stripe.com/docs/api/service_products/object#service_product_object-type
-     */
     const TYPE_GOOD = 'good';
     const TYPE_SERVICE = 'service';
 }

--- a/lib/Radar/EarlyFraudWarning.php
+++ b/lib/Radar/EarlyFraudWarning.php
@@ -20,11 +20,6 @@ class EarlyFraudWarning extends \Stripe\ApiResource
     use \Stripe\ApiOperations\All;
     use \Stripe\ApiOperations\Retrieve;
 
-    /**
-     * Possible string representations of an early fraud warning's fraud type.
-     *
-     * @see https://stripe.com/docs/api/early_fraud_warnings/object#early_fraud_warning_object-fraud_type
-     */
     const FRAUD_TYPE_CARD_NEVER_RECEIVED = 'card_never_received';
     const FRAUD_TYPE_FRAUDULENT_CARD_APPLICATION = 'fraudulent_card_application';
     const FRAUD_TYPE_MADE_WITH_COUNTERFEIT_CARD = 'made_with_counterfeit_card';

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -44,4 +44,9 @@ class Refund extends ApiResource
     const STATUS_FAILED = 'failed';
     const STATUS_PENDING = 'pending';
     const STATUS_SUCCEEDED = 'succeeded';
+
+    /**
+     * @deprecated use FAILURE_REASON_EXPIRED_OR_CANCELED_CARD instead
+     */
+    const FAILURE_REASON = 'expired_or_canceled_card';
 }

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -32,29 +32,14 @@ class Refund extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the failure reason.
-     *
-     * @see https://stripe.com/docs/api/refunds/object#refund_object-failure_reason
-     */
-    const FAILURE_REASON = 'expired_or_canceled_card';
+    const FAILURE_REASON_EXPIRED_OR_CANCELED_CARD = 'expired_or_canceled_card';
     const FAILURE_REASON_LOST_OR_STOLEN_CARD = 'lost_or_stolen_card';
     const FAILURE_REASON_UNKNOWN = 'unknown';
 
-    /**
-     * Possible string representations of the refund reason.
-     *
-     * @see https://stripe.com/docs/api/refunds/object#refund_object-reason
-     */
     const REASON_DUPLICATE = 'duplicate';
     const REASON_FRAUDULENT = 'fraudulent';
     const REASON_REQUESTED_BY_CUSTOMER = 'requested_by_customer';
 
-    /**
-     * Possible string representations of the refund status.
-     *
-     * @see https://stripe.com/docs/api/refunds/object#refund_object-status
-     */
     const STATUS_CANCELED = 'canceled';
     const STATUS_FAILED = 'failed';
     const STATUS_PENDING = 'pending';

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -27,21 +27,12 @@ class Review extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Retrieve;
 
-    const CLOSED_REASON_APPROVED = 'approved';
-    const CLOSED_REASON_DISPUTED = 'disputed';
-    const CLOSED_REASON_REFUNDED = 'refunded';
-    const CLOSED_REASON_REFUNDED_AS_FRAUD = 'refunded_as_fraud';
-
-    const OPENED_REASON_MANUAL = 'manual';
-    const OPENED_REASON_RULE = 'rule';
-
     /**
      * Possible string representations of the current, the opening or the closure reason of the review.
      * Not all of these enumeration apply to all of the ´reason´ fields. Please consult the Review object to
      * determine where these are apply.
      *
      * @see https://stripe.com/docs/api/radar/reviews/object
-     * @deprecated prefer using the OPENED_REASON_* or CLOSED_REASON_* constants
      */
     const REASON_APPROVED = 'approved';
     const REASON_DISPUTED = 'disputed';

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -27,12 +27,21 @@ class Review extends ApiResource
     use ApiOperations\All;
     use ApiOperations\Retrieve;
 
+    const CLOSED_REASON_APPROVED = 'approved';
+    const CLOSED_REASON_DISPUTED = 'disputed';
+    const CLOSED_REASON_REFUNDED = 'refunded';
+    const CLOSED_REASON_REFUNDED_AS_FRAUD = 'refunded_as_fraud';
+
+    const OPENED_REASON_MANUAL = 'manual';
+    const OPENED_REASON_RULE = 'rule';
+
     /**
      * Possible string representations of the current, the opening or the closure reason of the review.
      * Not all of these enumeration apply to all of the ´reason´ fields. Please consult the Review object to
      * determine where these are apply.
      *
      * @see https://stripe.com/docs/api/radar/reviews/object
+     * @deprecated prefer using the OPENED_REASON_* or CLOSED_REASON_* constants
      */
     const REASON_APPROVED = 'approved';
     const REASON_DISPUTED = 'disputed';

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -35,11 +35,6 @@ class SetupIntent extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * These constants are possible representations of the status field.
-     *
-     * @see https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status
-     */
     const STATUS_CANCELED = 'canceled';
     const STATUS_PROCESSING = 'processing';
     const STATUS_REQUIRES_ACTION = 'requires_action';

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -52,36 +52,21 @@ class Source extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    use ApiOperations\NestedResource;
-
-    /**
-     * Possible string representations of source flows.
-     *
-     * @see https://stripe.com/docs/api#source_object-flow
-     */
-    const FLOW_REDIRECT = 'redirect';
-    const FLOW_RECEIVER = 'receiver';
     const FLOW_CODE_VERIFICATION = 'code_verification';
     const FLOW_NONE = 'none';
+    const FLOW_RECEIVER = 'receiver';
+    const FLOW_REDIRECT = 'redirect';
 
-    /**
-     * Possible string representations of source statuses.
-     *
-     * @see https://stripe.com/docs/api#source_object-status
-     */
     const STATUS_CANCELED = 'canceled';
     const STATUS_CHARGEABLE = 'chargeable';
     const STATUS_CONSUMED = 'consumed';
     const STATUS_FAILED = 'failed';
     const STATUS_PENDING = 'pending';
 
-    /**
-     * Possible string representations of source usage.
-     *
-     * @see https://stripe.com/docs/api#source_object-usage
-     */
     const USAGE_REUSABLE = 'reusable';
     const USAGE_SINGLE_USE = 'single_use';
+
+    use ApiOperations\NestedResource;
 
     /**
      * @param null|array $params

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -50,18 +50,13 @@ class Subscription extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * These constants are possible representations of the status field.
-     *
-     * @see https://stripe.com/docs/api#subscription_object-status
-     */
     const STATUS_ACTIVE = 'active';
     const STATUS_CANCELED = 'canceled';
+    const STATUS_INCOMPLETE = 'incomplete';
+    const STATUS_INCOMPLETE_EXPIRED = 'incomplete_expired';
     const STATUS_PAST_DUE = 'past_due';
     const STATUS_TRIALING = 'trialing';
     const STATUS_UNPAID = 'unpaid';
-    const STATUS_INCOMPLETE = 'incomplete';
-    const STATUS_INCOMPLETE_EXPIRED = 'incomplete_expired';
 
     use ApiOperations\Delete {
         delete as protected _delete;

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -22,11 +22,6 @@ class Token extends ApiResource
     use ApiOperations\Create;
     use ApiOperations\Retrieve;
 
-    /**
-     * Possible string representations of the token type.
-     *
-     * @see https://stripe.com/docs/api/tokens/object#token_object-type
-     */
     const TYPE_ACCOUNT = 'account';
     const TYPE_BANK_ACCOUNT = 'bank_account';
     const TYPE_CARD = 'card';

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -31,11 +31,6 @@ class Topup extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the status of the top-up.
-     *
-     * @see https://stripe.com/docs/api/topups/object#topup_object-status
-     */
     const STATUS_CANCELED = 'canceled';
     const STATUS_FAILED = 'failed';
     const STATUS_PENDING = 'pending';

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -33,11 +33,6 @@ class Transfer extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    /**
-     * Possible string representations of the source type of the transfer.
-     *
-     * @see https://stripe.com/docs/api/transfers/object#transfer_object-source_type
-     */
     const SOURCE_TYPE_ALIPAY_ACCOUNT = 'alipay_account';
     const SOURCE_TYPE_BANK_ACCOUNT = 'bank_account';
     const SOURCE_TYPE_CARD = 'card';


### PR DESCRIPTION
r? @remi-stripe 

WIP PR for automatically generating constants for enum values.

This PR:
- removes the PHPDoc block for constants. I don't think that's a huge issue since the existing PHPDoc only applies to the topmost constant anyway. At the moment we can't really generate better docs, but as we migrate enum fields to our new-style enums where each value can be documented separately, we'll likely be able to generate good PHPDoc for each value in the future.
- adds some missing values
- changes the order of a few things

There a few constants that are still generated using the existing override system:
- `DECLINED_*` on `Charge`, because the field they're describing is actually kinda removed from Charge
- `REASON_*` on `Review`, because these values should actually be split into `CLOSED_REASON_*` and `OPENED_REASON_*`. ~The new values are generated and I added a deprecation notice.~
