### PR TITLE
Service factories

### DIFF
--- a/init.php
+++ b/init.php
@@ -43,10 +43,6 @@ require __DIR__ . '/lib/Exception/OAuth/UnknownOAuthErrorException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedGrantTypeException.php';
 require __DIR__ . '/lib/Exception/OAuth/UnsupportedResponseTypeException.php';
 
-// StripeClient
-require __DIR__ . '/lib/StripeClientInterface.php';
-require __DIR__ . '/lib/StripeClient.php';
-
 // API operations
 require __DIR__ . '/lib/ApiOperations/All.php';
 require __DIR__ . '/lib/ApiOperations/Create.php';
@@ -64,6 +60,12 @@ require __DIR__ . '/lib/ApiRequestor.php';
 require __DIR__ . '/lib/ApiResource.php';
 require __DIR__ . '/lib/SingletonApiResource.php';
 require __DIR__ . '/lib/Service/AbstractService.php';
+require __DIR__ . '/lib/Service/AbstractServiceFactory.php';
+
+// StripeClient
+require __DIR__ . '/lib/StripeClientInterface.php';
+require __DIR__ . '/lib/BaseStripeClient.php';
+require __DIR__ . '/lib/StripeClient.php';
 
 // Stripe API Resources
 require __DIR__ . '/lib/Account.php';
@@ -203,6 +205,15 @@ require __DIR__ . '/lib/Service/TokenService.php';
 require __DIR__ . '/lib/Service/TopupService.php';
 require __DIR__ . '/lib/Service/TransferService.php';
 require __DIR__ . '/lib/Service/WebhookEndpointService.php';
+
+// Service factories
+require __DIR__ . '/lib/Service/CoreServiceFactory.php';
+require __DIR__ . '/lib/Service/Checkout/CheckoutServiceFactory.php';
+require __DIR__ . '/lib/Service/Issuing/IssuingServiceFactory.php';
+require __DIR__ . '/lib/Service/Radar/RadarServiceFactory.php';
+require __DIR__ . '/lib/Service/Reporting/ReportingServiceFactory.php';
+require __DIR__ . '/lib/Service/Sigma/SigmaServiceFactory.php';
+require __DIR__ . '/lib/Service/Terminal/TerminalServiceFactory.php';
 
 // OAuth
 require __DIR__ . '/lib/OAuth.php';

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Stripe;
+
+class BaseStripeClient implements StripeClientInterface
+{
+    /** @var string default base URL for Stripe's API */
+    const DEFAULT_API_BASE = 'https://api.stripe.com';
+
+    /** @var string default base URL for Stripe's OAuth API */
+    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
+
+    /** @var string default base URL for Stripe's Files API */
+    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
+
+    /** @var null|string */
+    private $apiKey;
+
+    /** @var null|string */
+    private $clientId;
+
+    /** @var string */
+    private $apiBase;
+
+    /** @var string */
+    private $connectBase;
+
+    /** @var string */
+    private $filesBase;
+
+    /**
+     * Initializes a new instance of the {@link StripeClient} class.
+     *
+     * @param null|string $apiKey the API key used by the client to make requests
+     * @param null|string $clientId the client ID used by the client in OAuth requests
+     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
+     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
+     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     */
+    public function __construct(
+        $apiKey,
+        $clientId = null,
+        $apiBase = null,
+        $connectBase = null,
+        $filesBase = null
+    ) {
+        if (null !== $apiKey && ('' === $apiKey)) {
+            $msg = 'API key cannot be the empty string.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        if (null !== $apiKey && (\preg_match('/\s/', $apiKey))) {
+            $msg = 'API key cannot contain whitespace.';
+
+            throw new \Stripe\Exception\InvalidArgumentException($msg);
+        }
+
+        $this->apiKey = $apiKey;
+        $this->clientId = $clientId;
+
+        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
+        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
+        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+    }
+
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return null|string the API key used by the client to send requests
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return null|string the client ID used by the client in OAuth requests
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string the base URL for Stripe's API
+     */
+    public function getApiBase()
+    {
+        return $this->apiBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string the base URL for Stripe's OAuth API
+     */
+    public function getConnectBase()
+    {
+        return $this->connectBase;
+    }
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string the base URL for Stripe's Files API
+     */
+    public function getFilesBase()
+    {
+        return $this->filesBase;
+    }
+
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\StripeObject the object returned by Stripe's API
+     */
+    public function request($method, $path, $params, $opts)
+    {
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $baseUrl = $opts->apiBase ?: $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+
+        return $obj;
+    }
+
+    /**
+     * @param \Stripe\Util\RequestOptions $opts
+     *
+     * @throws \Stripe\Exception\AuthenticationException
+     *
+     * @return string
+     */
+    private function apiKeyForRequest($opts)
+    {
+        $apiKey = $opts->apiKey ?: $this->getApiKey();
+
+        if (null === $apiKey) {
+            $msg = 'No API key provided. Set your API key when constructing the '
+                . 'StripeClient instance, or provide it on a per-request basis '
+                . 'using the `api_key` key in the $opts argument.';
+
+            throw new Exception\AuthenticationException($msg);
+        }
+
+        return $apiKey;
+    }
+}

--- a/lib/Service/AbstractServiceFactory.php
+++ b/lib/Service/AbstractServiceFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Abstract base class for all service factories used to expose service
+ * instances through {@link \Stripe\StripeClient}.
+ *
+ * Service factories serve two purposes:
+ *
+ * 1. Expose properties for all services through the `__get()` magic method.
+ * 2. Lazily initialize each service instance the first time the property for
+ *    a given service is used.
+ */
+abstract class AbstractServiceFactory
+{
+    /** @var \Stripe\StripeClientInterface */
+    private $client;
+
+    /** @var array<string, AbstractService|AbstractServiceFactory> */
+    private $services;
+
+    /**
+     * @param \Stripe\StripeClientInterface $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+        $this->services = [];
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return null|string
+     */
+    abstract protected function getServiceClass($name);
+
+    /**
+     * @param string $name
+     *
+     * @return null|AbstractService|AbstractServiceFactory
+     */
+    public function __get($name)
+    {
+        $serviceClass = $this->getServiceClass($name);
+        if (null !== $serviceClass) {
+            if (!\array_key_exists($name, $this->services)) {
+                $this->services[$name] = new $serviceClass($this->client);
+            }
+
+            return $this->services[$name];
+        }
+
+        \trigger_error('Undefined property: ' . static::class . '::$' . $name);
+
+        return null;
+    }
+}

--- a/lib/Service/Checkout/CheckoutServiceFactory.php
+++ b/lib/Service/Checkout/CheckoutServiceFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\Checkout;
+
+/**
+ * Service factory class for API resources in the Checkout namespace.
+ *
+ * @property SessionService $sessions
+ */
+class CheckoutServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'sessions' => SessionService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/CoreServiceFactory.php
+++ b/lib/Service/CoreServiceFactory.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Service factory class for API resources in the root namespace.
+ *
+ * @property AccountLinkService $accountLinks
+ * @property AccountService $accounts
+ * @property ApplePayDomainService $applePayDomains
+ * @property ApplicationFeeService $applicationFees
+ * @property BalanceTransactionService $balanceTransactions
+ * @property BalanceService $balances
+ * @property ChargeService $charges
+ * @property Checkout\CheckoutServiceFactory $checkout
+ * @property CountrySpecService $countrySpecs
+ * @property CouponService $coupons
+ * @property CreditNoteService $creditNotes
+ * @property CustomerService $customers
+ * @property DisputeService $disputes
+ * @property EphemeralKeyService $ephemeralKeys
+ * @property EventService $events
+ * @property ExchangeRateService $exchangeRates
+ * @property FileLinkService $fileLinks
+ * @property FileService $files
+ * @property InvoiceItemService $invoiceItems
+ * @property InvoiceService $invoices
+ * @property Issuing\IssuingServiceFactory $issuing
+ * @property MandateService $mandates
+ * @property OrderReturnService $orderReturns
+ * @property OrderService $orders
+ * @property PaymentIntentService $paymentIntents
+ * @property PaymentMethodService $paymentMethods
+ * @property PayoutService $payouts
+ * @property PlanService $plans
+ * @property ProductService $products
+ * @property Radar\RadarServiceFactory $radar
+ * @property RefundService $refunds
+ * @property Reporting\ReportingServiceFactory $reporting
+ * @property ReviewService $reviews
+ * @property SetupIntentService $setupIntents
+ * @property Sigma\SigmaServiceFactory $sigma
+ * @property SkuService $skus
+ * @property SourceService $sources
+ * @property SubscriptionItemService $subscriptionItems
+ * @property SubscriptionScheduleService $subscriptionSchedules
+ * @property SubscriptionService $subscriptions
+ * @property TaxRateService $taxRates
+ * @property Terminal\TerminalServiceFactory $terminal
+ * @property TokenService $tokens
+ * @property TopupService $topups
+ * @property TransferService $transfers
+ * @property WebhookEndpointService $webhookEndpoints
+ */
+class CoreServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'accountLinks' => AccountLinkService::class,
+        'accounts' => AccountService::class,
+        'applePayDomains' => ApplePayDomainService::class,
+        'applicationFees' => ApplicationFeeService::class,
+        'balanceTransactions' => BalanceTransactionService::class,
+        'balances' => BalanceService::class,
+        'charges' => ChargeService::class,
+        'checkout' => Checkout\CheckoutServiceFactory::class,
+        'countrySpecs' => CountrySpecService::class,
+        'coupons' => CouponService::class,
+        'creditNotes' => CreditNoteService::class,
+        'customers' => CustomerService::class,
+        'disputes' => DisputeService::class,
+        'ephemeralKeys' => EphemeralKeyService::class,
+        'events' => EventService::class,
+        'exchangeRates' => ExchangeRateService::class,
+        'fileLinks' => FileLinkService::class,
+        'files' => FileService::class,
+        'invoiceItems' => InvoiceItemService::class,
+        'invoices' => InvoiceService::class,
+        'issuing' => Issuing\IssuingServiceFactory::class,
+        'mandates' => MandateService::class,
+        'orderReturns' => OrderReturnService::class,
+        'orders' => OrderService::class,
+        'paymentIntents' => PaymentIntentService::class,
+        'paymentMethods' => PaymentMethodService::class,
+        'payouts' => PayoutService::class,
+        'plans' => PlanService::class,
+        'products' => ProductService::class,
+        'radar' => Radar\RadarServiceFactory::class,
+        'refunds' => RefundService::class,
+        'reporting' => Reporting\ReportingServiceFactory::class,
+        'reviews' => ReviewService::class,
+        'setupIntents' => SetupIntentService::class,
+        'sigma' => Sigma\SigmaServiceFactory::class,
+        'skus' => SkuService::class,
+        'sources' => SourceService::class,
+        'subscriptionItems' => SubscriptionItemService::class,
+        'subscriptionSchedules' => SubscriptionScheduleService::class,
+        'subscriptions' => SubscriptionService::class,
+        'taxRates' => TaxRateService::class,
+        'terminal' => Terminal\TerminalServiceFactory::class,
+        'tokens' => TokenService::class,
+        'topups' => TopupService::class,
+        'transfers' => TransferService::class,
+        'webhookEndpoints' => WebhookEndpointService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Issuing/IssuingServiceFactory.php
+++ b/lib/Service/Issuing/IssuingServiceFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Stripe\Service\Issuing;
+
+/**
+ * Service factory class for API resources in the Issuing namespace.
+ *
+ * @property AuthorizationService $authorizations
+ * @property CardholderService $cardholders
+ * @property CardService $cards
+ * @property DisputeService $disputes
+ * @property TransactionService $transactions
+ */
+class IssuingServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'authorizations' => AuthorizationService::class,
+        'cardholders' => CardholderService::class,
+        'cards' => CardService::class,
+        'disputes' => DisputeService::class,
+        'transactions' => TransactionService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Radar/RadarServiceFactory.php
+++ b/lib/Service/Radar/RadarServiceFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stripe\Service\Radar;
+
+/**
+ * Service factory class for API resources in the Radar namespace.
+ *
+ * @property EarlyFraudWarningService $earlyFraudWarnings
+ * @property ValueListItemService $valueListItems
+ * @property ValueListService $valueLists
+ */
+class RadarServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'earlyFraudWarnings' => EarlyFraudWarningService::class,
+        'valueListItems' => ValueListItemService::class,
+        'valueLists' => ValueListService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Reporting/ReportingServiceFactory.php
+++ b/lib/Service/Reporting/ReportingServiceFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Stripe\Service\Reporting;
+
+/**
+ * Service factory class for API resources in the Reporting namespace.
+ *
+ * @property ReportRunService $reportRuns
+ * @property ReportTypeService $reportTypes
+ */
+class ReportingServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'reportRuns' => ReportRunService::class,
+        'reportTypes' => ReportTypeService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Sigma/SigmaServiceFactory.php
+++ b/lib/Service/Sigma/SigmaServiceFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\Service\Sigma;
+
+/**
+ * Service factory class for API resources in the Sigma namespace.
+ *
+ * @property ScheduledQueryRunService $scheduledQueryRuns
+ */
+class SigmaServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'scheduledQueryRuns' => ScheduledQueryRunService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/Service/Terminal/TerminalServiceFactory.php
+++ b/lib/Service/Terminal/TerminalServiceFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stripe\Service\Terminal;
+
+/**
+ * Service factory class for API resources in the Terminal namespace.
+ *
+ * @property ConnectionTokenService $connectionTokens
+ * @property LocationService $locations
+ * @property ReaderService $readers
+ */
+class TerminalServiceFactory extends \Stripe\Service\AbstractServiceFactory
+{
+    /**
+     * @var array<string, string>
+     */
+    private static $classMap = [
+        'connectionTokens' => ConnectionTokenService::class,
+        'locations' => LocationService::class,
+        'readers' => ReaderService::class,
+    ];
+
+    protected function getServiceClass($name)
+    {
+        return \array_key_exists($name, self::$classMap) ? self::$classMap[$name] : null;
+    }
+}

--- a/lib/StripeClient.php
+++ b/lib/StripeClient.php
@@ -2,150 +2,69 @@
 
 namespace Stripe;
 
-class StripeClient implements StripeClientInterface
+/**
+ * Client used to send requests to Stripe's API.
+ *
+ * @property \Stripe\Service\AccountLinkService $accountLinks
+ * @property \Stripe\Service\AccountService $accounts
+ * @property \Stripe\Service\ApplePayDomainService $applePayDomains
+ * @property \Stripe\Service\ApplicationFeeService $applicationFees
+ * @property \Stripe\Service\BalanceTransactionService $balanceTransactions
+ * @property \Stripe\Service\BalanceService $balances
+ * @property \Stripe\Service\ChargeService $charges
+ * @property \Stripe\Service\Checkout\CheckoutServiceFactory $checkout
+ * @property \Stripe\Service\CountrySpecService $countrySpecs
+ * @property \Stripe\Service\CouponService $coupons
+ * @property \Stripe\Service\CreditNoteService $creditNotes
+ * @property \Stripe\Service\CustomerService $customers
+ * @property \Stripe\Service\DisputeService $disputes
+ * @property \Stripe\Service\EphemeralKeyService $ephemeralKeys
+ * @property \Stripe\Service\EventService $events
+ * @property \Stripe\Service\ExchangeRateService $exchangeRates
+ * @property \Stripe\Service\FileLinkService $fileLinks
+ * @property \Stripe\Service\FileService $files
+ * @property \Stripe\Service\InvoiceItemService $invoiceItems
+ * @property \Stripe\Service\InvoiceService $invoices
+ * @property \Stripe\Service\Issuing\IssuingServiceFactory $issuing
+ * @property \Stripe\Service\MandateService $mandates
+ * @property \Stripe\Service\OrderReturnService $orderReturns
+ * @property \Stripe\Service\OrderService $orders
+ * @property \Stripe\Service\PaymentIntentService $paymentIntents
+ * @property \Stripe\Service\PaymentMethodService $paymentMethods
+ * @property \Stripe\Service\PayoutService $payouts
+ * @property \Stripe\Service\PlanService $plans
+ * @property \Stripe\Service\ProductService $products
+ * @property \Stripe\Service\Radar\RadarServiceFactory $radar
+ * @property \Stripe\Service\RefundService $refunds
+ * @property \Stripe\Service\Reporting\ReportingServiceFactory $reporting
+ * @property \Stripe\Service\ReviewService $reviews
+ * @property \Stripe\Service\SetupIntentService $setupIntents
+ * @property \Stripe\Service\Sigma\SigmaServiceFactory $sigma
+ * @property \Stripe\Service\SkuService $skus
+ * @property \Stripe\Service\SourceService $sources
+ * @property \Stripe\Service\SubscriptionItemService $subscriptionItems
+ * @property \Stripe\Service\SubscriptionScheduleService $subscriptionSchedules
+ * @property \Stripe\Service\SubscriptionService $subscriptions
+ * @property \Stripe\Service\TaxRateService $taxRates
+ * @property \Stripe\Service\Terminal\TerminalServiceFactory $terminal
+ * @property \Stripe\Service\TokenService $tokens
+ * @property \Stripe\Service\TopupService $topups
+ * @property \Stripe\Service\TransferService $transfers
+ * @property \Stripe\Service\WebhookEndpointService $webhookEndpoints
+ */
+class StripeClient extends BaseStripeClient
 {
     /**
-     * @var string default base URL for Stripe's API
+     * @var \Stripe\Service\CoreServiceFactory
      */
-    const DEFAULT_API_BASE = 'https://api.stripe.com';
+    private $coreServiceFactory;
 
-    /**
-     * @var string default base URL for Stripe's OAuth API
-     */
-    const DEFAULT_CONNECT_BASE = 'https://connect.stripe.com';
-
-    /**
-     * @var string default base URL for Stripe's Files API
-     */
-    const DEFAULT_FILES_BASE = 'https://files.stripe.com';
-
-    private $apiKey;
-    private $clientId;
-
-    private $apiBase;
-    private $connectBase;
-    private $filesBase;
-
-    /**
-     * Initializes a new instance of the {@link StripeClient} class.
-     *
-     * @param null|string $apiKey the API key used by the client to make requests
-     * @param null|string $clientId the client ID used by the client in OAuth requests
-     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
-     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
-     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
-     */
-    public function __construct(
-        $apiKey,
-        $clientId = null,
-        $apiBase = null,
-        $connectBase = null,
-        $filesBase = null
-    ) {
-        if (null !== $apiKey && ('' === $apiKey)) {
-            $msg = 'API key cannot be the empty string.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
-        }
-        if (null !== $apiKey && (\preg_match('/\s/', $apiKey))) {
-            $msg = 'API key cannot contain whitespace.';
-
-            throw new \Stripe\Exception\InvalidArgumentException($msg);
+    public function __get($name)
+    {
+        if (null === $this->coreServiceFactory) {
+            $this->coreServiceFactory = new \Stripe\Service\CoreServiceFactory($this);
         }
 
-        $this->apiKey = $apiKey;
-        $this->clientId = $clientId;
-
-        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
-        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
-        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
-    }
-
-    /**
-     * Gets the API key used by the client to send requests.
-     *
-     * @return null|string the API key used by the client to send requests
-     */
-    public function getApiKey()
-    {
-        return $this->apiKey;
-    }
-
-    /**
-     * Gets the client ID used by the client in OAuth requests.
-     *
-     * @return null|string the client ID used by the client in OAuth requests
-     */
-    public function getClientId()
-    {
-        return $this->clientId;
-    }
-
-    /**
-     * Gets the base URL for Stripe's API.
-     *
-     * @return string the base URL for Stripe's API
-     */
-    public function getApiBase()
-    {
-        return $this->apiBase;
-    }
-
-    /**
-     * Gets the base URL for Stripe's OAuth API.
-     *
-     * @return string the base URL for Stripe's OAuth API
-     */
-    public function getConnectBase()
-    {
-        return $this->connectBase;
-    }
-
-    /**
-     * Gets the base URL for Stripe's Files API.
-     *
-     * @return string the base URL for Stripe's Files API
-     */
-    public function getFilesBase()
-    {
-        return $this->filesBase;
-    }
-
-    /**
-     * Sends a request to Stripe's API.
-     *
-     * @param string $method the HTTP method
-     * @param string $path the path of the request
-     * @param array $params the parameters of the request
-     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
-     *
-     * @return \Stripe\StripeObject the object returned by Stripe's API
-     */
-    public function request($method, $path, $params, $opts)
-    {
-        $opts = \Stripe\Util\RequestOptions::parse($opts);
-        $baseUrl = $opts->apiBase ?: $this->getApiBase();
-        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
-        list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);
-        $opts->discardNonPersistentHeaders();
-        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
-        $obj->setLastResponse($response);
-
-        return $obj;
-    }
-
-    private function apiKeyForRequest($opts)
-    {
-        $apiKey = $opts->apiKey ?: $this->getApiKey();
-
-        if (null === $apiKey) {
-            $msg = 'No API key provided. Set your API key when constructing the '
-                . 'StripeClient instance, or provide it on a per-request basis '
-                . 'using the `api_key` key in the $opts argument.';
-
-            throw new Exception\AuthenticationException($msg);
-        }
-
-        return $apiKey;
+        return $this->coreServiceFactory->__get($name);
     }
 }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ * @covers \Stripe\BaseStripeClient
+ */
+final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    {
+        $client = new BaseStripeClient(null);
+        static::assertNotNull($client);
+        static::assertNull($client->getApiKey());
+    }
+
+    public function testCtorThrowsIfApiKeyIsEmpty()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot be the empty string.');
+
+        $client = new BaseStripeClient('');
+    }
+
+    public function testCtorThrowsIfApiKeyContainsWhitespace()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('API key cannot contain whitespace.');
+
+        $client = new BaseStripeClient("sk_test_123\n");
+    }
+
+    public function testRequestWithClientApiKey()
+    {
+        $client = new BaseStripeClient('sk_test_client', null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_client', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestWithOptsApiKey()
+    {
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
+        static::assertNotNull($charge);
+        static::assertNotNull($charge);
+        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
+        $optsReflector->setAccessible(true);
+        static::assertSame('sk_test_opts', $optsReflector->getValue($charge)->apiKey);
+    }
+
+    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
+    {
+        $this->expectException(\Stripe\Exception\AuthenticationException::class);
+        $this->expectExceptionMessage('No API key provided.');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
+}

--- a/tests/Stripe/Service/CoreServiceFactoryTest.php
+++ b/tests/Stripe/Service/CoreServiceFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * @internal
+ * @covers \Stripe\Service\CoreServiceFactory
+ */
+final class CoreServiceFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var \Stripe\StripeClient */
+    private $client;
+
+    /** @var CoreServiceFactory */
+    private $serviceFactory;
+
+    /**
+     * @before
+     */
+    protected function setUpService()
+    {
+        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->serviceFactory = new CoreServiceFactory($this->client);
+    }
+
+    public function testExposesPropertiesForServices()
+    {
+        static::assertInstanceOf(CouponService::class, $this->serviceFactory->coupons);
+        static::assertInstanceOf(\Stripe\Service\Issuing\IssuingServiceFactory::class, $this->serviceFactory->issuing);
+    }
+
+    public function testMultipleCallsReturnSameInstance()
+    {
+        $service = $this->serviceFactory->coupons;
+        static::assertSame($service, $this->serviceFactory->coupons);
+    }
+}

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -8,58 +8,11 @@ namespace Stripe;
  */
 final class StripeClientTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    public function testExposesPropertiesForServices()
     {
-        $client = new StripeClient(null);
-        static::assertNotNull($client);
-        static::assertNull($client->getApiKey());
-    }
-
-    public function testCtorThrowsIfApiKeyIsEmpty()
-    {
-        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot be the empty string.');
-
-        $client = new StripeClient('');
-    }
-
-    public function testCtorThrowsIfApiKeyContainsWhitespace()
-    {
-        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key cannot contain whitespace.');
-
-        $client = new StripeClient("sk_test_123\n");
-    }
-
-    public function testRequestWithClientApiKey()
-    {
-        $client = new StripeClient('sk_test_client', null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
-        static::assertNotNull($charge);
-        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
-        $optsReflector->setAccessible(true);
-        static::assertSame('sk_test_client', $optsReflector->getValue($charge)->apiKey);
-    }
-
-    public function testRequestWithOptsApiKey()
-    {
-        $client = new StripeClient(null, null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
-        static::assertNotNull($charge);
-        static::assertNotNull($charge);
-        $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
-        $optsReflector->setAccessible(true);
-        static::assertSame('sk_test_opts', $optsReflector->getValue($charge)->apiKey);
-    }
-
-    public function testRequestThrowsIfNoApiKeyInClientAndOpts()
-    {
-        $this->expectException(\Stripe\Exception\AuthenticationException::class);
-        $this->expectExceptionMessage('No API key provided.');
-
-        $client = new StripeClient(null, null, MOCK_URL);
-        $charge = $client->request('get', '/v1/charges/ch_123', [], []);
-        static::assertNotNull($charge);
-        static::assertSame('ch_123', $charge->id);
+        $client = new StripeClient('sk_test_123');
+        static::assertInstanceOf(\Stripe\Service\CouponService::class, $client->coupons);
+        static::assertInstanceOf(\Stripe\Service\Issuing\IssuingServiceFactory::class, $client->issuing);
+        static::assertInstanceOf(\Stripe\Service\Issuing\CardService::class, $client->issuing->cards);
     }
 }


### PR DESCRIPTION
This PR adds "service factories", i.e. classes that help initialize and expose instances of service classes. The intent is to alleviate the need for users to create the service instances themselves. Instead, they simply create an instance of the client, and the client then exposes properties for all services:

```php
$client = new \Stripe\StripeClient("sk_test_123");
$customer = $client->customers->retrieve("cus_123");
$issuingCard = $client->issuing->cards->retrieve("ic_123");
```

Here's how it works:
- `AbstractServiceFactory` is the base abstract class for service factory. Using the [`__get()` magic method](https://www.php.net/manual/en/language.oop5.overloading.php#object.get), it exposes properties for services using a mapping of property names to service classes defined in concrete factories. The service instances are lazily initialized the first time the property is accessed.
    - `CoreServiceFactory` is a concrete child that exposes services for API resources in the root namespace, as well as service factories for namespaces. This class will be codegen'd.
    - `IssuingServiceFactory` is a concrete child that exposes services for API resources in the issuing namespace. This class (and other similar classes for namespaced resources) will be codegen'd.
- `StripeClient` is renamed to `BaseStripeClient`
- A new `StripeClient` class is added that derives from `BaseStripeClient` and adds a `__get()` magic method to expose services through a `CoreServiceFactory` instance
    - the reason for splitting `BaseStripeClient` and `StripeClient` is that `BaseStripeClient` contains manually written infrastructure code, and `StripeClient` will need to be codegen'd in order to have the `@property` PHPDoc tags that will make autocompletion work for services in PHPStorm and other IDEs.

@brandur-stripe @rattrayalex-stripe @remi-stripe @richardm-stripe Thoughts on this approach?