### PR TITLE
Update PHPDocs

### DIFF
--- a/lib/LineItem.php
+++ b/lib/LineItem.php
@@ -9,8 +9,8 @@ namespace Stripe;
  *
  * @property string $id Unique identifier for the object.
  * @property string $object String representing the object's type. Objects of the same type share the same value.
- * @property null|int $amount_subtotal Total before any discounts or taxes are applied.
- * @property null|int $amount_total Total after discounts and taxes.
+ * @property int $amount_subtotal Total before any discounts or taxes are applied.
+ * @property int $amount_total Total after discounts and taxes.
  * @property string $currency Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
  * @property string $description An arbitrary string attached to the object. Often useful for displaying to users. Defaults to product name.
  * @property \Stripe\StripeObject[] $discounts The discounts applied to the line item.


### PR DESCRIPTION
Codegen for openapi 79b5ae3.
r? @remi-stripe
cc @stripe/api-libraries

## Changelog
* `LineItem.amount_subtotal` and `LineItem.amount_total` changed from `nullable(integer)` to `integer`

