### PR TITLE
Change StripeClient initialization

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -29,21 +29,42 @@ class BaseStripeClient implements StripeClientInterface
     private $filesBase;
 
     /**
-     * Initializes a new instance of the {@link StripeClient} class.
+     * Initializes a new instance of the {@link BaseStripeClient} class.
      *
-     * @param null|string $apiKey the API key used by the client to make requests
-     * @param null|string $clientId the client ID used by the client in OAuth requests
-     * @param null|string $apiBase The base URL for Stripe's API. Defaults to {@link DEFAULT_API_BASE}.
-     * @param null|string $connectBase The base URL for Stripe's OAuth API. Defaults to {@link DEFAULT_CONNECT_BASE}.
-     * @param null|string $filesBase The base URL for Stripe's Files API. Defaults to {@link DEFAULT_FILES_BASE}.
+     * The constructor takes a single argument. The argument can be a string, in which case it
+     * should be the API key. It can also be an array with various configuration settings.
+     *
+     * Configuration settings include the following options:
+     *
+     * - api_key (string): the Stripe API key, to be used in regular API requests.
+     * - client_id (string): the Stripe client ID, to be used in OAuth requests.
+     * - api_base (string): the base URL for regular API requests. Defaults to
+     *   {@link DEFAULT_API_BASE}. Changing this should rarely be necessary.
+     * - connect_base (string): the base URL for OAuth requests. Defaults to
+     *   {@link DEFAULT_CONNECT_BASE}. Changing this should rarely be necessary.
+     * - files_base (string): the base URL for file creation requests. Defaults to
+     *   {@link DEFAULT_FILES_BASE}. Changing this should rarely be necessary.
+     *
+     * @param array<string, mixed>|string $config the API key as a string, or an array containing
+     *   the client configuration settings
      */
-    public function __construct(
-        $apiKey,
-        $clientId = null,
-        $apiBase = null,
-        $connectBase = null,
-        $filesBase = null
-    ) {
+    public function __construct($config = [])
+    {
+        if (\is_string($config)) {
+            $config = ['api_key' => $config];
+        }
+
+        $defaults = [
+            'api_key' => null,
+            'client_id' => null,
+            'api_base' => self::DEFAULT_API_BASE,
+            'connect_base' => self::DEFAULT_CONNECT_BASE,
+            'files_base' => self::DEFAULT_FILES_BASE,
+        ];
+        $config = \array_merge($defaults, $config);
+
+        $apiKey = $config['api_key'];
+
         if (null !== $apiKey && ('' === $apiKey)) {
             $msg = 'API key cannot be the empty string.';
 
@@ -57,11 +78,10 @@ class BaseStripeClient implements StripeClientInterface
         }
 
         $this->apiKey = $apiKey;
-        $this->clientId = $clientId;
-
-        $this->apiBase = $apiBase ?: self::DEFAULT_API_BASE;
-        $this->connectBase = $connectBase ?: self::DEFAULT_CONNECT_BASE;
-        $this->filesBase = $filesBase ?: self::DEFAULT_FILES_BASE;
+        $this->clientId = $config['client_id'];
+        $this->apiBase = $config['api_base'];
+        $this->connectBase = $config['connect_base'];
+        $this->filesBase = $config['files_base'];
     }
 
     /**

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -8,9 +8,9 @@ namespace Stripe;
  */
 final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCtorDoesNotThrowIfApiKeyIsNull()
+    public function testCtorDoesNotThrowWhenNoParams()
     {
-        $client = new BaseStripeClient(null);
+        $client = new BaseStripeClient();
         static::assertNotNull($client);
         static::assertNull($client->getApiKey());
     }
@@ -33,7 +33,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 
     public function testRequestWithClientApiKey()
     {
-        $client = new BaseStripeClient('sk_test_client', null, MOCK_URL);
+        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], []);
         static::assertNotNull($charge);
         $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
@@ -43,9 +43,8 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
 
     public function testRequestWithOptsApiKey()
     {
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], ['api_key' => 'sk_test_opts']);
-        static::assertNotNull($charge);
         static::assertNotNull($charge);
         $optsReflector = new \ReflectionProperty(\Stripe\StripeObject::class, '_opts');
         $optsReflector->setAccessible(true);
@@ -57,7 +56,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\AuthenticationException::class);
         $this->expectExceptionMessage('No API key provided.');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], []);
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
@@ -68,7 +67,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#Do not pass a string for request options.#');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], 'foo');
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);
@@ -79,7 +78,7 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Got unexpected keys in options array: foo');
 
-        $client = new BaseStripeClient(null, null, MOCK_URL);
+        $client = new BaseStripeClient(['api_base' => MOCK_URL]);
         $charge = $client->request('get', '/v1/charges/ch_123', [], ['foo' => 'bar']);
         static::assertNotNull($charge);
         static::assertSame('ch_123', $charge->id);

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -21,7 +21,7 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
      */
     public function setUpMockService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         // Testing with CouponService, because testing abstract classes is hard in PHP :/
         $this->service = new \Stripe\Service\CouponService($this->client);
     }

--- a/tests/Stripe/Service/AccountLinkServiceTest.php
+++ b/tests/Stripe/Service/AccountLinkServiceTest.php
@@ -21,7 +21,7 @@ final class AccountLinkServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AccountLinkService($this->client);
     }
 

--- a/tests/Stripe/Service/AccountServiceTest.php
+++ b/tests/Stripe/Service/AccountServiceTest.php
@@ -26,7 +26,7 @@ final class AccountServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AccountService($this->client);
     }
 

--- a/tests/Stripe/Service/ApplePayDomainServiceTest.php
+++ b/tests/Stripe/Service/ApplePayDomainServiceTest.php
@@ -23,7 +23,7 @@ final class ApplePayDomainServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ApplePayDomainService($this->client);
     }
 

--- a/tests/Stripe/Service/ApplicationFeeServiceTest.php
+++ b/tests/Stripe/Service/ApplicationFeeServiceTest.php
@@ -24,7 +24,7 @@ final class ApplicationFeeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ApplicationFeeService($this->client);
     }
 

--- a/tests/Stripe/Service/BalanceServiceTest.php
+++ b/tests/Stripe/Service/BalanceServiceTest.php
@@ -21,7 +21,7 @@ final class BalanceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new BalanceService($this->client);
     }
 

--- a/tests/Stripe/Service/BalanceTransactionServiceTest.php
+++ b/tests/Stripe/Service/BalanceTransactionServiceTest.php
@@ -23,7 +23,7 @@ final class BalanceTransactionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new BalanceTransactionService($this->client);
     }
 

--- a/tests/Stripe/Service/ChargeServiceTest.php
+++ b/tests/Stripe/Service/ChargeServiceTest.php
@@ -23,7 +23,7 @@ final class ChargeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ChargeService($this->client);
     }
 

--- a/tests/Stripe/Service/Checkout/SessionServiceTest.php
+++ b/tests/Stripe/Service/Checkout/SessionServiceTest.php
@@ -23,7 +23,7 @@ final class SessionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SessionService($this->client);
     }
 

--- a/tests/Stripe/Service/CoreServiceFactoryTest.php
+++ b/tests/Stripe/Service/CoreServiceFactoryTest.php
@@ -19,7 +19,7 @@ final class CoreServiceFactoryTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->serviceFactory = new CoreServiceFactory($this->client);
     }
 

--- a/tests/Stripe/Service/CountrySpecServiceTest.php
+++ b/tests/Stripe/Service/CountrySpecServiceTest.php
@@ -23,7 +23,7 @@ final class CountrySpecServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CountrySpecService($this->client);
     }
 

--- a/tests/Stripe/Service/CouponServiceTest.php
+++ b/tests/Stripe/Service/CouponServiceTest.php
@@ -23,7 +23,7 @@ final class CouponServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CouponService($this->client);
     }
 

--- a/tests/Stripe/Service/CreditNoteServiceTest.php
+++ b/tests/Stripe/Service/CreditNoteServiceTest.php
@@ -23,7 +23,7 @@ final class CreditNoteServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CreditNoteService($this->client);
     }
 

--- a/tests/Stripe/Service/CustomerServiceTest.php
+++ b/tests/Stripe/Service/CustomerServiceTest.php
@@ -26,7 +26,7 @@ final class CustomerServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CustomerService($this->client);
     }
 

--- a/tests/Stripe/Service/DisputeServiceTest.php
+++ b/tests/Stripe/Service/DisputeServiceTest.php
@@ -23,7 +23,7 @@ final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new DisputeService($this->client);
     }
 

--- a/tests/Stripe/Service/EphemeralKeyServiceTest.php
+++ b/tests/Stripe/Service/EphemeralKeyServiceTest.php
@@ -23,7 +23,7 @@ final class EphemeralKeyServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EphemeralKeyService($this->client);
     }
 

--- a/tests/Stripe/Service/EventServiceTest.php
+++ b/tests/Stripe/Service/EventServiceTest.php
@@ -23,7 +23,7 @@ final class EventServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EventService($this->client);
     }
 

--- a/tests/Stripe/Service/ExchangeRateServiceTest.php
+++ b/tests/Stripe/Service/ExchangeRateServiceTest.php
@@ -21,7 +21,7 @@ final class ExchangeRateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ExchangeRateService($this->client);
     }
 

--- a/tests/Stripe/Service/FileLinkServiceTest.php
+++ b/tests/Stripe/Service/FileLinkServiceTest.php
@@ -23,7 +23,7 @@ final class FileLinkServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new FileLinkService($this->client);
     }
 

--- a/tests/Stripe/Service/FileServiceTest.php
+++ b/tests/Stripe/Service/FileServiceTest.php
@@ -23,7 +23,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new FileService($this->client);
     }
 
@@ -40,7 +40,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateWithCURLFile()
     {
-        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'files_base' => MOCK_URL]);
         $service = new FileService($client);
 
         $this->expectsRequest(
@@ -62,7 +62,7 @@ final class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateWithFileHandle()
     {
-        $client = new \Stripe\StripeClient('sk_test_123', null, null, null, MOCK_URL);
+        $client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'files_base' => MOCK_URL]);
         $service = new FileService($client);
 
         $this->expectsRequest(

--- a/tests/Stripe/Service/InvoiceItemServiceTest.php
+++ b/tests/Stripe/Service/InvoiceItemServiceTest.php
@@ -23,7 +23,7 @@ final class InvoiceItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new InvoiceItemService($this->client);
     }
 

--- a/tests/Stripe/Service/InvoiceServiceTest.php
+++ b/tests/Stripe/Service/InvoiceServiceTest.php
@@ -23,7 +23,7 @@ final class InvoiceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new InvoiceService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
+++ b/tests/Stripe/Service/Issuing/AuthorizationServiceTest.php
@@ -23,7 +23,7 @@ final class AuthorizationServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new AuthorizationService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/CardServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardServiceTest.php
@@ -23,7 +23,7 @@ final class CardServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CardService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/CardholderServiceTest.php
+++ b/tests/Stripe/Service/Issuing/CardholderServiceTest.php
@@ -23,7 +23,7 @@ final class CardholderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new CardholderService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/DisputeServiceTest.php
+++ b/tests/Stripe/Service/Issuing/DisputeServiceTest.php
@@ -23,7 +23,7 @@ final class DisputeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new DisputeService($this->client);
     }
 

--- a/tests/Stripe/Service/Issuing/TransactionServiceTest.php
+++ b/tests/Stripe/Service/Issuing/TransactionServiceTest.php
@@ -23,7 +23,7 @@ final class TransactionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TransactionService($this->client);
     }
 

--- a/tests/Stripe/Service/MandateServiceTest.php
+++ b/tests/Stripe/Service/MandateServiceTest.php
@@ -23,7 +23,7 @@ final class MandateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new MandateService($this->client);
     }
 

--- a/tests/Stripe/Service/OrderReturnServiceTest.php
+++ b/tests/Stripe/Service/OrderReturnServiceTest.php
@@ -23,7 +23,7 @@ final class OrderReturnServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new OrderReturnService($this->client);
     }
 

--- a/tests/Stripe/Service/OrderServiceTest.php
+++ b/tests/Stripe/Service/OrderServiceTest.php
@@ -23,7 +23,7 @@ final class OrderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new OrderService($this->client);
     }
 

--- a/tests/Stripe/Service/PaymentIntentServiceTest.php
+++ b/tests/Stripe/Service/PaymentIntentServiceTest.php
@@ -23,7 +23,7 @@ final class PaymentIntentServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PaymentIntentService($this->client);
     }
 

--- a/tests/Stripe/Service/PaymentMethodServiceTest.php
+++ b/tests/Stripe/Service/PaymentMethodServiceTest.php
@@ -23,7 +23,7 @@ final class PaymentMethodServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PaymentMethodService($this->client);
     }
 

--- a/tests/Stripe/Service/PayoutServiceTest.php
+++ b/tests/Stripe/Service/PayoutServiceTest.php
@@ -23,7 +23,7 @@ final class PayoutServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PayoutService($this->client);
     }
 

--- a/tests/Stripe/Service/PlanServiceTest.php
+++ b/tests/Stripe/Service/PlanServiceTest.php
@@ -23,7 +23,7 @@ final class PlanServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new PlanService($this->client);
     }
 

--- a/tests/Stripe/Service/ProductServiceTest.php
+++ b/tests/Stripe/Service/ProductServiceTest.php
@@ -23,7 +23,7 @@ final class ProductServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ProductService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
+++ b/tests/Stripe/Service/Radar/EarlyFraudWarningServiceTest.php
@@ -23,7 +23,7 @@ final class EarlyFraudWarningServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new EarlyFraudWarningService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListItemServiceTest.php
@@ -23,7 +23,7 @@ final class ValueListItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ValueListItemService($this->client);
     }
 

--- a/tests/Stripe/Service/Radar/ValueListServiceTest.php
+++ b/tests/Stripe/Service/Radar/ValueListServiceTest.php
@@ -23,7 +23,7 @@ final class ValueListServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ValueListService($this->client);
     }
 

--- a/tests/Stripe/Service/RefundServiceTest.php
+++ b/tests/Stripe/Service/RefundServiceTest.php
@@ -23,7 +23,7 @@ final class RefundServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new RefundService($this->client);
     }
 

--- a/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportRunServiceTest.php
@@ -23,7 +23,7 @@ final class ReportRunServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReportRunService($this->client);
     }
 

--- a/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
+++ b/tests/Stripe/Service/Reporting/ReportTypeServiceTest.php
@@ -23,7 +23,7 @@ final class ReportTypeServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReportTypeService($this->client);
     }
 

--- a/tests/Stripe/Service/ReviewServiceTest.php
+++ b/tests/Stripe/Service/ReviewServiceTest.php
@@ -23,7 +23,7 @@ final class ReviewServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReviewService($this->client);
     }
 

--- a/tests/Stripe/Service/SetupIntentServiceTest.php
+++ b/tests/Stripe/Service/SetupIntentServiceTest.php
@@ -23,7 +23,7 @@ final class SetupIntentServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SetupIntentService($this->client);
     }
 

--- a/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
+++ b/tests/Stripe/Service/Sigma/ScheduledQueryRunServiceTest.php
@@ -23,7 +23,7 @@ final class ScheduledQueryRunServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ScheduledQueryRunService($this->client);
     }
 

--- a/tests/Stripe/Service/SkuServiceTest.php
+++ b/tests/Stripe/Service/SkuServiceTest.php
@@ -23,7 +23,7 @@ final class SkuServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SkuService($this->client);
     }
 

--- a/tests/Stripe/Service/SourceServiceTest.php
+++ b/tests/Stripe/Service/SourceServiceTest.php
@@ -23,7 +23,7 @@ final class SourceServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SourceService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionItemServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionItemServiceTest.php
@@ -23,7 +23,7 @@ final class SubscriptionItemServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionItemService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionScheduleServiceTest.php
@@ -24,7 +24,7 @@ final class SubscriptionScheduleServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionScheduleService($this->client);
     }
 

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -23,7 +23,7 @@ final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new SubscriptionService($this->client);
     }
 

--- a/tests/Stripe/Service/TaxRateServiceTest.php
+++ b/tests/Stripe/Service/TaxRateServiceTest.php
@@ -23,7 +23,7 @@ final class TaxRateServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TaxRateService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ConnectionTokenServiceTest.php
@@ -21,7 +21,7 @@ final class ConnectionTokenServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ConnectionTokenService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/LocationServiceTest.php
+++ b/tests/Stripe/Service/Terminal/LocationServiceTest.php
@@ -23,7 +23,7 @@ final class LocationServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new LocationService($this->client);
     }
 

--- a/tests/Stripe/Service/Terminal/ReaderServiceTest.php
+++ b/tests/Stripe/Service/Terminal/ReaderServiceTest.php
@@ -23,7 +23,7 @@ final class ReaderServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new ReaderService($this->client);
     }
 

--- a/tests/Stripe/Service/TokenServiceTest.php
+++ b/tests/Stripe/Service/TokenServiceTest.php
@@ -23,7 +23,7 @@ final class TokenServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TokenService($this->client);
     }
 

--- a/tests/Stripe/Service/TopupServiceTest.php
+++ b/tests/Stripe/Service/TopupServiceTest.php
@@ -23,7 +23,7 @@ final class TopupServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TopupService($this->client);
     }
 

--- a/tests/Stripe/Service/TransferServiceTest.php
+++ b/tests/Stripe/Service/TransferServiceTest.php
@@ -24,7 +24,7 @@ final class TransferServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new TransferService($this->client);
     }
 

--- a/tests/Stripe/Service/WebhookEndpointServiceTest.php
+++ b/tests/Stripe/Service/WebhookEndpointServiceTest.php
@@ -23,7 +23,7 @@ final class WebhookEndpointServiceTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUpService()
     {
-        $this->client = new \Stripe\StripeClient('sk_test_123', null, MOCK_URL);
+        $this->client = new \Stripe\StripeClient(['api_key' => 'sk_test_123', 'api_base' => MOCK_URL]);
         $this->service = new WebhookEndpointService($this->client);
     }
 


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 
cc @stripe/api-libraries 

Change the `StripeClient` constructor to expose a simpler API.

The new constructor takes a single argument, which can be a string (the API key) or an array with various configuration values.

In most cases, users will use the string form:
```php
$stripe = new \Stripe\StripeClient('sk_test_123');
```

If needed, it's easy to pass "advanced" configuration settings:
```php
$stripe = new \Stripe\StripeClient([
    'api_key' => 'sk_test_123',
    'client_id' => 'ca_123',
]);
```

The configuration array approach is used by other PHP libraries, including Guzzle, the most popular PHP HTTP client library (https://github.com/guzzle/guzzle/blob/1cdd69a0cd361ee8b6ba5584e45db80c0ea8b31c/src/Client.php#L51). The main downside is that there is no standard PHPDoc syntax for defining the shape of the array, but I think PHPStan and other static analyzer tools are working on something like this, and it's not _that_ bad to just use freeform text to expose the various configuration keys and their expected types.
