### PR TITLE
Set Api Base

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -119,6 +119,16 @@ class Stripe
     }
 
     /**
+     * Sets the base URL for the Stripe API.
+     *
+     * @param string $apiKey
+     */
+    public static function setApiBase($apiBase)
+    {
+        self::$apiBase = $apiBase;
+    }
+
+    /**
      * @return string The API version used for requests. null if we're using the
      *    latest version.
      */


### PR DESCRIPTION
This PR allows the base URL for the Stripe API to be changed.

This is useful if you want to interacted with https://github.com/stripe/stripe-mock