### PR TITLE
Fix wrong namespace

### DIFF
--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -99,7 +99,7 @@ class Session extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Session the expired session
+     * @return \Stripe\Checkout\Session the expired session
      */
     public function expire($params = null, $opts = null)
     {


### PR DESCRIPTION
Small fix, maybe it was a case not handle by the automated script creating the API resource classes.