### PR TITLE
[RFC] Add PHPDoc generics to Collection

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -9,6 +9,9 @@ namespace Stripe;
  * @property string $url
  * @property bool $has_more
  * @property \Stripe\StripeObject[] $data
+ *
+ * @template TStripeObject of StripeObject
+ * @template-implements \IteratorAggregate<TStripeObject>
  */
 class Collection extends StripeObject implements \Countable, \IteratorAggregate
 {
@@ -60,6 +63,9 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
         throw new Exception\InvalidArgumentException($msg);
     }
 
+    /**
+     * @return Collection<TStripeObject>
+     */
     public function all($params = null, $opts = null)
     {
         self::_validateParams($params);
@@ -77,6 +83,9 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
         return $obj;
     }
 
+    /**
+     * @return TStripeObject
+     */
     public function create($params = null, $opts = null)
     {
         self::_validateParams($params);
@@ -87,6 +96,9 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
         return Util\Util::convertToStripeObject($response, $opts);
     }
 
+    /**
+     * @return TStripeObject
+     */
     public function retrieve($id, $params = null, $opts = null)
     {
         self::_validateParams($params);

--- a/lib/Service/InvoiceService.php
+++ b/lib/Service/InvoiceService.php
@@ -16,7 +16,7 @@ class InvoiceService extends \Stripe\Service\AbstractService
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Collection
+     * @return \Stripe\Collection<\Stripe\Invoice>
      */
     public function all($params = null, $opts = null)
     {


### PR DESCRIPTION
Hi, this is just to see if it's fine, then I'll continue. Nowadays many tools support this generic `@template` annotation, this would improve the developer experience allowing to specify which types a `Collection` holds.

I've only used in `InvoiceService` to see how would look like.