### PR TITLE
Pin PHP-CS-Fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php-coveralls/php-coveralls": "^2.1",
     "squizlabs/php_codesniffer": "^3.3",
     "symfony/process": "~3.4",
-    "friendsofphp/php-cs-fixer": "^2.15"
+    "friendsofphp/php-cs-fixer": "2.16.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Pin PHP-CS-Fixer to a specific version to avoid builds suddenly failing when a new version is released.
