### PR TITLE
Warn if opts are in params

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -27,6 +27,8 @@ class ApiRequestor
      */
     private static $requestTelemetry;
 
+    private static $OPTIONS_KEYS = ['api_key', 'idempotency_key', 'stripe_account', 'stripe_version', 'api_base'];
+
     /**
      * ApiRequestor constructor.
      *
@@ -348,6 +350,21 @@ class ApiRequestor
         $clientUAInfo = null;
         if (\method_exists($this->httpClient(), 'getUserAgentInfo')) {
             $clientUAInfo = $this->httpClient()->getUserAgentInfo();
+        }
+
+        if ($params && \is_array($params)) {
+            $optionKeysInParams = \array_filter(
+                static::$OPTIONS_KEYS,
+                function ($key) use ($params) {
+                    return \array_key_exists($key, $params);
+                }
+            );
+            if (\count($optionKeysInParams) > 0) {
+                $message = \sprintf('Options found in $params: %s. Options should '
+                  . 'be passed in their own array after $params. (HINT: pass an '
+                  . 'empty array to $params if you do not have any.)', \implode(', ', $optionKeysInParams));
+                \trigger_error($message, \E_USER_WARNING);
+            }
         }
 
         $absUrl = $this->_apiBase . $url;

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -178,4 +178,27 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
         $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
         $client->requestCollection('get', '/v1/charges/ch_123', [], []);
     }
+
+    public function testRequestWithOptsInParamsWarns()
+    {
+        $this->expectException(\PHPUnit_Framework_Error_Warning::class);
+
+        $client = new BaseStripeClient([
+            'api_key' => 'sk_test_client',
+            'stripe_account' => 'acct_123',
+            'api_base' => MOCK_URL,
+        ]);
+        $charge = $client->request(
+            'get',
+            '/v1/charges/ch_123',
+            [
+                'api_key' => 'sk_test_client',
+                'stripe_account' => 'acct_123',
+                'api_base' => MOCK_URL,
+            ],
+            ['stripe_account' => 'acct_456']
+        );
+        static::assertNotNull($charge);
+        static::assertSame('acct_456', $this->optsReflector->getValue($charge)->headers['Stripe-Account']);
+    }
 }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -182,7 +182,8 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
     public function testRequestWithOptsInParamsWarns()
     {
         $this->expectException(\PHPUnit_Framework_Error_Warning::class);
-
+        $this->expectExceptionMessage('Options found in $params: api_key, stripe_account, api_base. Options should be '
+            . 'passed in their own array after $params. (HINT: pass an empty array to $params if you do not have any.)');
         $client = new BaseStripeClient([
             'api_key' => 'sk_test_client',
             'stripe_account' => 'acct_123',


### PR DESCRIPTION
### Summary
Warn the user if they mistakenly put options into the `$params` argument to a method, similar to the [Stripe Node warning](https://github.com/stripe/stripe-node/blob/master/lib/utils.js#L128-L132). For example, we warn when the user includes an `api_key` in `$params`.

### Motivation
https://jira.corp.stripe.com/browse/DX-6065

### Testing
Unit tests