### PR TITLE
add `Stripe-Account` to the event object for connect account

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -37,6 +37,8 @@ abstract class Webhook
             throw new Exception\UnexpectedValueException($msg);
         }
 
-        return Event::constructFrom($data);
+        $opts = isset($data['account']) ? ['stripe_account' => $data['account']] : null;
+
+        return Event::constructFrom($data, $opts);
     }
 }

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -2,6 +2,8 @@
 
 namespace Stripe;
 
+use ReflectionClass;
+
 /**
  * @internal
  * @covers \Stripe\Webhook
@@ -13,7 +15,8 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
     const EVENT_PAYLOAD = '{
   "id": "evt_test_webhook",
-  "object": "event"
+  "object": "event",
+  "account": "connect_account_id"
 }';
     const SECRET = 'whsec_test_secret';
 
@@ -37,6 +40,11 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $sigHeader = $this->generateHeader();
         $event = Webhook::constructEvent(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
         static::assertSame('evt_test_webhook', $event->id);
+
+        $reflection = new ReflectionClass($event);
+        $property = $reflection->getProperty('_opts');
+        $property->setAccessible(true);
+        static::assertSame('connect_account_id', $property->getValue($event)->headers['Stripe-Account']);
     }
 
     public function testInvalidJson()


### PR DESCRIPTION
For [connect account](https://stripe.com/connect), The `Stripe-Account` header is missing when converting a webhook payload to a `\Stripe\Event` object, so the following code will report an error.
```php
    $event = Webhook::constructEvent($payload, $signature, $secret);

    /** @var \Stripe\Invoice $stripe_invoice */
    $stripe_invoice = $event->data->object;

    $stripe_invoice->finalizeInvoice();
```
Error message:
```json
{
    "title": "Unprocessable Entity",
    "detail": {
        "id": [
            "No such invoice: in_xxx"
        ]
    },
    "status": 422,
    "data": [],
    "doc_url": "https:\/\/stripe.com\/docs\/error-codes\/resource-missing"
}
```
