### PR TITLE
Remove extra array_keys() call.

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -234,7 +234,6 @@ class BaseStripeClient implements StripeClientInterface
         }
 
         // check absence of extra keys
-        $validConfigKeys = \array_keys($this->getDefaultConfig());
         $extraConfigKeys = \array_diff(\array_keys($config), \array_keys($this->getDefaultConfig()));
         if (!empty($extraConfigKeys)) {
             throw new \Stripe\Exception\InvalidArgumentException('Found unknown key(s) in configuration array: ' . \implode(',', $extraConfigKeys));


### PR DESCRIPTION
This seems redundant, since the variable isn't being used.