### PR TITLE
Services bugfix: handle null properly on arrays

### DIFF
--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -40,7 +40,7 @@ abstract class AbstractService
      *
      * @param null|array $params
      */
-    public static function formatParams($params)
+    private static function formatParams($params)
     {
         if (null === $params) {
             return null;

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -40,14 +40,17 @@ abstract class AbstractService
      *
      * @param null|array $params
      */
-    private static function formatParams($params)
+    public static function formatParams($params)
     {
         if (null === $params) {
             return $params;
         }
+
         $formatted = [];
         foreach ($params as $k => $v) {
-            if (null === $v) {
+            if (\is_array($v)) {
+                $formatted[$k] = static::formatParams($v);
+            } elseif (null === $v) {
                 $formatted[$k] = '';
             } else {
                 $formatted[$k] = $v;

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -43,21 +43,15 @@ abstract class AbstractService
     public static function formatParams($params)
     {
         if (null === $params) {
-            return $params;
+            return null;
         }
-
-        $formatted = [];
-        foreach ($params as $k => $v) {
-            if (\is_array($v)) {
-                $formatted[$k] = static::formatParams($v);
-            } elseif (null === $v) {
-                $formatted[$k] = '';
-            } else {
-                $formatted[$k] = $v;
+        \array_walk_recursive($params, function (&$value, $key) {
+            if (null === $value) {
+                $value = '';
             }
-        }
+        });
 
-        return $formatted;
+        return $params;
     }
 
     protected function request($method, $path, $params, $opts)

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -57,4 +57,16 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->retrieve(' ');
     }
+
+    public function testFormatParams()
+    {
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => null]);
+        static::assertTrue('' === $result['foo']);
+        static::assertTrue(null !== $result['foo']);
+
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1]]);
+        static::assertTrue('' === $result['foo']['bar']);
+        static::assertTrue(null !== $result['foo']['bar']);
+        static::assertTrue(1 === $result['foo']['baz']);
+    }
 }

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -68,5 +68,11 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         static::assertTrue('' === $result['foo']['bar']);
         static::assertTrue(null !== $result['foo']['bar']);
         static::assertTrue(1 === $result['foo']['baz']);
+
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ["bar", null, null, "baz"]]);
+        static::assertTrue('bar' === $result['foo'][0]);
+        static::assertTrue('' === $result['foo'][1]);
+        static::assertTrue('' === $result['foo'][2]);
+        static::assertTrue('baz' === $result['foo'][3]);
     }
 }

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -26,6 +26,15 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         $this->service = new \Stripe\Service\CouponService($this->client);
     }
 
+    /**
+     * @before
+     */
+    public function setUpReflectors()
+    {
+      $this->formatParamsReflector = new \ReflectionMethod(\Stripe\Service\AbstractService::class, 'formatParams');
+      $this->formatParamsReflector->setAccessible(true);
+    }
+
     public function testNullGetsEmptyStringified()
     {
         $this->expectException(\Stripe\Exception\InvalidRequestException::class);
@@ -60,18 +69,18 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testFormatParams()
     {
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => null]);
+        $result = $this->formatParamsReflector->invoke(null, ['foo' => null]);
         static::assertTrue('' === $result['foo']);
         static::assertTrue(null !== $result['foo']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1, 'nest' => ['triplynestednull' => null, 'triplynestednonnull' => 1]]]);
+        $result = $this->formatParamsReflector->invoke(null, ['foo' => ['bar' => null, 'baz' => 1, 'nest' => ['triplynestednull' => null, 'triplynestednonnull' => 1]]]);
         static::assertTrue('' === $result['foo']['bar']);
         static::assertTrue(null !== $result['foo']['bar']);
         static::assertTrue(1 === $result['foo']['baz']);
         static::assertTrue('' === $result['foo']['nest']['triplynestednull']);
         static::assertTrue(1 === $result['foo']['nest']['triplynestednonnull']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['zero', null, null, 'three'], 'toplevelnull' => null, 'toplevelnonnull' => 4]);
+        $result = $this->formatParamsReflector->invoke(null, ['foo' => ['zero', null, null, 'three'], 'toplevelnull' => null, 'toplevelnonnull' => 4]);
         static::assertTrue('zero' === $result['foo'][0]);
         static::assertTrue('' === $result['foo'][1]);
         static::assertTrue('' === $result['foo'][2]);

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -64,15 +64,19 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         static::assertTrue('' === $result['foo']);
         static::assertTrue(null !== $result['foo']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1]]);
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1, 'nest' => ["triplynestednull" => null, "triplynestednonnull" => 1]]]);
         static::assertTrue('' === $result['foo']['bar']);
         static::assertTrue(null !== $result['foo']['bar']);
         static::assertTrue(1 === $result['foo']['baz']);
+        static::assertTrue('' === $result['foo']['nest']['triplynestednull']);
+        static::assertTrue(1 === $result['foo']['nest']['triplynestednonnull']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ["bar", null, null, "baz"]]);
-        static::assertTrue('bar' === $result['foo'][0]);
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ["zero", null, null, "three"], 'toplevelnull' => null, 'toplevelnonnull' => 4]);
+        static::assertTrue('zero' === $result['foo'][0]);
         static::assertTrue('' === $result['foo'][1]);
         static::assertTrue('' === $result['foo'][2]);
-        static::assertTrue('baz' === $result['foo'][3]);
+        static::assertTrue('three' === $result['foo'][3]);
+        static::assertTrue('' === $result['toplevelnull']);
+        static::assertTrue(4 === $result['toplevelnonnull']);
     }
 }

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -16,6 +16,9 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
     /** @var CouponService */
     private $service;
 
+    /** @var \ReflectionMethod */
+    private $formatParamsReflector;
+
     /**
      * @before
      */

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -64,14 +64,14 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
         static::assertTrue('' === $result['foo']);
         static::assertTrue(null !== $result['foo']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1, 'nest' => ["triplynestednull" => null, "triplynestednonnull" => 1]]]);
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['bar' => null, 'baz' => 1, 'nest' => ['triplynestednull' => null, 'triplynestednonnull' => 1]]]);
         static::assertTrue('' === $result['foo']['bar']);
         static::assertTrue(null !== $result['foo']['bar']);
         static::assertTrue(1 === $result['foo']['baz']);
         static::assertTrue('' === $result['foo']['nest']['triplynestednull']);
         static::assertTrue(1 === $result['foo']['nest']['triplynestednonnull']);
 
-        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ["zero", null, null, "three"], 'toplevelnull' => null, 'toplevelnonnull' => 4]);
+        $result = \Stripe\Service\AbstractService::formatParams(['foo' => ['zero', null, null, 'three'], 'toplevelnull' => null, 'toplevelnonnull' => 4]);
         static::assertTrue('zero' === $result['foo'][0]);
         static::assertTrue('' === $result['foo'][1]);
         static::assertTrue('' === $result['foo'][2]);

--- a/tests/Stripe/Service/AbstractServiceTest.php
+++ b/tests/Stripe/Service/AbstractServiceTest.php
@@ -31,8 +31,8 @@ final class AbstractServiceTest extends \PHPUnit\Framework\TestCase
      */
     public function setUpReflectors()
     {
-      $this->formatParamsReflector = new \ReflectionMethod(\Stripe\Service\AbstractService::class, 'formatParams');
-      $this->formatParamsReflector->setAccessible(true);
+        $this->formatParamsReflector = new \ReflectionMethod(\Stripe\Service\AbstractService::class, 'formatParams');
+        $this->formatParamsReflector->setAccessible(true);
     }
 
     public function testNullGetsEmptyStringified()


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 
With PHP services, sending `null` on a method's params is translated to an empty string when it is sent to the API, to cause the API to unset that field. This was only working properly at the top level. This PR causes it to work correctly for nested fields.
