### PR TITLE
Make `\Stripe\Collection` implement `\Countable`

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -10,7 +10,7 @@ namespace Stripe;
  * @property bool $has_more
  * @property \Stripe\StripeObject[] $data
  */
-class Collection extends StripeObject implements \IteratorAggregate
+class Collection extends StripeObject implements \Countable, \IteratorAggregate
 {
     const OBJECT_NAME = 'list';
 
@@ -102,6 +102,14 @@ class Collection extends StripeObject implements \IteratorAggregate
         );
 
         return Util\Util::convertToStripeObject($response, $opts);
+    }
+
+    /**
+     * @return int the number of objects in the current page
+     */
+    public function count()
+    {
+        return \count($this->data);
     }
 
     /**

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -88,6 +88,19 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
+    public function testCanCount()
+    {
+        $collection = Collection::constructFrom([
+            'data' => [['id' => 1]],
+        ]);
+        static::assertCount(1, $collection);
+
+        $collection = Collection::constructFrom([
+            'data' => [['id' => 1], ['id' => 2], ['id' => 3]],
+        ]);
+        static::assertCount(3, $collection);
+    }
+
     public function testCanIterate()
     {
         $collection = Collection::constructFrom([


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

Make `\Stripe\Collection` implement `\Countable`, so that calling `count($page)` will return the number of objects in the page rather than the number of keys on the page object.

Fixes #807.
