### PR TITLE
Add `mode` constants into Checkout\Session

### DIFF
--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -70,6 +70,10 @@ class Session extends \Stripe\ApiResource
     const PAYMENT_STATUS_PAID = 'paid';
     const PAYMENT_STATUS_UNPAID = 'unpaid';
 
+    const MODE_PAYMENT = 'payment';
+    const MODE_SETUP = 'setup';
+    const MODE_SUBSCRIPTION = 'subscription';
+
     const SUBMIT_TYPE_AUTO = 'auto';
     const SUBMIT_TYPE_BOOK = 'book';
     const SUBMIT_TYPE_DONATE = 'donate';


### PR DESCRIPTION
Hi guys. 
I would like to add these constants. I don't really want to keep them on my side in the project.
according [Checkout Session API doc](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-mode)