### PR TITLE
Update CA cert bundle URL

### DIFF
--- a/update_certs.php
+++ b/update_certs.php
@@ -9,7 +9,7 @@ $fp = \fopen(__DIR__ . '/data/ca-certificates.crt', 'w+b');
 $options = [
     \CURLOPT_FILE => $fp,
     \CURLOPT_TIMEOUT => 3600,
-    \CURLOPT_URL => 'https://curl.haxx.se/ca/cacert.pem',
+    \CURLOPT_URL => 'https://curl.se/ca/cacert.pem',
 ];
 
 $ch = \curl_init();


### PR DESCRIPTION
The curl domain has changed from curl.haxx.se to curl.se. Calling update_certs.php with the old CA bundle URL may result in the text of the 301 response being downloaded instead of the bundle file, breaking communication with Stripe.