### PR TITLE
Upgrade php-cs-fixer to 3.4.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches: [ master ]
   pull_request:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga:3.2.1
+        uses: docker://oskarstark/php-cs-fixer-ga:3.4.0
         with:
           args: --format=txt --diff --dry-run --using-cache=no --verbose .
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "phpunit/phpunit": "^5.7 || ^9.0",
     "squizlabs/php_codesniffer": "^3.3",
-    "friendsofphp/php-cs-fixer": "3.2.1",
+    "friendsofphp/php-cs-fixer": "3.4.0",
     "phpstan/phpstan": "^1.2"
   },
   "autoload": {


### PR DESCRIPTION
r? @yejia-stripe 
cc @richardm-stripe 

### Summary

Upgrades php-cs-fixer to 3.4.0 as this version supports PHP8.1.

### Test plan

Tests pass and no formatting changes.