### PR TITLE
Force IPv4 resolving

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -271,6 +271,10 @@ class CurlClient implements ClientInterface
             $opts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2TLS;
         }
 
+        // Stripe's API servers are only accessible over IPv4. Force IPv4 resolving to avoid
+        // potential issues (cf. https://github.com/stripe/stripe-php/issues/1045).
+        $opts[\CURLOPT_IPRESOLVE] = \CURL_IPRESOLVE_V4;
+
         list($rbody, $rcode, $rheaders) = $this->executeRequestWithRetries($opts, $absUrl);
 
         return [$rbody, $rcode, $rheaders];
@@ -283,7 +287,6 @@ class CurlClient implements ClientInterface
     private function executeRequestWithRetries($opts, $absUrl)
     {
         $numRetries = 0;
-        $isPost = \array_key_exists(\CURLOPT_POST, $opts) && 1 === $opts[\CURLOPT_POST];
 
         while (true) {
             $rcode = 0;


### PR DESCRIPTION
r? @richardm-stripe 

Had a few minutes to kill while waiting for a merge :)

The constants are defined in curl 7.10.8 which is 17 years old. I've verified that the oldest curl version we see in live traffic is 7.19.7 (still a respectable 11 years old) so I don't think we need to add `\defined` guards or manually define the constants ourselves.

Fixes #1045.
