### PR TITLE
Add pending update constants

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -63,6 +63,10 @@ class Subscription extends ApiResource
     const STATUS_TRIALING = 'trialing';
     const STATUS_UNPAID = 'unpaid';
 
+    const ALLOW_INCOMPLETE = 'allow_incomplete';
+    const ERROR_IF_INCOMPLETE = 'error_if_incomplete';
+    const PENDING_IF_INCOMPLETE = 'pending_if_incomplete';
+
     use ApiOperations\Delete {
         delete as protected _delete;
       }


### PR DESCRIPTION
I wasn't sure where to send this to but thought the subscription object was probably the right place. This PR adds the different values for the `payment_behavior` field to accommodate pending updates: https://stripe.com/docs/billing/subscriptions/pending-updates