### PR TITLE
Fixes issue #896

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -443,7 +443,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         };
 
         return \array_reduce(\array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {
-            if ('_' === $k[0]) {
+            if ('_' === substr($k, 0, 1)) {
                 return $acc;
             }
             $v = $this->_values[$k];


### PR DESCRIPTION
In this PR:

- Fixes issue introduced in PHP 7.4 with accessing an integer as an array (123[0] now throws a notice)


_Note: I'm not sure which branch to submit this PR to since PRs to master are automatically closed._