### PR TITLE
Convert keys to strings in `StripeObject::toArray()`

### DIFF
--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -443,7 +443,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
         };
 
         return \array_reduce(\array_keys($this->_values), function ($acc, $k) use ($maybeToArray) {
-            if ('_' === $k[0]) {
+            if ('_' === \substr((string) $k, 0, 1)) {
                 return $acc;
             }
             $v = $this->_values[$k];

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -98,6 +98,10 @@ final class StripeObjectTest extends \PHPUnit\Framework\TestCase
             'foo' => 'a',
             'list' => [1, 2, 3],
             'null' => null,
+            'metadata' => [
+                'key' => 'value',
+                1 => 'one',
+            ],
         ];
         $s = StripeObject::constructFrom($array);
 
@@ -118,13 +122,13 @@ final class StripeObjectTest extends \PHPUnit\Framework\TestCase
             'id' => 1,
             // simple associative array that contains a StripeObject to help us
             // test deep recursion
-            'nested' => ['object' => 'list', 'data' => $nested],
+            'nested' => ['object' => 'list', 'data' => [$nested]],
             'list' => [$nested],
         ]);
 
         $expected = [
             'id' => 1,
-            'nested' => ['object' => 'list', 'data' => $nestedArray],
+            'nested' => ['object' => 'list', 'data' => [$nestedArray]],
             'list' => [$nestedArray],
         ];
 


### PR DESCRIPTION
r? @cjavilla-stripe @remi-stripe 
cc @stripe/api-libraries @justin-schroeder

Convert keys to strings in `StripeObject::toArray()`.

Fixes #896.
