### PR TITLE
GHA: Remove apparently redundant extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
         uses: shivammathur/setup-php@master
         with:
           php-version: ${{ matrix.php-version }}
-          extension-csv: curl, json, mbstring, simplexml, xdebug
           coverage: xdebug
 
       - name: Get Composer Cache Directory


### PR DESCRIPTION
r? @ob-stripe 
Should fix some warnings as appear in https://github.com/stripe/stripe-php/actions/runs/562861010