### PR TITLE
fix autopagination for Service

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -151,16 +151,16 @@ class BaseStripeClient implements StripeClientInterface
      */
     public function requestCollection($method, $path, $params, $opts)
     {
-         $obj = $this->request($method, $path, $params, $opts);
-         if (!($obj instanceof \Stripe\Collection)) {
-             $received_class = \get_class($obj);
-             $msg = "Expected to receive `Stripe\Collection` object from Stripe API. Instead received `{$received_class}`.";
-             throw new \Stripe\Exception\UnexpectedValueException
-             ($msg);
-         }
-         $obj->setFilters($params);
+        $obj = $this->request($method, $path, $params, $opts);
+        if (!($obj instanceof \Stripe\Collection)) {
+            $received_class = \get_class($obj);
+            $msg = "Expected to receive `Stripe\\Collection` object from Stripe API. Instead received `{$received_class}`.";
 
-         return $obj;
+            throw new \Stripe\Exception\UnexpectedValueException($msg);
+        }
+        $obj->setFilters($params);
+
+        return $obj;
     }
 
     /**

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -152,6 +152,12 @@ class BaseStripeClient implements StripeClientInterface
     public function requestCollection($method, $path, $params, $opts)
     {
          $obj = $this->request($method, $path, $params, $opts);
+         if (!($obj instanceof \Stripe\Collection)) {
+             $received_class = \get_class($obj);
+             $msg = "Expected to receive `Stripe\Collection` object from Stripe API. Instead received `{$received_class}`.";
+             throw new \Stripe\Exception\UnexpectedValueException
+             ($msg);
+         }
          $obj->setFilters($params);
 
          return $obj;

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -140,6 +140,24 @@ class BaseStripeClient implements StripeClientInterface
     }
 
     /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\Collection of ApiResources
+     */
+    public function requestCollection($method, $path, $params, $opts)
+    {
+         $obj = $this->request($method, $path, $params, $opts);
+         $obj->setFilters($params);
+
+         return $obj;
+    }
+
+    /**
      * @param \Stripe\Util\RequestOptions $opts
      *
      * @throws \Stripe\Exception\AuthenticationException

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -59,6 +59,11 @@ abstract class AbstractService
         return $this->getClient()->request($method, $path, static::formatParams($params), $opts);
     }
 
+    protected function requestCollection($method, $path, $params, $opts)
+    {
+        return $this->getClient()->requestCollection($method, $path, static::formatParams($params), $opts);
+    }
+
     protected function buildPath($basePath, ...$ids)
     {
         foreach ($ids as $id) {

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -17,7 +17,7 @@ class AccountService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/accounts', $params, $opts);
+        return $this->requestCollection('get', '/v1/accounts', $params, $opts);
     }
 
     /**
@@ -35,7 +35,7 @@ class AccountService extends \Stripe\Service\AbstractService
      */
     public function allCapabilities($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/accounts/%s/capabilities', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/accounts/%s/capabilities', $parentId), $params, $opts);
     }
 
     /**
@@ -51,7 +51,7 @@ class AccountService extends \Stripe\Service\AbstractService
      */
     public function allExternalAccounts($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/accounts/%s/external_accounts', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/accounts/%s/external_accounts', $parentId), $params, $opts);
     }
 
     /**
@@ -69,7 +69,7 @@ class AccountService extends \Stripe\Service\AbstractService
      */
     public function allPersons($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/accounts/%s/persons', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/accounts/%s/persons', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/ApplePayDomainService.php
+++ b/lib/Service/ApplePayDomainService.php
@@ -16,7 +16,7 @@ class ApplePayDomainService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/apple_pay/domains', $params, $opts);
+        return $this->requestCollection('get', '/v1/apple_pay/domains', $params, $opts);
     }
 
     /**

--- a/lib/Service/ApplicationFeeService.php
+++ b/lib/Service/ApplicationFeeService.php
@@ -17,7 +17,7 @@ class ApplicationFeeService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/application_fees', $params, $opts);
+        return $this->requestCollection('get', '/v1/application_fees', $params, $opts);
     }
 
     /**
@@ -37,7 +37,7 @@ class ApplicationFeeService extends \Stripe\Service\AbstractService
      */
     public function allRefunds($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/application_fees/%s/refunds', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/application_fees/%s/refunds', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/BalanceTransactionService.php
+++ b/lib/Service/BalanceTransactionService.php
@@ -21,7 +21,7 @@ class BalanceTransactionService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/balance_transactions', $params, $opts);
+        return $this->requestCollection('get', '/v1/balance_transactions', $params, $opts);
     }
 
     /**

--- a/lib/Service/ChargeService.php
+++ b/lib/Service/ChargeService.php
@@ -17,7 +17,7 @@ class ChargeService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/charges', $params, $opts);
+        return $this->requestCollection('get', '/v1/charges', $params, $opts);
     }
 
     /**

--- a/lib/Service/Checkout/SessionService.php
+++ b/lib/Service/Checkout/SessionService.php
@@ -16,7 +16,7 @@ class SessionService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/checkout/sessions', $params, $opts);
+        return $this->requestCollection('get', '/v1/checkout/sessions', $params, $opts);
     }
 
     /**
@@ -35,7 +35,7 @@ class SessionService extends \Stripe\Service\AbstractService
      */
     public function allLineItems($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/checkout/sessions/%s/line_items', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/checkout/sessions/%s/line_items', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/CountrySpecService.php
+++ b/lib/Service/CountrySpecService.php
@@ -16,7 +16,7 @@ class CountrySpecService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/country_specs', $params, $opts);
+        return $this->requestCollection('get', '/v1/country_specs', $params, $opts);
     }
 
     /**

--- a/lib/Service/CouponService.php
+++ b/lib/Service/CouponService.php
@@ -16,7 +16,7 @@ class CouponService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/coupons', $params, $opts);
+        return $this->requestCollection('get', '/v1/coupons', $params, $opts);
     }
 
     /**

--- a/lib/Service/CreditNoteService.php
+++ b/lib/Service/CreditNoteService.php
@@ -16,7 +16,7 @@ class CreditNoteService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/credit_notes', $params, $opts);
+        return $this->requestCollection('get', '/v1/credit_notes', $params, $opts);
     }
 
     /**
@@ -34,7 +34,7 @@ class CreditNoteService extends \Stripe\Service\AbstractService
      */
     public function allLines($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/credit_notes/%s/lines', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/credit_notes/%s/lines', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -17,7 +17,7 @@ class CustomerService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/customers', $params, $opts);
+        return $this->requestCollection('get', '/v1/customers', $params, $opts);
     }
 
     /**
@@ -34,7 +34,7 @@ class CustomerService extends \Stripe\Service\AbstractService
      */
     public function allBalanceTransactions($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/customers/%s/balance_transactions', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/customers/%s/balance_transactions', $parentId), $params, $opts);
     }
 
     /**
@@ -50,7 +50,7 @@ class CustomerService extends \Stripe\Service\AbstractService
      */
     public function allSources($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/customers/%s/sources', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/customers/%s/sources', $parentId), $params, $opts);
     }
 
     /**
@@ -66,7 +66,7 @@ class CustomerService extends \Stripe\Service\AbstractService
      */
     public function allTaxIds($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/customers/%s/tax_ids', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/customers/%s/tax_ids', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/DisputeService.php
+++ b/lib/Service/DisputeService.php
@@ -16,7 +16,7 @@ class DisputeService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/disputes', $params, $opts);
+        return $this->requestCollection('get', '/v1/disputes', $params, $opts);
     }
 
     /**

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -20,7 +20,7 @@ class EventService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/events', $params, $opts);
+        return $this->requestCollection('get', '/v1/events', $params, $opts);
     }
 
     /**

--- a/lib/Service/ExchangeRateService.php
+++ b/lib/Service/ExchangeRateService.php
@@ -17,7 +17,7 @@ class ExchangeRateService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/exchange_rates', $params, $opts);
+        return $this->requestCollection('get', '/v1/exchange_rates', $params, $opts);
     }
 
     /**

--- a/lib/Service/FileLinkService.php
+++ b/lib/Service/FileLinkService.php
@@ -16,7 +16,7 @@ class FileLinkService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/file_links', $params, $opts);
+        return $this->requestCollection('get', '/v1/file_links', $params, $opts);
     }
 
     /**

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -18,7 +18,7 @@ class FileService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/files', $params, $opts);
+        return $this->requestCollection('get', '/v1/files', $params, $opts);
     }
 
     /**

--- a/lib/Service/InvoiceItemService.php
+++ b/lib/Service/InvoiceItemService.php
@@ -17,7 +17,7 @@ class InvoiceItemService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/invoiceitems', $params, $opts);
+        return $this->requestCollection('get', '/v1/invoiceitems', $params, $opts);
     }
 
     /**

--- a/lib/Service/InvoiceService.php
+++ b/lib/Service/InvoiceService.php
@@ -18,7 +18,7 @@ class InvoiceService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/invoices', $params, $opts);
+        return $this->requestCollection('get', '/v1/invoices', $params, $opts);
     }
 
     /**
@@ -37,7 +37,7 @@ class InvoiceService extends \Stripe\Service\AbstractService
      */
     public function allLines($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/invoices/%s/lines', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/invoices/%s/lines', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/Issuing/AuthorizationService.php
+++ b/lib/Service/Issuing/AuthorizationService.php
@@ -18,7 +18,7 @@ class AuthorizationService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/authorizations', $params, $opts);
+        return $this->requestCollection('get', '/v1/issuing/authorizations', $params, $opts);
     }
 
     /**

--- a/lib/Service/Issuing/CardService.php
+++ b/lib/Service/Issuing/CardService.php
@@ -18,7 +18,7 @@ class CardService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/cards', $params, $opts);
+        return $this->requestCollection('get', '/v1/issuing/cards', $params, $opts);
     }
 
     /**

--- a/lib/Service/Issuing/CardholderService.php
+++ b/lib/Service/Issuing/CardholderService.php
@@ -18,7 +18,7 @@ class CardholderService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/cardholders', $params, $opts);
+        return $this->requestCollection('get', '/v1/issuing/cardholders', $params, $opts);
     }
 
     /**

--- a/lib/Service/Issuing/DisputeService.php
+++ b/lib/Service/Issuing/DisputeService.php
@@ -18,7 +18,7 @@ class DisputeService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/disputes', $params, $opts);
+        return $this->requestCollection('get', '/v1/issuing/disputes', $params, $opts);
     }
 
     /**

--- a/lib/Service/Issuing/TransactionService.php
+++ b/lib/Service/Issuing/TransactionService.php
@@ -18,7 +18,7 @@ class TransactionService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/issuing/transactions', $params, $opts);
+        return $this->requestCollection('get', '/v1/issuing/transactions', $params, $opts);
     }
 
     /**

--- a/lib/Service/OrderReturnService.php
+++ b/lib/Service/OrderReturnService.php
@@ -17,7 +17,7 @@ class OrderReturnService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/order_returns', $params, $opts);
+        return $this->requestCollection('get', '/v1/order_returns', $params, $opts);
     }
 
     /**

--- a/lib/Service/OrderService.php
+++ b/lib/Service/OrderService.php
@@ -17,7 +17,7 @@ class OrderService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/orders', $params, $opts);
+        return $this->requestCollection('get', '/v1/orders', $params, $opts);
     }
 
     /**

--- a/lib/Service/PaymentIntentService.php
+++ b/lib/Service/PaymentIntentService.php
@@ -16,7 +16,7 @@ class PaymentIntentService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/payment_intents', $params, $opts);
+        return $this->requestCollection('get', '/v1/payment_intents', $params, $opts);
     }
 
     /**

--- a/lib/Service/PaymentMethodService.php
+++ b/lib/Service/PaymentMethodService.php
@@ -16,7 +16,7 @@ class PaymentMethodService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/payment_methods', $params, $opts);
+        return $this->requestCollection('get', '/v1/payment_methods', $params, $opts);
     }
 
     /**

--- a/lib/Service/PayoutService.php
+++ b/lib/Service/PayoutService.php
@@ -18,7 +18,7 @@ class PayoutService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/payouts', $params, $opts);
+        return $this->requestCollection('get', '/v1/payouts', $params, $opts);
     }
 
     /**

--- a/lib/Service/PlanService.php
+++ b/lib/Service/PlanService.php
@@ -16,7 +16,7 @@ class PlanService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/plans', $params, $opts);
+        return $this->requestCollection('get', '/v1/plans', $params, $opts);
     }
 
     /**

--- a/lib/Service/PriceService.php
+++ b/lib/Service/PriceService.php
@@ -16,7 +16,7 @@ class PriceService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/prices', $params, $opts);
+        return $this->requestCollection('get', '/v1/prices', $params, $opts);
     }
 
     /**

--- a/lib/Service/ProductService.php
+++ b/lib/Service/ProductService.php
@@ -17,7 +17,7 @@ class ProductService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/products', $params, $opts);
+        return $this->requestCollection('get', '/v1/products', $params, $opts);
     }
 
     /**

--- a/lib/Service/Radar/EarlyFraudWarningService.php
+++ b/lib/Service/Radar/EarlyFraudWarningService.php
@@ -16,7 +16,7 @@ class EarlyFraudWarningService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/radar/early_fraud_warnings', $params, $opts);
+        return $this->requestCollection('get', '/v1/radar/early_fraud_warnings', $params, $opts);
     }
 
     /**

--- a/lib/Service/Radar/ValueListItemService.php
+++ b/lib/Service/Radar/ValueListItemService.php
@@ -18,7 +18,7 @@ class ValueListItemService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/radar/value_list_items', $params, $opts);
+        return $this->requestCollection('get', '/v1/radar/value_list_items', $params, $opts);
     }
 
     /**

--- a/lib/Service/Radar/ValueListService.php
+++ b/lib/Service/Radar/ValueListService.php
@@ -18,7 +18,7 @@ class ValueListService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/radar/value_lists', $params, $opts);
+        return $this->requestCollection('get', '/v1/radar/value_lists', $params, $opts);
     }
 
     /**

--- a/lib/Service/RefundService.php
+++ b/lib/Service/RefundService.php
@@ -19,7 +19,7 @@ class RefundService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/refunds', $params, $opts);
+        return $this->requestCollection('get', '/v1/refunds', $params, $opts);
     }
 
     /**

--- a/lib/Service/Reporting/ReportRunService.php
+++ b/lib/Service/Reporting/ReportRunService.php
@@ -17,7 +17,7 @@ class ReportRunService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/reporting/report_runs', $params, $opts);
+        return $this->requestCollection('get', '/v1/reporting/report_runs', $params, $opts);
     }
 
     /**

--- a/lib/Service/Reporting/ReportTypeService.php
+++ b/lib/Service/Reporting/ReportTypeService.php
@@ -17,7 +17,7 @@ class ReportTypeService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/reporting/report_types', $params, $opts);
+        return $this->requestCollection('get', '/v1/reporting/report_types', $params, $opts);
     }
 
     /**

--- a/lib/Service/ReviewService.php
+++ b/lib/Service/ReviewService.php
@@ -18,7 +18,7 @@ class ReviewService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/reviews', $params, $opts);
+        return $this->requestCollection('get', '/v1/reviews', $params, $opts);
     }
 
     /**

--- a/lib/Service/SetupIntentService.php
+++ b/lib/Service/SetupIntentService.php
@@ -16,7 +16,7 @@ class SetupIntentService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/setup_intents', $params, $opts);
+        return $this->requestCollection('get', '/v1/setup_intents', $params, $opts);
     }
 
     /**

--- a/lib/Service/Sigma/ScheduledQueryRunService.php
+++ b/lib/Service/Sigma/ScheduledQueryRunService.php
@@ -16,7 +16,7 @@ class ScheduledQueryRunService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/sigma/scheduled_query_runs', $params, $opts);
+        return $this->requestCollection('get', '/v1/sigma/scheduled_query_runs', $params, $opts);
     }
 
     /**

--- a/lib/Service/SkuService.php
+++ b/lib/Service/SkuService.php
@@ -17,7 +17,7 @@ class SkuService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/skus', $params, $opts);
+        return $this->requestCollection('get', '/v1/skus', $params, $opts);
     }
 
     /**

--- a/lib/Service/SubscriptionItemService.php
+++ b/lib/Service/SubscriptionItemService.php
@@ -16,7 +16,7 @@ class SubscriptionItemService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/subscription_items', $params, $opts);
+        return $this->requestCollection('get', '/v1/subscription_items', $params, $opts);
     }
 
     /**
@@ -41,7 +41,7 @@ class SubscriptionItemService extends \Stripe\Service\AbstractService
      */
     public function allUsageRecordSummaries($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/subscription_items/%s/usage_record_summaries', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/subscription_items/%s/usage_record_summaries', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/SubscriptionScheduleService.php
+++ b/lib/Service/SubscriptionScheduleService.php
@@ -16,7 +16,7 @@ class SubscriptionScheduleService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/subscription_schedules', $params, $opts);
+        return $this->requestCollection('get', '/v1/subscription_schedules', $params, $opts);
     }
 
     /**

--- a/lib/Service/SubscriptionService.php
+++ b/lib/Service/SubscriptionService.php
@@ -17,7 +17,7 @@ class SubscriptionService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/subscriptions', $params, $opts);
+        return $this->requestCollection('get', '/v1/subscriptions', $params, $opts);
     }
 
     /**

--- a/lib/Service/TaxRateService.php
+++ b/lib/Service/TaxRateService.php
@@ -17,7 +17,7 @@ class TaxRateService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/tax_rates', $params, $opts);
+        return $this->requestCollection('get', '/v1/tax_rates', $params, $opts);
     }
 
     /**

--- a/lib/Service/Terminal/LocationService.php
+++ b/lib/Service/Terminal/LocationService.php
@@ -16,7 +16,7 @@ class LocationService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/terminal/locations', $params, $opts);
+        return $this->requestCollection('get', '/v1/terminal/locations', $params, $opts);
     }
 
     /**

--- a/lib/Service/Terminal/ReaderService.php
+++ b/lib/Service/Terminal/ReaderService.php
@@ -16,7 +16,7 @@ class ReaderService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/terminal/readers', $params, $opts);
+        return $this->requestCollection('get', '/v1/terminal/readers', $params, $opts);
     }
 
     /**

--- a/lib/Service/TopupService.php
+++ b/lib/Service/TopupService.php
@@ -16,7 +16,7 @@ class TopupService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/topups', $params, $opts);
+        return $this->requestCollection('get', '/v1/topups', $params, $opts);
     }
 
     /**

--- a/lib/Service/TransferService.php
+++ b/lib/Service/TransferService.php
@@ -18,7 +18,7 @@ class TransferService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/transfers', $params, $opts);
+        return $this->requestCollection('get', '/v1/transfers', $params, $opts);
     }
 
     /**
@@ -38,7 +38,7 @@ class TransferService extends \Stripe\Service\AbstractService
      */
     public function allReversals($parentId, $params = null, $opts = null)
     {
-        return $this->request('get', $this->buildPath('/v1/transfers/%s/reversals', $parentId), $params, $opts);
+        return $this->requestCollection('get', $this->buildPath('/v1/transfers/%s/reversals', $parentId), $params, $opts);
     }
 
     /**

--- a/lib/Service/WebhookEndpointService.php
+++ b/lib/Service/WebhookEndpointService.php
@@ -16,7 +16,7 @@ class WebhookEndpointService extends \Stripe\Service\AbstractService
      */
     public function all($params = null, $opts = null)
     {
-        return $this->request('get', '/v1/webhook_endpoints', $params, $opts);
+        return $this->requestCollection('get', '/v1/webhook_endpoints', $params, $opts);
     }
 
     /**

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -168,7 +168,6 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $charges = $client->requestCollection('get', '/v1/charges', [], []);
         static::assertNotNull($charges);
         static::assertSame('sk_test_client', $this->optsReflector->getValue($charges)->apiKey);
-
     }
 
     public function testRequestCollectionThrowsForNonList()

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -161,4 +161,22 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         static::assertNotNull($charge);
         static::assertSame('acct_456', $this->optsReflector->getValue($charge)->headers['Stripe-Account']);
     }
+
+    public function testRequestCollectionWithClientApiKey()
+    {
+        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
+        $charges = $client->requestCollection('get', '/v1/charges', [], []);
+        static::assertNotNull($charges);
+        static::assertSame('sk_test_client', $this->optsReflector->getValue($charges)->apiKey);
+
+    }
+
+    public function testRequestCollectionThrowsForNonList()
+    {
+        $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected to receive `Stripe\Collection` object from Stripe API. Instead received `Stripe\Charge`.');
+
+        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
+        $client->requestCollection('get', '/v1/charges/ch_123', [], []);
+    }
 }

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -45,13 +45,13 @@ final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
             '/v1/subscriptions'
         );
         $resources = $this->service->all([
-          'status' => 'all',
-          'limit' => 100,
+            'status' => 'all',
+            'limit' => 100,
         ]);
         $filters = $resources->getFilters();
-        static::assertEquals($filters, [
-          'status' => 'all',
-          'limit' => 100,
+        static::assertSame($filters, [
+            'status' => 'all',
+            'limit' => 100,
         ]);
     }
 

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -38,6 +38,24 @@ final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
         static::assertInstanceOf(\Stripe\Subscription::class, $resources->data[0]);
     }
 
+    public function testAllPagination()
+    {
+        $this->expectsRequest(
+            'get',
+            '/v1/subscriptions'
+        );
+        $resources = $this->service->all([
+          'status' => 'all',
+          'limit' => 100,
+        ]);
+        var_dump($resources->getFilters());
+        $filters = $resources->getFilters();
+        static::assertEquals($filters, [
+          'status' => 'all',
+          'limit' => 100,
+        ]);
+    }
+
     public function testCancel()
     {
         $this->expectsRequest(

--- a/tests/Stripe/Service/SubscriptionServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionServiceTest.php
@@ -48,7 +48,6 @@ final class SubscriptionServiceTest extends \PHPUnit\Framework\TestCase
           'status' => 'all',
           'limit' => 100,
         ]);
-        var_dump($resources->getFilters());
         $filters = $resources->getFilters();
         static::assertEquals($filters, [
           'status' => 'all',


### PR DESCRIPTION
Should fix #939.

Briefly, `autoPagingIterator` expects the `filters` property on `Stripe\Collection` to be set from `$params`.

This was happening before in `\ApiOperations\All::all` https://github.com/stripe/stripe-php/blob/master/lib/ApiOperations/All.php#L33, but isn't done in
`BaseStripeClient#request`

https://github.com/stripe/stripe-php/blob/master/lib/BaseStripeClient.php#L129-L140.

This PR introduces `BaseStripeClient#requestCollection` (and `AbstractService#requestCollection`, to call it), which simply calls `#request` and then `->setFilters($params)`, and then we updated the "SubscriptionService" to use it.

ptal @ob-stripe to see if this seems right (feel free to bikeshed on naming)

I prefer adding a separate #requestCollection method rather than adding the call conditionally to `#request` -- since `->all` should always return a `\Stripe\Collection`, it seems better that it call a method guaranteed to return the narrower `\Stripe\Collection` rather than the broader `\Stripe\Object`