### PR TITLE
Add streaming methods to Service infra

### DIFF
--- a/init.php
+++ b/init.php
@@ -17,8 +17,8 @@ require __DIR__ . '/lib/Util/ObjectTypes.php';
 
 // HttpClient
 require __DIR__ . '/lib/HttpClient/ClientInterface.php';
-require __DIR__ . '/lib/HttpClient/CurlClient.php';
 require __DIR__ . '/lib/HttpClient/StreamingClientInterface.php';
+require __DIR__ . '/lib/HttpClient/CurlClient.php';
 
 // Exceptions
 require __DIR__ . '/lib/Exception/ExceptionInterface.php';
@@ -67,11 +67,11 @@ require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/AbstractServiceFactory.php';
 
 // StripeClient
-require __DIR__ . '/lib/BaseStripeClient.php';
 require __DIR__ . '/lib/BaseStripeClientInterface.php';
-require __DIR__ . '/lib/StripeClient.php';
 require __DIR__ . '/lib/StripeClientInterface.php';
 require __DIR__ . '/lib/StripeStreamingClientInterface.php';
+require __DIR__ . '/lib/BaseStripeClient.php';
+require __DIR__ . '/lib/StripeClient.php';
 
 // Stripe API Resources
 require __DIR__ . '/lib/Account.php';

--- a/init.php
+++ b/init.php
@@ -18,6 +18,7 @@ require __DIR__ . '/lib/Util/ObjectTypes.php';
 // HttpClient
 require __DIR__ . '/lib/HttpClient/ClientInterface.php';
 require __DIR__ . '/lib/HttpClient/CurlClient.php';
+require __DIR__ . '/lib/HttpClient/StreamingClientInterface.php';
 
 // Exceptions
 require __DIR__ . '/lib/Exception/ExceptionInterface.php';
@@ -66,9 +67,11 @@ require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/AbstractServiceFactory.php';
 
 // StripeClient
-require __DIR__ . '/lib/StripeClientInterface.php';
 require __DIR__ . '/lib/BaseStripeClient.php';
+require __DIR__ . '/lib/BaseStripeClientInterface.php';
 require __DIR__ . '/lib/StripeClient.php';
+require __DIR__ . '/lib/StripeClientInterface.php';
+require __DIR__ . '/lib/StripeStreamingClientInterface.php';
 
 // Stripe API Resources
 require __DIR__ . '/lib/Account.php';

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -156,7 +156,6 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
         $baseUrl = $opts->apiBase ?: $this->getApiBase();
         $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
         list($response, $opts->apiKey) = $requestor->requestStream($method, $path, $readBodyChunkCallable, $params, $opts->headers);
-        $opts->discardNonPersistentHeaders();
     }
 
     /**

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -2,7 +2,7 @@
 
 namespace Stripe;
 
-class BaseStripeClient implements StripeClientInterface
+class BaseStripeClient implements StripeClientInterface, StripeStreamingClientInterface
 {
     /** @var string default base URL for Stripe's API */
     const DEFAULT_API_BASE = 'https://api.stripe.com';
@@ -137,6 +137,26 @@ class BaseStripeClient implements StripeClientInterface
         $obj->setLastResponse($response);
 
         return $obj;
+    }
+
+    /**
+     * Sends a request to Stripe's API, passing chunks of the streamed response
+     * into a user-provided $readBodyChunkCallable callback.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param callable $readBodyChunkCallable a function that will be called
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     * with chunks of bytes from the body if the request is successful
+     */
+    public function requestStream($method, $path, $readBodyChunkCallable, $params, $opts)
+    {
+        $opts = $this->defaultOpts->merge($opts, true);
+        $baseUrl = $opts->apiBase ?: $this->getApiBase();
+        $requestor = new \Stripe\ApiRequestor($this->apiKeyForRequest($opts), $baseUrl);
+        list($response, $opts->apiKey) = $requestor->requestStream($method, $path, $readBodyChunkCallable, $params, $opts->headers);
+        $opts->discardNonPersistentHeaders();
     }
 
     /**

--- a/lib/BaseStripeClientInterface.php
+++ b/lib/BaseStripeClientInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Interface for a Stripe client.
+ */
+interface BaseStripeClientInterface
+{
+    /**
+     * Gets the API key used by the client to send requests.
+     *
+     * @return null|string the API key used by the client to send requests
+     */
+    public function getApiKey();
+
+    /**
+     * Gets the client ID used by the client in OAuth requests.
+     *
+     * @return null|string the client ID used by the client in OAuth requests
+     */
+    public function getClientId();
+
+    /**
+     * Gets the base URL for Stripe's API.
+     *
+     * @return string the base URL for Stripe's API
+     */
+    public function getApiBase();
+
+    /**
+     * Gets the base URL for Stripe's OAuth API.
+     *
+     * @return string the base URL for Stripe's OAuth API
+     */
+    public function getConnectBase();
+
+    /**
+     * Gets the base URL for Stripe's Files API.
+     *
+     * @return string the base URL for Stripe's Files API
+     */
+    public function getFilesBase();
+}

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -24,7 +24,7 @@ if (!\defined('CURL_HTTP_VERSION_2TLS')) {
     \define('CURL_HTTP_VERSION_2TLS', 4);
 }
 
-class CurlClient implements ClientInterface
+class CurlClient implements ClientInterface, StreamingClientInterface
 {
     protected static $instance;
 

--- a/lib/HttpClient/StreamingClientInterface.php
+++ b/lib/HttpClient/StreamingClientInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stripe\HttpClient;
+
+interface StreamingClientInterface
+{
+    /**
+     * @param string $method The HTTP method being used
+     * @param string $absUrl The URL being requested, including domain and protocol
+     * @param array $headers Headers to be used in the request (full strings, not KV pairs)
+     * @param array $params KV pairs for parameters. Can be nested for arrays and hashes
+     * @param bool $hasFile Whether or not $params references a file (via an @ prefix or
+     *                         CURLFile)
+     * @param callable $readBodyChunkCallable a function that will be called with chunks of bytes from the body if the request is successful
+     *
+     * @throws \Stripe\Exception\ApiConnectionException
+     * @throws \Stripe\Exception\UnexpectedValueException
+     *
+     * @return array an array whose first element is raw request body, second
+     *    element is HTTP status code and third array of HTTP headers
+     */
+    public function requestStream($method, $absUrl, $headers, $params, $hasFile, $readBodyChunkCallable);
+}

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -13,6 +13,11 @@ abstract class AbstractService
     protected $client;
 
     /**
+     * @var \Stripe\StripeStreamingClientInterface
+     */
+    protected $streamingClient;
+
+    /**
      * Initializes a new instance of the {@link AbstractService} class.
      *
      * @param \Stripe\StripeClientInterface $client
@@ -20,6 +25,7 @@ abstract class AbstractService
     public function __construct($client)
     {
         $this->client = $client;
+        $this->streamingClient = $client;
     }
 
     /**
@@ -30,6 +36,16 @@ abstract class AbstractService
     public function getClient()
     {
         return $this->client;
+    }
+
+    /**
+     * Gets the client used by this service to send requests.
+     *
+     * @return \Stripe\StripeStreamingClientInterface
+     */
+    public function getStreamingClient()
+    {
+        return $this->streamingClient;
     }
 
     /**
@@ -57,6 +73,11 @@ abstract class AbstractService
     protected function request($method, $path, $params, $opts)
     {
         return $this->getClient()->request($method, $path, static::formatParams($params), $opts);
+    }
+
+    protected function requestStream($method, $path, $readBodyChunkCallable, $params, $opts)
+    {
+        return $this->getStreamingClient()->requestStream($method, $path, $readBodyChunkCallable, static::formatParams($params), $opts);
     }
 
     protected function requestCollection($method, $path, $params, $opts)

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -5,43 +5,8 @@ namespace Stripe;
 /**
  * Interface for a Stripe client.
  */
-interface StripeClientInterface
+interface StripeClientInterface extends BaseStripeClientInterface
 {
-    /**
-     * Gets the API key used by the client to send requests.
-     *
-     * @return null|string the API key used by the client to send requests
-     */
-    public function getApiKey();
-
-    /**
-     * Gets the client ID used by the client in OAuth requests.
-     *
-     * @return null|string the client ID used by the client in OAuth requests
-     */
-    public function getClientId();
-
-    /**
-     * Gets the base URL for Stripe's API.
-     *
-     * @return string the base URL for Stripe's API
-     */
-    public function getApiBase();
-
-    /**
-     * Gets the base URL for Stripe's OAuth API.
-     *
-     * @return string the base URL for Stripe's OAuth API
-     */
-    public function getConnectBase();
-
-    /**
-     * Gets the base URL for Stripe's Files API.
-     *
-     * @return string the base URL for Stripe's Files API
-     */
-    public function getFilesBase();
-
     /**
      * Sends a request to Stripe's API.
      *

--- a/lib/StripeStreamingClientInterface.php
+++ b/lib/StripeStreamingClientInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Interface for a Stripe client.
+ */
+interface StripeStreamingClientInterface extends BaseStripeClientInterface
+{
+    public function requestStream($method, $path, $readBodyChunkCallable, $params, $opts);
+}

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -93,7 +93,7 @@ class RequestOptions
     public static function parse($options, $strict = false)
     {
         if ($options instanceof self) {
-            return $options;
+            return clone $options;
         }
 
         if (null === $options) {

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -198,6 +198,7 @@ trait TestHelper
         $base = null
     ) {
         ApiRequestor::setHttpClient($this->clientMock);
+
         if (null === $base) {
             $base = Stripe::$apiBase;
         }
@@ -221,7 +222,7 @@ trait TestHelper
                     return true;
                 }),
                 null === $params ? static::anything() : static::identicalTo($params),
-                static::identicalTo($hasFile),
+                static::identicalTo($hasFile)
             )
         ;
     }
@@ -278,7 +279,7 @@ trait TestHelper
                 }),
                 null === $params ? static::anything() : static::identicalTo($params),
                 static::identicalTo($hasFile),
-                static::anything(),
+                static::anything()
             )
         ;
     }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -25,6 +25,9 @@ trait TestHelper
     /** @var \PHPUnit_Framework_MockObject_MockObject HTTP client mocker */
     protected $clientMock;
 
+    /** @var \PHPUnit_Framework_MockObject_MockObject HTTP client mocker */
+    protected $streamingClientMock;
+
     /** @before */
     protected function setUpConfig()
     {
@@ -37,6 +40,7 @@ trait TestHelper
 
         // Set up host and credentials for stripe-mock
         Stripe::$apiBase = \defined('MOCK_URL') ? MOCK_URL : 'http://localhost:12111';
+        Stripe::$apiUploadBase = \defined('MOCK_URL') ? MOCK_URL : 'http://localhost:12111';
         Stripe::setApiKey('sk_test_123');
         Stripe::setClientId('ca_123');
         Stripe::setApiVersion(null);
@@ -44,9 +48,11 @@ trait TestHelper
 
         // Set up the HTTP client mocker
         $this->clientMock = $this->createMock('\Stripe\HttpClient\ClientInterface');
+        $this->streamingClientMock = $this->createMock('\Stripe\HttpClient\StreamingClientInterface');
 
         // By default, use the real HTTP client
         ApiRequestor::setHttpClient(HttpClient\CurlClient::instance());
+        ApiRequestor::setStreamingHttpClient(HttpClient\CurlClient::instance());
     }
 
     /** @after */
@@ -83,6 +89,7 @@ trait TestHelper
         $hasFile = false,
         $base = null
     ) {
+        ApiRequestor::setHttpClient($this->clientMock);
         $this->prepareRequestMock($method, $path, $params, $headers, $hasFile, $base)
             ->willReturnCallback(
                 function ($method, $absUrl, $headers, $params, $hasFile) {
@@ -90,6 +97,41 @@ trait TestHelper
                     ApiRequestor::setHttpClient($curlClient);
 
                     return $curlClient->request($method, $absUrl, $headers, $params, $hasFile);
+                }
+            )
+        ;
+    }
+
+    /**
+     * Sets up a request expectation with the provided parameters. The request
+     * will actually go through and be emitted.
+     *
+     * @param string $method HTTP method (e.g. 'post', 'get', etc.)
+     * @param string $path relative path (e.g. '/v1/charges')
+     * @param null|array $params array of parameters. If null, parameters will
+     *   not be checked.
+     * @param null|string[] $headers array of headers. Does not need to be
+     *   exhaustive. If null, headers are not checked.
+     * @param bool $hasFile Whether the request parameters contains a file.
+     *   Defaults to false.
+     * @param null|string $base base URL (e.g. 'https://api.stripe.com')
+     */
+    protected function expectsRequestStream(
+        $method,
+        $path,
+        $params = null,
+        $headers = null,
+        $hasFile = false,
+        $base = null
+    ) {
+        ApiRequestor::setStreamingHttpClient($this->streamingClientMock);
+        $this->prepareRequestStreamMock($method, $path, $params, $headers, $hasFile, $base)
+            ->willReturnCallback(
+                function ($method, $absUrl, $readBodyChunkCallable, $headers, $params, $hasFile) {
+                    $curlClient = HttpClient\CurlClient::instance();
+                    ApiRequestor::setStreamingHttpClient($curlClient);
+
+                    return $curlClient->requestStream($method, $absUrl, $readBodyChunkCallable, $headers, $params, $hasFile);
                 }
             )
         ;
@@ -156,7 +198,6 @@ trait TestHelper
         $base = null
     ) {
         ApiRequestor::setHttpClient($this->clientMock);
-
         if (null === $base) {
             $base = Stripe::$apiBase;
         }
@@ -180,7 +221,64 @@ trait TestHelper
                     return true;
                 }),
                 null === $params ? static::anything() : static::identicalTo($params),
-                static::identicalTo($hasFile)
+                static::identicalTo($hasFile),
+            )
+        ;
+    }
+
+    /**
+     * Prepares the client mocker for an invocation of the `request` method.
+     * This helper method is used by both `expectsRequest` and `stubRequest` to
+     * prepare the client mocker to expect an invocation of the `request` method
+     * with the provided arguments.
+     *
+     * @param string $method HTTP method (e.g. 'post', 'get', etc.)
+     * @param string $path relative path (e.g. '/v1/charges')
+     * @param null|array $params array of parameters. If null, parameters will
+     *   not be checked.
+     * @param null|string[] $headers array of headers. Does not need to be
+     *   exhaustive. If null, headers are not checked.
+     * @param bool $hasFile Whether the request parameters contains a file.
+     *   Defaults to false.
+     * @param null|string $base base URL (e.g. 'https://api.stripe.com')
+     * @param string $requestMethod name of the method on httpclient to mock - 'request' or 'requestStream'
+     *
+     * @return \PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     */
+    private function prepareRequestStreamMock(
+        $method,
+        $path,
+        $params = null,
+        $headers = null,
+        $hasFile = false,
+        $base = null
+    ) {
+        ApiRequestor::setStreamingHttpClient($this->streamingClientMock);
+        if (null === $base) {
+            $base = Stripe::$apiBase;
+        }
+        $absUrl = $base . $path;
+
+        return $this->streamingClientMock
+            ->expects(static::once())
+            ->method('requestStream')
+            ->with(
+                static::identicalTo(\strtolower($method)),
+                static::identicalTo($absUrl),
+                // for headers, we only check that all of the headers provided in $headers are
+                // present in the list of headers of the actual request
+                null === $headers ? static::anything() : static::callback(function ($array) use ($headers) {
+                    foreach ($headers as $header) {
+                        if (!\in_array($header, $array, true)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }),
+                null === $params ? static::anything() : static::identicalTo($params),
+                static::identicalTo($hasFile),
+                static::anything(),
             )
         ;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/StripeMock.php';
 
-\define('MOCK_MINIMUM_VERSION', '0.89.0');
+\define('MOCK_MINIMUM_VERSION', '0.109.0');
 
 if (\Stripe\StripeMock::start()) {
     \register_shutdown_function('\Stripe\StripeMock::stop');


### PR DESCRIPTION
r? @dcr-stripe 

https://github.com/stripe/stripe-php/pull/1143 was sufficient for adding Streaming support to `CurlClient`
This PR adds analogous methods onto `AbstractStripeService`, `BaseStripeClient` and such. 

Adding `requestStream` onto `HttpClient\ClientInterface` directly would technically be a breaking change, so I am now exposing separate interfaces for `requestStream` and `request`, and I store two separate references on ApiRequestor.

## Changelog
- Add support for streaming requests on the Services interfaces
  - Add support for `setStreamingHttpClient` and `streamingHttpClient` to `ApiRequestor`
  - Add support for `getStreamingClient` and `requestStream` to `AbstractService`
  - Add support for `requestStream` to `BaseStripeClient`
- `\Stripe\RequestOptions::parse` now clones its input if it is already a `RequestOptions` object, to prevent accidental mutation.