### PR TITLE
Prepare for `strict_types`

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -43,8 +43,6 @@ abstract class ApiResource extends StripeObject
             ($v instanceof ApiResource)) {
             $v->saveWithParent = true;
         }
-
-        return $v;
     }
 
     /**

--- a/lib/BankAccount.php
+++ b/lib/BankAccount.php
@@ -89,7 +89,7 @@ class BankAccount extends ApiResource
                "'bank_account_id')` or `Account::retrieveExternalAccount(" .
                "'account_id', 'bank_account_id')`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 
     /**
@@ -107,7 +107,7 @@ class BankAccount extends ApiResource
                '$updateParams)` or `Account::updateExternalAccount(' .
                "'account_id', 'bank_account_id', \$updateParams)`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 
     /**

--- a/lib/Capability.php
+++ b/lib/Capability.php
@@ -65,7 +65,7 @@ class Capability extends ApiResource
                'Retrieve a capability using `Account::retrieveCapability(' .
                "'account_id', 'capability_id')`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 
     /**
@@ -81,6 +81,6 @@ class Capability extends ApiResource
                'Update a capability using `Account::updateCapability(' .
                "'account_id', 'capability_id', \$updateParams)`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 }

--- a/lib/CustomerBalanceTransaction.php
+++ b/lib/CustomerBalanceTransaction.php
@@ -72,7 +72,7 @@ class CustomerBalanceTransaction extends ApiResource
                "`Customer::retrieveBalanceTransaction('customer_id', " .
                "'balance_transaction_id')`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 
     /**
@@ -89,6 +89,6 @@ class CustomerBalanceTransaction extends ApiResource
                "`Customer::updateBalanceTransaction('customer_id', " .
                "'balance_transaction_id', \$updateParams)`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 }

--- a/lib/Person.php
+++ b/lib/Person.php
@@ -91,7 +91,7 @@ class Person extends ApiResource
                "a person using `Account::retrievePerson('account_id', " .
                "'person_id')`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 
     /**
@@ -107,6 +107,6 @@ class Person extends ApiResource
                "a person using `Account::updatePerson('account_id', " .
                "'person_id', \$updateParams)`.";
 
-        throw new Exception\BadMethodCallException($msg, null);
+        throw new Exception\BadMethodCallException($msg);
     }
 }

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -7,12 +7,25 @@ namespace Stripe;
  */
 class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
 {
+    /** @var Util\RequestOptions */
     protected $_opts;
+
+    /** @var array */
     protected $_originalValues;
+
+    /** @var array */
     protected $_values;
+
+    /** @var Util\Set */
     protected $_unsavedValues;
+
+    /** @var Util\Set */
     protected $_transientValues;
+
+    /** @var null|array */
     protected $_retrieveOptions;
+
+    /** @var null|ApiResponse */
     protected $_lastResponse;
 
     /**
@@ -534,7 +547,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     }
 
     /**
-     * @return object The last response from the Stripe API
+     * @return null|ApiResponse The last response from the Stripe API
      */
     public function getLastResponse()
     {

--- a/lib/Util/DefaultLogger.php
+++ b/lib/Util/DefaultLogger.php
@@ -8,8 +8,10 @@ namespace Stripe\Util;
  */
 class DefaultLogger implements LoggerInterface
 {
+    /** @var int */
     public $messageType = 0;
 
+    /** @var null|string */
     public $destination;
 
     public function error($message, array $context = [])
@@ -17,6 +19,11 @@ class DefaultLogger implements LoggerInterface
         if (\count($context) > 0) {
             throw new \Stripe\Exception\BadMethodCallException('DefaultLogger does not currently implement context. Please implement if you need it.');
         }
-        \error_log($message, $this->messageType, $this->destination);
+
+        if (null === $this->destination) {
+            \error_log($message, $this->messageType);
+        } else {
+            \error_log($message, $this->messageType, $this->destination);
+        }
     }
 }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -314,7 +314,7 @@ abstract class Util
      */
     public static function urlEncode($key)
     {
-        $s = \urlencode($key);
+        $s = \urlencode((string) $key);
 
         // Don't use strict form encoding by changing the square bracket control
         // characters back to their literals. This is fine by the server, and

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -19,7 +19,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
     public function setUpFixture()
     {
         $this->fixture = Collection::constructFrom([
-            'data' => [['id' => 1]],
+            'data' => [['id' => '1']],
             'has_more' => true,
             'url' => '/things',
         ]);
@@ -43,7 +43,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             false,
             [
                 'object' => 'list',
-                'data' => [['id' => 1]],
+                'data' => [['id' => '1']],
                 'has_more' => true,
                 'url' => '/things',
             ]
@@ -62,11 +62,11 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             null,
             false,
             [
-                'id' => 1,
+                'id' => '1',
             ]
         );
 
-        $this->fixture->retrieve(1);
+        $this->fixture->retrieve('1');
     }
 
     public function testCanCreate()
@@ -80,7 +80,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             null,
             false,
             [
-                'id' => 2,
+                'id' => '2',
             ]
         );
 
@@ -92,12 +92,12 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testCanCount()
     {
         $collection = Collection::constructFrom([
-            'data' => [['id' => 1]],
+            'data' => [['id' => '1']],
         ]);
         static::assertCount(1, $collection);
 
         $collection = Collection::constructFrom([
-            'data' => [['id' => 1], ['id' => 2], ['id' => 3]],
+            'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
         ]);
         static::assertCount(3, $collection);
     }
@@ -105,7 +105,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testCanIterate()
     {
         $collection = Collection::constructFrom([
-            'data' => [['id' => 1], ['id' => 2], ['id' => 3]],
+            'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
             'has_more' => true,
             'url' => '/things',
         ]);
@@ -115,13 +115,13 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([1, 2, 3], $seen);
+        static::assertSame(['1', '2', '3'], $seen);
     }
 
     public function testCanIterateBackwards()
     {
         $collection = Collection::constructFrom([
-            'data' => [['id' => 1], ['id' => 2], ['id' => 3]],
+            'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
             'has_more' => true,
             'url' => '/things',
         ]);
@@ -131,7 +131,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([3, 2, 1], $seen);
+        static::assertSame(['3', '2', '1'], $seen);
     }
 
     public function testSupportsIteratorToArray()
@@ -141,7 +141,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([1], $seen);
+        static::assertSame(['1'], $seen);
     }
 
     public function testProvidesAutoPagingIterator()
@@ -150,13 +150,13 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             'GET',
             '/things',
             [
-                'starting_after' => 1,
+                'starting_after' => '1',
             ],
             null,
             false,
             [
                 'object' => 'list',
-                'data' => [['id' => 2], ['id' => 3]],
+                'data' => [['id' => '2'], ['id' => '3']],
                 'has_more' => false,
             ]
         );
@@ -166,7 +166,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([1, 2, 3], $seen);
+        static::assertSame(['1', '2', '3'], $seen);
     }
 
     public function testAutoPagingIteratorSupportsIteratorToArray()
@@ -175,13 +175,13 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             'GET',
             '/things',
             [
-                'starting_after' => 1,
+                'starting_after' => '1',
             ],
             null,
             false,
             [
                 'object' => 'list',
-                'data' => [['id' => 2], ['id' => 3]],
+                'data' => [['id' => '2'], ['id' => '3']],
                 'has_more' => false,
             ]
         );
@@ -191,7 +191,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([1, 2, 3], $seen);
+        static::assertSame(['1', '2', '3'], $seen);
     }
 
     public function testProvidesAutoPagingIteratorThatSupportsBackwardsPagination()
@@ -200,30 +200,30 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             'GET',
             '/things',
             [
-                'ending_before' => 3,
+                'ending_before' => '3',
             ],
             null,
             false,
             [
                 'object' => 'list',
-                'data' => [['id' => 1], ['id' => 2]],
+                'data' => [['id' => '1'], ['id' => '2']],
                 'has_more' => false,
             ]
         );
 
         $collection = Collection::constructFrom([
-            'data' => [['id' => 3]],
+            'data' => [['id' => '3']],
             'has_more' => true,
             'url' => '/things',
         ]);
-        $collection->setFilters(['ending_before' => 4]);
+        $collection->setFilters(['ending_before' => '4']);
 
         $seen = [];
         foreach ($collection->autoPagingIterator() as $item) {
             \array_push($seen, $item['id']);
         }
 
-        static::assertSame([3, 2, 1], $seen);
+        static::assertSame(['3', '2', '1'], $seen);
     }
 
     public function testHeaders()
@@ -240,7 +240,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             ],
             false,
             [
-                'id' => 2,
+                'id' => '2',
             ]
         );
 
@@ -263,7 +263,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
         $empty = Collection::constructFrom(['data' => []]);
         static::assertTrue($empty->isEmpty());
 
-        $notEmpty = Collection::constructFrom(['data' => [['id' => 1]]]);
+        $notEmpty = Collection::constructFrom(['data' => [['id' => '1']]]);
         static::assertFalse($notEmpty->isEmpty());
     }
 
@@ -273,13 +273,13 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             'GET',
             '/things',
             [
-                'starting_after' => 1,
+                'starting_after' => '1',
             ],
             null,
             false,
             [
                 'object' => 'list',
-                'data' => [['id' => 2], ['id' => 3]],
+                'data' => [['id' => '2'], ['id' => '3']],
                 'has_more' => false,
             ]
         );
@@ -289,7 +289,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
         foreach ($nextPage->data as $element) {
             \array_push($ids, $element['id']);
         }
-        static::assertSame([2, 3], $ids);
+        static::assertSame(['2', '3'], $ids);
     }
 
     public function testPreviousPage()
@@ -298,7 +298,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
             'GET',
             '/things',
             [
-                'ending_before' => 1,
+                'ending_before' => '1',
             ],
             null,
             false,


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 
cc @stripe/api-libraries 

Some changes in preparation of [strict typing](https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict) once we drop support for PHP 5.x.

I'll add inline comments to explain the different changes.