### PR TITLE
Add multiple constants missing for `Event`

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -83,6 +83,8 @@ class Event extends ApiResource
     const CHARGE_DISPUTE_FUNDS_WITHDRAWN = 'charge.dispute.funds_withdrawn';
     const CHARGE_DISPUTE_UPDATED = 'charge.dispute.updated';
     const CHARGE_REFUND_UPDATED = 'charge.refund.updated';
+    const CHECKOUT_SESSION_ASYNC_PAYMENT_FAILED = 'checkout.session.async_payment_failed';
+    const CHECKOUT_SESSION_ASYNC_PAYMENT_SUCCEEDED = 'checkout.session.async_payment_succeeded';
     const CHECKOUT_SESSION_COMPLETED = 'checkout.session.completed';
     const COUPON_CREATED = 'coupon.created';
     const COUPON_DELETED = 'coupon.deleted';
@@ -109,6 +111,7 @@ class Event extends ApiResource
     const INVOICE_DELETED = 'invoice.deleted';
     const INVOICE_FINALIZED = 'invoice.finalized';
     const INVOICE_MARKED_UNCOLLECTIBLE = 'invoice.marked_uncollectible';
+    const INVOICE_PAID = 'invoice.paid';
     const INVOICE_PAYMENT_ACTION_REQUIRED = 'invoice.payment_action_required';
     const INVOICE_PAYMENT_FAILED = 'invoice.payment_failed';
     const INVOICE_PAYMENT_SUCCEEDED = 'invoice.payment_succeeded';
@@ -128,6 +131,7 @@ class Event extends ApiResource
     const ISSUING_CARDHOLDER_CREATED = 'issuing_cardholder.created';
     const ISSUING_CARDHOLDER_UPDATED = 'issuing_cardholder.updated';
     const ISSUING_DISPUTE_CREATED = 'issuing_dispute.created';
+    const ISSUING_DISPUTE_FUNDS_REINSTATED = 'issuing_dispute.funds_reinstated';
     const ISSUING_DISPUTE_UPDATED = 'issuing_dispute.updated';
     const ISSUING_TRANSACTION_CREATED = 'issuing_transaction.created';
     const ISSUING_TRANSACTION_UPDATED = 'issuing_transaction.updated';
@@ -157,6 +161,9 @@ class Event extends ApiResource
     const PLAN_CREATED = 'plan.created';
     const PLAN_DELETED = 'plan.deleted';
     const PLAN_UPDATED = 'plan.updated';
+    const PRICE_CREATED = 'price.created';
+    const PRICE_DELETED = 'price.deleted';
+    const PRICE_UPDATED = 'price.updated';
     const PRODUCT_CREATED = 'product.created';
     const PRODUCT_DELETED = 'product.deleted';
     const PRODUCT_UPDATED = 'product.updated';


### PR DESCRIPTION
We automatically generate stripe-php and I had missed we don't properly handle the list of events yet. So this PR adds the new one `invoice.paid` but also others I missed. I used the history of the types on stripe-node [here](https://github.com/stripe/stripe-node/commits/master/types/2020-03-02/WebhookEndpoints.d.ts) to find what's missing

r? @paulasjes-stripe 
cc @stripe/api-libraries 