### PR TITLE
Add trim to getSignatures to allow for leading whitespace.

### DIFF
--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -115,7 +115,7 @@ abstract class WebhookSignature
 
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
-            if (trim($itemParts[0]) === $scheme) {
+            if (\trim($itemParts[0]) === $scheme) {
                 \array_push($signatures, $itemParts[1]);
             }
         }

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -115,7 +115,7 @@ abstract class WebhookSignature
 
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
-            if ($itemParts[0] === $scheme) {
+            if (trim($itemParts[0]) === $scheme) {
                 \array_push($signatures, $itemParts[1]);
             }
         }


### PR DESCRIPTION
Details on the issue can be found here:
https://github.com/stripe/stripe-php/issues/1001

Applied simple `trim` and verified that tests passed.

r? @richardm-stripe 
cc? @stripe/api-libraries 