### PR TITLE
Add const for BNPL capabilities  (Affirm, Afterpay/Clearpay, Klarna)

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -54,6 +54,7 @@ class Account extends ApiResource
     const CAPABILITY_AFTERPAY_CLEARPAY_PAYMENTS = 'afterpay_clearpay_payments';
     const CAPABILITY_CARD_PAYMENTS = 'card_payments';
     const CAPABILITY_LEGACY_PAYMENTS = 'legacy_payments';
+    const CAPABILITY_KLARNA_PAYMENTS = 'klarna_payments';
     const CAPABILITY_PLATFORM_PAYMENTS = 'platform_payments';
     const CAPABILITY_TRANSFERS = 'transfers';
 

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -51,6 +51,7 @@ class Account extends ApiResource
     const BUSINESS_TYPE_INDIVIDUAL = 'individual';
     const BUSINESS_TYPE_NON_PROFIT = 'non_profit';
 
+    const CAPABILITY_AFFIRM_PAYMENTS = 'affirm_payments';
     const CAPABILITY_AFTERPAY_CLEARPAY_PAYMENTS = 'afterpay_clearpay_payments';
     const CAPABILITY_CARD_PAYMENTS = 'card_payments';
     const CAPABILITY_LEGACY_PAYMENTS = 'legacy_payments';


### PR DESCRIPTION
Elsewhere in our code we reference Account::CAPABILITY_CARD_PAYMENTS or Account::CAPABILITY_TRANSFERS, but there isn't one for afterpay_clearpay_payments.