### PR TITLE
Trim spaces when parsing php.ini disablefunctions

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -258,6 +258,27 @@ class ApiRequestor
     /**
      * @static
      *
+     * @param string $disabledFunctionsOutput - String value of the 'disable_function' setting, as output by \ini_get('disable_functions')
+     * @param string $functionName - Name of the function we are interesting in seeing whether or not it is disabled
+     * @param mixed $disableFunctionsOutput
+     *
+     * @return bool
+     */
+    private static function _isDisabled($disableFunctionsOutput, $functionName)
+    {
+        $disabledFunctions = \explode(',', $disableFunctionsOutput);
+        foreach ($disabledFunctions as $disabledFunction) {
+            if (\trim($disabledFunction) === $functionName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @static
+     *
      * @param string $apiKey
      * @param null   $clientInfo
      *
@@ -268,7 +289,7 @@ class ApiRequestor
         $uaString = 'Stripe/v1 PhpBindings/' . Stripe::VERSION;
 
         $langVersion = \PHP_VERSION;
-        $uname_disabled = \in_array('php_uname', \explode(',', \ini_get('disable_functions')), true);
+        $uname_disabled = static::_isDisabled(\ini_get('disable_functions'), 'php_uname');
         $uname = $uname_disabled ? '(disabled)' : \php_uname();
 
         $appInfo = Stripe::getAppInfo();

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -576,4 +576,38 @@ final class ApiRequestorTest extends \PHPUnit\Framework\TestCase
         );
         Charge::create([], ['stripe_account' => 'acct_123']);
     }
+
+    public function testIsDisabled()
+    {
+        $reflector = new \ReflectionClass(\Stripe\ApiRequestor::class);
+        $method = $reflector->getMethod('_isDisabled');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(null, '', 'php_uname');
+        static::assertFalse($result);
+
+        $result = $method->invoke(null, 'exec', 'php_uname');
+        static::assertFalse($result);
+
+        $result = $method->invoke(null, 'exec, procopen', 'php_uname');
+        static::assertFalse($result);
+
+        $result = $method->invoke(null, 'exec,procopen', 'php_uname');
+        static::assertFalse($result);
+
+        $result = $method->invoke(null, 'exec,php_uname', 'php_uname');
+        static::assertTrue($result);
+
+        $result = $method->invoke(null, 'exec, php_uname', 'php_uname');
+        static::assertTrue($result);
+
+        $result = $method->invoke(null, 'php_uname, exec', 'php_uname');
+        static::assertTrue($result);
+
+        $result = $method->invoke(null, 'procopen,php_uname, exec', 'php_uname');
+        static::assertTrue($result);
+
+        $result = $method->invoke(null, 'procopen, php_uname, exec', 'php_uname');
+        static::assertTrue($result);
+    }
 }


### PR DESCRIPTION
Fixes #1009

r? @ctrudeau-stripe 
cc @stripe/api-libraries 

Summary: we were throwing exceptions by trying to call \php_uname on systems where \php_uname isn't supported because it was disabled in the php.ini, and we were not detecting the disabling correctly. I tested this by manually executing the function on my machine and setting various values of `disable_functions` inside my own /etc/php.ini.

Thanks for the contribution in #1009 @flinebux. I took a slightly different approach because I wanted to try and add a test as well.