### PR TITLE
Remove unused API error types from docs.

### DIFF
--- a/lib/ErrorObject.php
+++ b/lib/ErrorObject.php
@@ -30,10 +30,8 @@ namespace Stripe;
  *    returned on a request involving a SetupIntent.
  * @property StripeObject $source The source object for errors returned on a
  *    request involving a source.
- * @property string $type The type of error returned. One of
- *    `api_connection_error`, `api_error`, `authentication_error`,
- *    `card_error`, `idempotency_error`, `invalid_request_error`, or
- *    `rate_limit_error`.
+ * @property string $type The type of error returned. One of `api_error`,
+ *   `card_error`, `idempotency_error`, or `invalid_request_error`.
  */
 class ErrorObject extends StripeObject
 {


### PR DESCRIPTION
r? @richardm-stripe 

Removes unused error types (`api_connection_error`, `authentication_error`, and `rate_limit_error`) from docstring.