### PR TITLE
Fix typo in docblock `CurlClient::executeStreamingRequestWithRetries`

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -355,8 +355,7 @@ class CurlClient implements ClientInterface, StreamingClientInterface
      *
      * @param array $opts cURL options
      * @param string $absUrl
-     * @param callable @readBodyChunk
-     * @param mixed $readBodyChunk
+     * @param callable $readBodyChunk
      *
      * @return array
      */


### PR DESCRIPTION
# Description
A small PHP DocBlock typo fix.

Parameter `$readBodyChunk` was set in docblock with an `@` instead of a `$`.
This resulted in failing annotation parsing (doctrine/annotations):

```
[Semantical Error] The annotation "@readBodyChunk" in method Stripe\HttpClient\CurlClient::executeStreamingRequestWithRetries() was never imported. Did you maybe forget to add a "use" statement for this annotation?
```