### PR TITLE
Use codegen for static custom method generation.

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -200,7 +200,7 @@ class Account extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Account the rejected account
+     * @return \Stripe\Account the rejected account
      */
     public function reject($params = null, $opts = null)
     {

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -133,7 +133,7 @@ class Charge extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Charge the captured charge
+     * @return \Stripe\Charge the captured charge
      */
     public function capture($params = null, $opts = null)
     {

--- a/lib/CreditNote.php
+++ b/lib/CreditNote.php
@@ -70,7 +70,7 @@ class CreditNote extends ApiResource
     {
         $url = static::classUrl() . '/preview';
         list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
-        $obj = Util\Util::convertToStripeObject($response->json, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
         $obj->setLastResponse($response);
 
         return $obj;
@@ -82,7 +82,7 @@ class CreditNote extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return CreditNote the voided credit note
+     * @return \Stripe\CreditNote the voided credit note
      */
     public function voidCreditNote($params = null, $opts = null)
     {

--- a/lib/Identity/VerificationSession.php
+++ b/lib/Identity/VerificationSession.php
@@ -57,7 +57,7 @@ class VerificationSession extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return VerificationSession the canceled verification session
+     * @return \Stripe\VerificationSession the canceled verification session
      */
     public function cancel($params = null, $opts = null)
     {
@@ -74,7 +74,7 @@ class VerificationSession extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return VerificationSession the redacted verification session
+     * @return \Stripe\VerificationSession the redacted verification session
      */
     public function redact($params = null, $opts = null)
     {

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -143,24 +143,6 @@ class Invoice extends ApiResource
     const PATH_LINES = '/lines';
 
     /**
-     * @param null|array $params
-     * @param null|array|string $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return \Stripe\Invoice the upcoming invoice
-     */
-    public static function upcoming($params = null, $opts = null)
-    {
-        $url = static::classUrl() . '/upcoming';
-        list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
-        $obj = Util\Util::convertToStripeObject($response->json, $opts);
-        $obj->setLastResponse($response);
-
-        return $obj;
-    }
-
-    /**
      * @param string $id the ID of the invoice on which to retrieve the lines
      * @param null|array $params
      * @param null|array|string $opts
@@ -180,7 +162,7 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Invoice the finalized invoice
+     * @return \Stripe\Invoice the finalized invoice
      */
     public function finalizeInvoice($params = null, $opts = null)
     {
@@ -197,7 +179,7 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Invoice the uncollectible invoice
+     * @return \Stripe\Invoice the uncollectible invoice
      */
     public function markUncollectible($params = null, $opts = null)
     {
@@ -214,7 +196,7 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Invoice the paid invoice
+     * @return \Stripe\Invoice the paid invoice
      */
     public function pay($params = null, $opts = null)
     {
@@ -231,7 +213,7 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Invoice the sent invoice
+     * @return \Stripe\Invoice the sent invoice
      */
     public function sendInvoice($params = null, $opts = null)
     {
@@ -248,7 +230,25 @@ class Invoice extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Invoice the voided invoice
+     * @return \Stripe\Invoice the upcoming invoice
+     */
+    public static function upcoming($params = null, $opts = null)
+    {
+        $url = static::classUrl() . '/upcoming';
+        list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+
+        return $obj;
+    }
+
+    /**
+     * @param null|array $params
+     * @param null|array|string $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\Invoice the voided invoice
      */
     public function voidInvoice($params = null, $opts = null)
     {

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -51,7 +51,7 @@ class Authorization extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Authorization the approved authorization
+     * @return \Stripe\Authorization the approved authorization
      */
     public function approve($params = null, $opts = null)
     {
@@ -68,7 +68,7 @@ class Authorization extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Authorization the declined authorization
+     * @return \Stripe\Authorization the declined authorization
      */
     public function decline($params = null, $opts = null)
     {

--- a/lib/Issuing/Dispute.php
+++ b/lib/Issuing/Dispute.php
@@ -40,7 +40,7 @@ class Dispute extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Dispute the submited dispute
+     * @return \Stripe\Dispute the submited dispute
      */
     public function submit($params = null, $opts = null)
     {

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -68,7 +68,7 @@ class Order extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Order the paid order
+     * @return \Stripe\Order the paid order
      */
     public function pay($params = null, $opts = null)
     {

--- a/lib/PaymentIntent.php
+++ b/lib/PaymentIntent.php
@@ -78,7 +78,7 @@ class PaymentIntent extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return PaymentIntent the canceled payment intent
+     * @return \Stripe\PaymentIntent the canceled payment intent
      */
     public function cancel($params = null, $opts = null)
     {
@@ -95,7 +95,7 @@ class PaymentIntent extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return PaymentIntent the captured payment intent
+     * @return \Stripe\PaymentIntent the captured payment intent
      */
     public function capture($params = null, $opts = null)
     {
@@ -112,7 +112,7 @@ class PaymentIntent extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return PaymentIntent the confirmed payment intent
+     * @return \Stripe\PaymentIntent the confirmed payment intent
      */
     public function confirm($params = null, $opts = null)
     {

--- a/lib/PaymentMethod.php
+++ b/lib/PaymentMethod.php
@@ -58,7 +58,7 @@ class PaymentMethod extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return PaymentMethod the attached payment method
+     * @return \Stripe\PaymentMethod the attached payment method
      */
     public function attach($params = null, $opts = null)
     {
@@ -75,7 +75,7 @@ class PaymentMethod extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return PaymentMethod the detached payment method
+     * @return \Stripe\PaymentMethod the detached payment method
      */
     public function detach($params = null, $opts = null)
     {

--- a/lib/Payout.php
+++ b/lib/Payout.php
@@ -78,7 +78,7 @@ class Payout extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Payout the canceled payout
+     * @return \Stripe\Payout the canceled payout
      */
     public function cancel($params = null, $opts = null)
     {
@@ -95,7 +95,7 @@ class Payout extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Payout the reversed payout
+     * @return \Stripe\Payout the reversed payout
      */
     public function reverse($params = null, $opts = null)
     {

--- a/lib/Review.php
+++ b/lib/Review.php
@@ -53,7 +53,7 @@ class Review extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Review the approved review
+     * @return \Stripe\Review the approved review
      */
     public function approve($params = null, $opts = null)
     {

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -146,11 +146,11 @@ class AccountService extends \Stripe\Service\AbstractService
     }
 
     /**
-     * With <a href="/docs/connect">Connect</a>, you can delete Custom or Express
-     * accounts you manage.
+     * With <a href="/docs/connect">Connect</a>, you can delete accounts you manage.
      *
-     * Accounts created using test-mode keys can be deleted at any time. Accounts
-     * created using live-mode keys can only be deleted once all balances are zero.
+     * Accounts created using test-mode keys can be deleted at any time. Custom or
+     * Express accounts created using live-mode keys can only be deleted once all
+     * balances are zero.
      *
      * If you want to delete your own account, use the <a
      * href="https://dashboard.stripe.com/account">account information tab in your

--- a/lib/SetupIntent.php
+++ b/lib/SetupIntent.php
@@ -84,7 +84,7 @@ class SetupIntent extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return SetupIntent the canceled setup intent
+     * @return \Stripe\SetupIntent the canceled setup intent
      */
     public function cancel($params = null, $opts = null)
     {
@@ -101,7 +101,7 @@ class SetupIntent extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return SetupIntent the confirmed setup intent
+     * @return \Stripe\SetupIntent the confirmed setup intent
      */
     public function confirm($params = null, $opts = null)
     {

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -155,7 +155,7 @@ class Source extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Source the verified source
+     * @return \Stripe\Source the verified source
      */
     public function verify($params = null, $opts = null)
     {

--- a/lib/SubscriptionSchedule.php
+++ b/lib/SubscriptionSchedule.php
@@ -44,7 +44,7 @@ class SubscriptionSchedule extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return SubscriptionSchedule the canceled subscription schedule
+     * @return \Stripe\SubscriptionSchedule the canceled subscription schedule
      */
     public function cancel($params = null, $opts = null)
     {
@@ -61,7 +61,7 @@ class SubscriptionSchedule extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return SubscriptionSchedule the released subscription schedule
+     * @return \Stripe\SubscriptionSchedule the released subscription schedule
      */
     public function release($params = null, $opts = null)
     {

--- a/lib/Topup.php
+++ b/lib/Topup.php
@@ -50,7 +50,7 @@ class Topup extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Topup the canceled topup
+     * @return \Stripe\Topup the canceled topup
      */
     public function cancel($params = null, $opts = null)
     {

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -57,7 +57,7 @@ class Transfer extends ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return Transfer the canceled transfer
+     * @return \Stripe\Transfer the canceled transfer
      */
     public function cancel($params = null, $opts = null)
     {


### PR DESCRIPTION
Updates the static custom methods to be code generated. These should be functionally equivalent (eg. see `CreditNote#preview`). As part of this change, the type annotation for the return type on custom methods will now be fully namespaced (eg. `Account` becomes `\Stripe\Account`) for consistency with standard methods.

r? @richardm-stripe 
cc @stripe/api-libraries