### PR TITLE
FIX: delete spaces from disable_functions string

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -268,7 +268,7 @@ class ApiRequestor
         $uaString = 'Stripe/v1 PhpBindings/' . Stripe::VERSION;
 
         $langVersion = \PHP_VERSION;
-        $uname_disabled = \in_array('php_uname', \explode(',', \ini_get('disable_functions')), true);
+        $uname_disabled = \in_array('php_uname', \explode(',', \str_replace(' ','', \ini_get('disable_functions'))), true);
         $uname = $uname_disabled ? '(disabled)' : \php_uname();
 
         $appInfo = Stripe::getAppInfo();


### PR DESCRIPTION
Sometime disable_functions config consist spaces at string.

For example my config is "dl, apache_child_terminate, apache_setenv, define_syslog_variables, eval, exec, fp, fput, ftp_connect, ftp_exec, ftp_get, ftp_login, ftp_nb_fput, ftp_put, ftp_raw, ftp_rawlist, highlight_file, ini_alter, ini_get_all, ini_restore, inject_code, mysql_pconnect, openlog, passthru, php_uname, phpAds_remoteInfo, phpAds_XmlRpc, phpAds_xmlrpcDecode, phpAds_xmlrpcEncode, popen, posix_getpwuid, posix_kill, posix_mkfifo, posix_setpgid, posix_setsid, posix_setuid, posix_setuid, posix_uname, proc_close, proc_get_status, proc_nice, proc_terminate, shell_exec, syslog, system, xmlrpc_entity_decode".

With config as at example we get error: "php_uname() has been disabled for security reasons", because we didnt trim spaces from the string.