### PR TITLE
Add support for `ae_trn`, `cl_tin` and `sa_vat` as `type` on `TaxId`

### DIFF
--- a/lib/LineItem.php
+++ b/lib/LineItem.php
@@ -13,7 +13,7 @@ namespace Stripe;
  * @property string $description An arbitrary string attached to the object. Often useful for displaying to users. Defaults to product name.
  * @property \Stripe\Price $price <p>Prices define the unit cost, currency, and (optional) billing cycle for both recurring and one-time purchases of products. <a href="https://stripe.com/docs/api#products">Products</a> help you track inventory or provisioning, and prices help you track payment terms. Different physical goods or levels of service should be represented by products, and pricing options should be represented by prices. This approach lets you change prices without having to change your provisioning scheme.</p><p>For example, you might have a single &quot;gold&quot; product that has prices for $10/month, $100/year, and €9 once.</p><p>Related guides: <a href="https://stripe.com/docs/billing/subscriptions/set-up-subscription">Set up a subscription</a>, <a href="https://stripe.com/docs/billing/invoices/create">create an invoice</a>, and more about <a href="https://stripe.com/docs/billing/prices-guide">products and prices</a>.</p>
  * @property null|int $quantity The quantity of products being purchased.
- * @property null|\Stripe\StripeObject[] $taxes The taxes applied to the line item.
+ * @property \Stripe\StripeObject[] $taxes The taxes applied to the line item.
  */
 class LineItem extends ApiResource
 {

--- a/lib/TaxId.php
+++ b/lib/TaxId.php
@@ -16,7 +16,7 @@ namespace Stripe;
  * @property int $created Time at which the object was created. Measured in seconds since the Unix epoch.
  * @property string|\Stripe\Customer $customer ID of the customer.
  * @property bool $livemode Has the value <code>true</code> if the object exists in live mode or the value <code>false</code> if the object exists in test mode.
- * @property string $type Type of the tax ID, one of <code>au_abn</code>, <code>br_cnpj</code>, <code>br_cpf</code>, <code>ca_bn</code>, <code>ca_qst</code>, <code>ch_vat</code>, <code>es_cif</code>, <code>eu_vat</code>, <code>hk_br</code>, <code>in_gst</code>, <code>jp_cn</code>, <code>kr_brn</code>, <code>li_uid</code>, <code>mx_rfc</code>, <code>my_itn</code>, <code>my_sst</code>, <code>no_vat</code>, <code>nz_gst</code>, <code>ru_inn</code>, <code>sg_gst</code>, <code>sg_uen</code>, <code>th_vat</code>, <code>tw_vat</code>, <code>us_ein</code>, or <code>za_vat</code>. Note that some legacy tax IDs have type <code>unknown</code>
+ * @property string $type Type of the tax ID, one of <code>ae_trn</code>, <code>au_abn</code>, <code>br_cnpj</code>, <code>br_cpf</code>, <code>ca_bn</code>, <code>ca_qst</code>, <code>ch_vat</code>, <code>cl_tin</code>, <code>es_cif</code>, <code>eu_vat</code>, <code>hk_br</code>, <code>in_gst</code>, <code>jp_cn</code>, <code>kr_brn</code>, <code>li_uid</code>, <code>mx_rfc</code>, <code>my_itn</code>, <code>my_sst</code>, <code>no_vat</code>, <code>nz_gst</code>, <code>ru_inn</code>, <code>sa_vat</code>, <code>sg_gst</code>, <code>sg_uen</code>, <code>th_vat</code>, <code>tw_vat</code>, <code>us_ein</code>, or <code>za_vat</code>. Note that some legacy tax IDs have type <code>unknown</code>
  * @property string $value Value of the tax ID.
  * @property \Stripe\StripeObject $verification
  */
@@ -26,12 +26,14 @@ class TaxId extends ApiResource
 
     use ApiOperations\Delete;
 
+    const TYPE_AE_TRN = 'ae_trn';
     const TYPE_AU_ABN = 'au_abn';
     const TYPE_BR_CNPJ = 'br_cnpj';
     const TYPE_BR_CPF = 'br_cpf';
     const TYPE_CA_BN = 'ca_bn';
     const TYPE_CA_QST = 'ca_qst';
     const TYPE_CH_VAT = 'ch_vat';
+    const TYPE_CL_TIN = 'cl_tin';
     const TYPE_ES_CIF = 'es_cif';
     const TYPE_EU_VAT = 'eu_vat';
     const TYPE_HK_BR = 'hk_br';
@@ -45,6 +47,7 @@ class TaxId extends ApiResource
     const TYPE_NO_VAT = 'no_vat';
     const TYPE_NZ_GST = 'nz_gst';
     const TYPE_RU_INN = 'ru_inn';
+    const TYPE_SA_VAT = 'sa_vat';
     const TYPE_SG_GST = 'sg_gst';
     const TYPE_SG_UEN = 'sg_uen';
     const TYPE_TH_VAT = 'th_vat';


### PR DESCRIPTION
Codegen for openapi cd33b40

r? @cjavilla-stripe 
cc @stripe/api-libraries 