### PR TITLE
Add strict parsing for RequestOptions

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -126,7 +126,7 @@ class BaseStripeClient implements StripeClientInterface
      */
     public function request($method, $path, $params, $opts)
     {
-        $opts = \Stripe\Util\RequestOptions::parse($opts);
+        $opts = \Stripe\Util\RequestOptions::parse($opts, true);
         $baseUrl = $opts->apiBase ?: $this->getApiBase();
         $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
         list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers);

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -2,22 +2,30 @@
 
 namespace Stripe\Util;
 
-use Stripe\Exception;
-
 class RequestOptions
 {
     /**
-     * @var array a list of headers that should be persisted across requests
+     * @var array<string> a list of headers that should be persisted across requests
      */
     public static $HEADERS_TO_PERSIST = [
         'Stripe-Account',
         'Stripe-Version',
     ];
 
+    /** @var array<string, string> */
     public $headers;
+
+    /** @var null|string */
     public $apiKey;
+
+    /** @var null|string */
     public $apiBase;
 
+    /**
+     * @param null|string $key
+     * @param array<string, string> $headers
+     * @param null|string $base
+     */
     public function __construct($key = null, $headers = [], $base = null)
     {
         $this->apiKey = $key;
@@ -25,6 +33,9 @@ class RequestOptions
         $this->apiBase = $base;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function __debugInfo()
     {
         return [
@@ -38,13 +49,14 @@ class RequestOptions
      * Unpacks an options array and merges it into the existing RequestOptions
      * object.
      *
-     * @param null|array|string $options a key => value array
+     * @param null|array|RequestOptions|string $options a key => value array
+     * @param bool $strict when true, forbid string form and arbitrary keys in array form
      *
      * @return RequestOptions
      */
-    public function merge($options)
+    public function merge($options, $strict = false)
     {
-        $other_options = self::parse($options);
+        $other_options = self::parse($options, $strict);
         if (null === $other_options->apiKey) {
             $other_options->apiKey = $this->apiKey;
         }
@@ -71,11 +83,14 @@ class RequestOptions
     /**
      * Unpacks an options array into an RequestOptions object.
      *
-     * @param null|array|string $options a key => value array
+     * @param null|array|RequestOptions|string $options a key => value array
+     * @param bool $strict when true, forbid string form and arbitrary keys in array form
+     *
+     * @throws \Stripe\Exception\InvalidArgumentException
      *
      * @return RequestOptions
      */
-    public static function parse($options)
+    public static function parse($options, $strict = false)
     {
         if ($options instanceof self) {
             return $options;
@@ -86,6 +101,13 @@ class RequestOptions
         }
 
         if (\is_string($options)) {
+            if ($strict) {
+                $message = 'Do not pass a string for request options. If you want to set the '
+                    . 'API key, pass an array like ["api_key" => <apiKey>] instead.';
+
+                throw new \Stripe\Exception\InvalidArgumentException($message);
+            }
+
             return new RequestOptions($options, [], null);
         }
 
@@ -93,20 +115,32 @@ class RequestOptions
             $headers = [];
             $key = null;
             $base = null;
+
             if (\array_key_exists('api_key', $options)) {
                 $key = $options['api_key'];
+                unset($options['api_key']);
             }
             if (\array_key_exists('idempotency_key', $options)) {
                 $headers['Idempotency-Key'] = $options['idempotency_key'];
+                unset($options['idempotency_key']);
             }
             if (\array_key_exists('stripe_account', $options)) {
                 $headers['Stripe-Account'] = $options['stripe_account'];
+                unset($options['stripe_account']);
             }
             if (\array_key_exists('stripe_version', $options)) {
                 $headers['Stripe-Version'] = $options['stripe_version'];
+                unset($options['stripe_version']);
             }
             if (\array_key_exists('api_base', $options)) {
                 $base = $options['api_base'];
+                unset($options['api_base']);
+            }
+
+            if ($strict && !empty($options)) {
+                $message = 'Got unexpected keys in options array: ' . \implode(', ', \array_keys($options));
+
+                throw new \Stripe\Exception\InvalidArgumentException($message);
             }
 
             return new RequestOptions($key, $headers, $base);
@@ -117,7 +151,7 @@ class RequestOptions
            . 'per-request options, which must be an array. (HINT: you can set '
            . 'a global apiKey by "Stripe::setApiKey(<apiKey>)")';
 
-        throw new Exception\InvalidArgumentException($message);
+        throw new \Stripe\Exception\InvalidArgumentException($message);
     }
 
     private function redactedApiKey()

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -62,4 +62,26 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
     }
+
+    public function testRequestThrowsIfOptsIsString()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessageRegExp('#Do not pass a string for request options.#');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], 'foo');
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
+
+    public function testRequestThrowsIfOptsIsArrayWithUnexpectedKeys()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Got unexpected keys in options array: foo');
+
+        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $charge = $client->request('get', '/v1/charges/ch_123', [], ['foo' => 'bar']);
+        static::assertNotNull($charge);
+        static::assertSame('ch_123', $charge->id);
+    }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add strict parsing option to `RequestOptions::parse()`. When enabled, strict parsing will throw an `InvalidArgumentException` when:
- a string is passed (to deprecate passing per-request API keys as strings, and instead force the use of arrays like `['api_key' => 'sk_...']`)
- an array with unexpected keys is passed

Strict parsing is disabled by default, but is enabled when used from `StripeClient`. This makes this change fully backwards compatible for existing request methods on models, but forces strict parsing when using request methods on services.
