### PR TITLE
Services: null as emptystring

### DIFF
--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -32,9 +32,22 @@ abstract class AbstractService
         return $this->client;
     }
 
+    private static function formatParams($params)
+    {
+      $formatted = [];
+      foreach ($params as $k => $v) {
+        if (null === $v) {
+          $formatted[$k] = "";
+        } else {
+          $formatted[$k] = $v;
+        }
+      }
+      return $formatted;
+    }
+
     protected function request($method, $path, $params, $opts)
     {
-        return $this->getClient()->request($method, $path, $params, $opts);
+        return $this->getClient()->request($method, $path, static::formatParams($params), $opts);
     }
 
     protected function buildPath($basePath, ...$ids)

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -26,6 +26,14 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         $this->service = new \Stripe\Service\CouponService($this->client);
     }
 
+    public function testNullGetsEmptyStringified()
+    {
+      $this->expectException(\Stripe\Exception\InvalidRequestException::class);
+      $this->service->update("id", [
+        "doesnotexist" => null
+      ]);
+    }
+
     public function testRetrieveThrowsIfIdNullIsNull()
     {
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);


### PR DESCRIPTION
r? @ob-stripe 
For resource-style PHP methods, we ignore any `null` value that is sent inside `$params`. For service-style PHP methods this is no longer necessary because we do not support `->save`, and we should understand that a null param is an instruction to unset the field in question -- which our API supports through sending an empty string. This pull request changes `AbstractServiceMethod` so that all incoming null params are translated to empty strings.
