### PR TITLE
Suggestion: Add Decoding Charset option to Webhook::constructEvent

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -39,7 +39,7 @@ abstract class Webhook
             throw new Exception\UnexpectedValueException($msg);
         }
 
-        if (function_exists('mb_convert_encoding') && $charset !== 'UTF-8') {
+        if (version_compare(PHP_VERSION, '7.2.0') >= 0 && function_exists('mb_convert_encoding') && $charset !== 'UTF-8') {
             $deData = mb_convert_encoding($data, $charset);
             if ($deData !== null && $deData !== $data)
                 $data = $deData;

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -39,8 +39,8 @@ abstract class Webhook
             throw new Exception\UnexpectedValueException($msg);
         }
 
-        if (version_compare(PHP_VERSION, '7.2.0') >= 0 && function_exists('mb_convert_encoding') && $charset !== 'UTF-8') {
-            $deData = mb_convert_encoding($data, $charset);
+        if (\version_compare(\PHP_VERSION, '7.2', '>=') && \function_exists('mb_convert_encoding') && $charset !== 'UTF-8') {
+            $deData = \mb_convert_encoding($data, $charset);
             if ($deData !== null && $deData !== $data)
                 $data = $deData;
         }


### PR DESCRIPTION
 Because `json_decode()` always returns strings in UTF-8 and because PHP doesn't seamlessly convert between encodings, developers may run into issues with special-character names or addresses sent via Webhook. If mbstring is installed (and PHP is 7.2 or newer), it'd be wonderful to allow `mb_convert_encoding()` to be called before `\lib\Webhook.php`'s `Event::constructFrom()` call. An optional parameter with the desired charset should take care of everything. This pull request is just an example of what I'm suggesting.