### PR TITLE
Bump PHP-CS-Fixer and update code

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         // Additional rules
         'fopen_flags' => true,
         'linebreak_after_opening_tag' => true,
+        'native_constant_invocation' => true,
         'native_function_invocation' => true,
 
         // --- Diffs from @PhpCsFixer / @PhpCsFixer:risky ---

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,12 @@ return PhpCsFixer\Config::create()
 
         // --- Diffs from @PhpCsFixer / @PhpCsFixer:risky ---
 
+        // This is the same as the default for the @PhpCsFixer ruleset, minus
+        // the following values: ['include', 'include_once', 'require',
+        // 'require_once']. We could enable them and remove this line after
+        // updating codegen for the `init.php` file to be compliant.
+        'blank_line_before_statement' => ['statements' => ['break', 'case', 'continue', 'declare', 'default', 'exit', 'goto', 'return', 'switch', 'throw', 'try']],
+
         // This is just prettier / easier to read.
         'concat_space' => ['spacing' => 'one'],
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php-coveralls/php-coveralls": "^2.1",
     "squizlabs/php_codesniffer": "^3.3",
     "symfony/process": "~3.4",
-    "friendsofphp/php-cs-fixer": "2.16.5"
+    "friendsofphp/php-cs-fixer": "2.17.1"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -128,9 +128,9 @@ class Account extends ApiResource
             $update = ($v instanceof StripeObject) ? $v->serializeParameters() : $v;
 
             if ([] !== $update) {
-                if (!$originalValue ||
-                    !\array_key_exists($i, $originalValue) ||
-                    ($update !== $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
+                if (!$originalValue
+                    || !\array_key_exists($i, $originalValue)
+                    || ($update !== $legalEntity->serializeParamsValue($originalValue[$i], null, false, true))) {
                     $updateArr[$i] = $update;
                 }
             }

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -187,14 +187,19 @@ class ApiRequestor
                 // no break
             case 404:
                 return Exception\InvalidRequestException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
+
             case 401:
                 return Exception\AuthenticationException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
+
             case 402:
                 return Exception\CardException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $declineCode, $param);
+
             case 403:
                 return Exception\PermissionException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
+
             case 429:
                 return Exception\RateLimitException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
+
             default:
                 return Exception\UnknownApiErrorException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
         }
@@ -218,16 +223,22 @@ class ApiRequestor
         switch ($errorCode) {
             case 'invalid_client':
                 return Exception\OAuth\InvalidClientException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             case 'invalid_grant':
                 return Exception\OAuth\InvalidGrantException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             case 'invalid_request':
                 return Exception\OAuth\InvalidRequestException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             case 'invalid_scope':
                 return Exception\OAuth\InvalidScopeException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             case 'unsupported_grant_type':
                 return Exception\OAuth\UnsupportedGrantTypeException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             case 'unsupported_response_type':
                 return Exception\OAuth\UnsupportedResponseTypeException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
+
             default:
                 return Exception\OAuth\UnknownOAuthErrorException::factory($description, $rcode, $rbody, $resp, $rheaders, $errorCode);
         }

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -39,8 +39,8 @@ abstract class ApiResource extends StripeObject
     {
         parent::__set($k, $v);
         $v = $this->{$k};
-        if ((static::getSavedNestedResources()->includes($k)) &&
-            ($v instanceof ApiResource)) {
+        if ((static::getSavedNestedResources()->includes($k))
+            && ($v instanceof ApiResource)) {
             $v->saveWithParent = true;
         }
     }

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -142,8 +142,8 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
 
         while (true) {
             $filters = $this->filters ?: [];
-            if (\array_key_exists('ending_before', $filters) &&
-                !\array_key_exists('starting_after', $filters)) {
+            if (\array_key_exists('ending_before', $filters)
+                && !\array_key_exists('starting_after', $filters)) {
                 foreach ($page->getReverseIterator() as $item) {
                     yield $item;
                 }

--- a/lib/EphemeralKey.php
+++ b/lib/EphemeralKey.php
@@ -17,11 +17,11 @@ class EphemeralKey extends ApiResource
 {
     const OBJECT_NAME = 'ephemeral_key';
 
-    use ApiOperations\Delete;
-
     use ApiOperations\Create {
         create as protected _create;
     }
+
+    use ApiOperations\Delete;
 
     /**
      * @param null|array $params

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -366,6 +366,7 @@ class CurlClient implements ClientInterface
                  . 'https://twitter.com/stripestatus, or';
 
                 break;
+
             case \CURLE_SSL_CACERT:
             case \CURLE_SSL_PEER_CERTIFICATE:
                 $msg = "Could not verify Stripe's SSL certificate.  Please make sure "
@@ -374,6 +375,7 @@ class CurlClient implements ClientInterface
                  . 'If this problem persists,';
 
                 break;
+
             default:
                 $msg = 'Unexpected error communicating with Stripe.  '
                  . 'If this problem persists,';

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -237,7 +237,7 @@ class CurlClient implements ClientInterface
         // add an Idempotency-Key header
         if (('post' === $method) && (Stripe::$maxNetworkRetries > 0)) {
             if (!$this->hasHeader($headers, 'Idempotency-Key')) {
-                \array_push($headers, 'Idempotency-Key: ' . $this->randomGenerator->uuid());
+                $headers[] = 'Idempotency-Key: ' . $this->randomGenerator->uuid();
             }
         }
 
@@ -253,7 +253,7 @@ class CurlClient implements ClientInterface
         // we'll error under that condition. To compensate for that problem
         // for the time being, override cURL's behavior by simply always
         // sending an empty `Expect:` header.
-        \array_push($headers, 'Expect: ');
+        $headers[] = 'Expect: ';
 
         $absUrl = Util\Util::utf8($absUrl);
         $opts[\CURLOPT_URL] = $absUrl;

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -397,7 +397,7 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
                 // Sequential array, i.e. a list
                 $update = [];
                 foreach ($value as $v) {
-                    \array_push($update, $this->serializeParamsValue($v, null, true, $force));
+                    $update[] = $this->serializeParamsValue($v, null, true, $force);
                 }
                 // This prevents an array that's unchanged from being resent.
                 if ($update !== $this->serializeParamsValue($original, null, true, $force, $key)) {

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -161,7 +161,7 @@ class RequestOptions
         $redactedLast = \strlen($last) > 4
             ? (\str_repeat('*', \strlen($last) - 4) . \substr($last, -4))
             : $last;
-        \array_push($pieces, $redactedLast);
+        $pieces[] = $redactedLast;
 
         return \implode('_', $pieces);
     }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -47,7 +47,7 @@ abstract class Util
         if (self::isList($resp)) {
             $mapped = [];
             foreach ($resp as $i) {
-                \array_push($mapped, self::convertToStripeObject($i, $opts));
+                $mapped[] = self::convertToStripeObject($i, $opts);
             }
 
             return $mapped;
@@ -138,7 +138,7 @@ abstract class Util
         if (static::isList($h)) {
             $results = [];
             foreach ($h as $v) {
-                \array_push($results, static::objectsToIds($v));
+                $results[] = static::objectsToIds($v);
             }
 
             return $results;
@@ -169,7 +169,7 @@ abstract class Util
         $pieces = [];
         foreach ($flattenedParams as $param) {
             list($k, $v) = $param;
-            \array_push($pieces, self::urlEncode($k) . '=' . self::urlEncode($v));
+            $pieces[] = self::urlEncode($k) . '=' . self::urlEncode($v);
         }
 
         return \implode('&', $pieces);

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -116,7 +116,7 @@ abstract class WebhookSignature
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
             if (\trim($itemParts[0]) === $scheme) {
-                \array_push($signatures, $itemParts[1]);
+                $signatures[] = $itemParts[1];
             }
         }
 

--- a/tests/Stripe/CollectionTest.php
+++ b/tests/Stripe/CollectionTest.php
@@ -112,7 +112,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $seen = [];
         foreach ($collection as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['1', '2', '3'], $seen);
@@ -128,7 +128,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $seen = [];
         foreach ($collection->getReverseIterator() as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['3', '2', '1'], $seen);
@@ -138,7 +138,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
     {
         $seen = [];
         foreach (\iterator_to_array($this->fixture) as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['1'], $seen);
@@ -163,7 +163,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $seen = [];
         foreach ($this->fixture->autoPagingIterator() as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['1', '2', '3'], $seen);
@@ -188,7 +188,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $seen = [];
         foreach (\iterator_to_array($this->fixture->autoPagingIterator()) as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['1', '2', '3'], $seen);
@@ -220,7 +220,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
 
         $seen = [];
         foreach ($collection->autoPagingIterator() as $item) {
-            \array_push($seen, $item['id']);
+            $seen[] = $item['id'];
         }
 
         static::assertSame(['3', '2', '1'], $seen);
@@ -287,7 +287,7 @@ final class CollectionTest extends \PHPUnit\Framework\TestCase
         $nextPage = $this->fixture->nextPage();
         $ids = [];
         foreach ($nextPage->data as $element) {
-            \array_push($ids, $element['id']);
+            $ids[] = $element['id'];
         }
         static::assertSame(['2', '3'], $ids);
     }

--- a/tests/StripeMock.php
+++ b/tests/StripeMock.php
@@ -48,7 +48,7 @@ class StripeMock
         if (static::$process->isRunning()) {
             echo 'Started stripe-mock, PID = ' . static::$process->getPid() . "\n";
         } else {
-            die('stripe-mock terminated early, exit code = ' . static::$process->wait());
+            exit('stripe-mock terminated early, exit code = ' . static::$process->wait());
         }
 
         return true;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,7 @@ $resp = \curl_exec($ch);
 if (\curl_errno($ch)) {
     echo "Couldn't reach stripe-mock at `" . MOCK_HOST . ':' . MOCK_PORT . '`. Is ' .
          "it running? Please see README for setup instructions.\n";
+
     exit(1);
 }
 
@@ -43,6 +44,7 @@ if (null === $version) {
     echo 'Could not retrieve Stripe-Mock-Version header. Are you sure ' .
          'that the server at `' . MOCK_HOST . ':' . MOCK_PORT . '` is a stripe-mock ' .
          'instance?';
+
     exit(1);
 }
 
@@ -50,6 +52,7 @@ if ('master' !== $version && -1 === \version_compare($version, MOCK_MINIMUM_VERS
     echo 'Your version of stripe-mock (' . $version . ') is too old. The minimum ' .
          'version to run this test suite is ' . MOCK_MINIMUM_VERSION . '. ' .
          "Please see its repository for upgrade instructions.\n";
+
     exit(1);
 }
 


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

Upgrade PHP-CS-Fixer to 2.17.1 and update code to be compliant with changes to the [`@PhpCsFixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.17/doc/ruleSets/PhpCsFixer.rst) ruleset.

This is a prerequisite to start supporting PHP 8, as the previously pinned version (2.16.5) does not support PHP 8.

I recommend reviewing commit by commit. The changes are fairly minor and affect mostly manually written files, with a couple of exceptions:
- `lib/Account.php`: changes to a method defined via an override, so we can simply update the method definition in codegen to be consistent
- `lib/EphemeralKey.php`: changes to the order in which traits are listed. I don't think we can easily fix this in codegen, as one trait (`Delete`) is added automatically and the other (`Create`) is added via an override. We can likely leave things as-is and just let the `make fmt` postprocess step fix things.
