### PR TITLE
Fixing telemetry

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -377,9 +377,11 @@ class ApiRequestor
             $hasFile
         );
 
-        if (isset($rheaders['request-id'], $rheaders['request-id'][0])) {
+        if (isset($rheaders['request-id'])
+        && \is_string($rheaders['request-id'])
+        && \strlen($rheaders['request-id']) > 0) {
             self::$requestTelemetry = new RequestTelemetry(
-                $rheaders['request-id'][0],
+                $rheaders['request-id'],
                 Util\Util::currentTimeMillis() - $requestStartMs
             );
         }

--- a/tests/Stripe/StripeTelemetryTest.php
+++ b/tests/Stripe/StripeTelemetryTest.php
@@ -96,7 +96,7 @@ final class StripeTelemetryTest extends \PHPUnit\Framework\TestCase
                 }),
                 static::anything(),
                 static::anything()
-            )->willReturn([self::FAKE_VALID_RESPONSE, 200, ['request-id' => ['req_123']]]);
+            )->willReturn([self::FAKE_VALID_RESPONSE, 200, ['request-id' => 'req_123']]);
 
         ApiRequestor::setHttpClient($stub);
 


### PR DESCRIPTION
User pointed out [an issue](https://github.com/stripe/stripe-php/issues/992) where we discovered that we weren't sending telemetry correctly since #781. This removes that and checks to see if the request ID is a string. 

r? @ob-stripe 
cc? @stripe/api-libraries 