### PR TITLE
Fix namespaced classes in @return PHPDoc.

### DIFF
--- a/lib/Checkout/Session.php
+++ b/lib/Checkout/Session.php
@@ -99,7 +99,7 @@ class Session extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Session the expired session
+     * @return \Stripe\Checkout\Session the expired session
      */
     public function expire($params = null, $opts = null)
     {

--- a/lib/Identity/VerificationSession.php
+++ b/lib/Identity/VerificationSession.php
@@ -58,7 +58,7 @@ class VerificationSession extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\VerificationSession the canceled verification session
+     * @return \Stripe\Identity\VerificationSession the canceled verification session
      */
     public function cancel($params = null, $opts = null)
     {
@@ -75,7 +75,7 @@ class VerificationSession extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\VerificationSession the redacted verification session
+     * @return \Stripe\Identity\VerificationSession the redacted verification session
      */
     public function redact($params = null, $opts = null)
     {

--- a/lib/Issuing/Authorization.php
+++ b/lib/Issuing/Authorization.php
@@ -51,7 +51,7 @@ class Authorization extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Authorization the approved authorization
+     * @return \Stripe\Issuing\Authorization the approved authorization
      */
     public function approve($params = null, $opts = null)
     {
@@ -68,7 +68,7 @@ class Authorization extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Authorization the declined authorization
+     * @return \Stripe\Issuing\Authorization the declined authorization
      */
     public function decline($params = null, $opts = null)
     {

--- a/lib/Issuing/Dispute.php
+++ b/lib/Issuing/Dispute.php
@@ -40,7 +40,7 @@ class Dispute extends \Stripe\ApiResource
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Dispute the submited dispute
+     * @return \Stripe\Issuing\Dispute the submited dispute
      */
     public function submit($params = null, $opts = null)
     {


### PR DESCRIPTION
r? @richardm-stripe 

## Summary

Adds missing namespaces to the return types in PHPDoc.