### PR TITLE
Improve error message for invalid keys in StripeClient

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -260,7 +260,10 @@ class BaseStripeClient implements StripeClientInterface
         // check absence of extra keys
         $extraConfigKeys = \array_diff(\array_keys($config), \array_keys($this->getDefaultConfig()));
         if (!empty($extraConfigKeys)) {
-            throw new \Stripe\Exception\InvalidArgumentException('Found unknown key(s) in configuration array: ' . \implode(',', $extraConfigKeys));
+            // Wrap in single quote to more easily catch trailing spaces errors
+            $invalidKeys = "'" . \implode("', '", $extraConfigKeys) . "'";
+
+            throw new \Stripe\Exception\InvalidArgumentException('Found unknown key(s) in configuration array: ' . $invalidKeys);
         }
     }
 }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -60,9 +60,9 @@ final class BaseStripeClientTest extends \PHPUnit\Framework\TestCase
     public function testCtorThrowsIfConfigArrayContainsUnexpectedKey()
     {
         $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Found unknown key(s) in configuration array: foo');
+        $this->expectExceptionMessage('Found unknown key(s) in configuration array: \'foo\', \'foo2\'');
 
-        $client = new BaseStripeClient(['foo' => 'bar']);
+        $client = new BaseStripeClient(['foo' => 'bar', 'foo2' => 'bar2']);
     }
 
     public function testRequestWithClientApiKey()


### PR DESCRIPTION
This change helps catch trailing space in keys in the config which happens often with copy/pastes and are hard to debug today without the wrapping single quotes.

r? @ob-stripe 
cc @stripe/api-libraries 