### PR TITLE
Upgrade PHPStan to 0.12.59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export PHPDOCUMENTOR_VERSION := v3.0.0-rc
-export PHPSTAN_VERSION := 0.12.18
+export PHPSTAN_VERSION := 0.12.59
 
 vendor: composer.json
 	composer install

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,8 @@ includes:
 parameters:
 	level: 1
 
-	bootstrap: tests/bootstrap.php
+	bootstrapFiles:
+		- tests/bootstrap.php
 
 	ignoreErrors:
 		- '#Unsafe usage of new static\(\).#'


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

Upgrade PHPStan to 0.12.59 (current latest version).

Another prerequisite step to start supporting PHP 8, as the currently pinned version (0.12.18) does not support it.