### PR TITLE
Add PAYMENT_BEHAVIOR enum to Subscription resource

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -55,6 +55,10 @@ class Subscription extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
+    const PAYMENT_BEHAVIOR_ALLOW_INCOMPLETE = 'allow_incomplete';
+    const PAYMENT_BEHAVIOR_ERROR_IF_INCOMPLETE = 'error_if_incomplete';
+    const PAYMENT_BEHAVIOR_PENDING_IF_INCOMPLETE = 'pending_if_incomplete';
+
     const STATUS_ACTIVE = 'active';
     const STATUS_CANCELED = 'canceled';
     const STATUS_INCOMPLETE = 'incomplete';


### PR DESCRIPTION
Fixes #941, but using enum names compatible with codegen.