### PR TITLE
Fix link to old stripe-php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [video demonstrations][youtube-playlist] covering how to use the library.
 ### PHP 5.4 & 5.5
 
 If you are using PHP 5.4 or 5.5, you should consider upgrading your environment as those versions have been past end of life since September 2015 and July 2016 respectively.
-Otherwise, you can still use Stripe by downloading stripe-php v6.43.1 ([zip](https://github.com/stripe/stripe-php/archive/v6.43.1.zip), [tar.gz](https://github.com/stripe/stripe-php/archive/v6.21.1.tar.gz)) from our [releases page](https://github.com/stripe/stripe-php/releases). This version will work but might not support recent features we added since the version was released and upgrading PHP is the best course of action.
+Otherwise, you can still use Stripe by downloading stripe-php v6.43.1 ([zip](https://github.com/stripe/stripe-php/archive/v6.43.1.zip), [tar.gz](https://github.com/stripe/stripe-php/archive/6.43.1.tar.gz)) from our [releases page](https://github.com/stripe/stripe-php/releases). This version will work but might not support recent features we added since the version was released and upgrading PHP is the best course of action.
 
 ### PHP 5.3
 


### PR DESCRIPTION
Address report in https://github.com/stripe/stripe-php/pull/1157#discussion_r671671420

cc @stripe/api-libraries 