### PR TITLE
Add ServiceNavigatorTrait to support namespace/resource homonyms

### DIFF
--- a/init.php
+++ b/init.php
@@ -63,6 +63,7 @@ require __DIR__ . '/lib/StripeObject.php';
 require __DIR__ . '/lib/ApiRequestor.php';
 require __DIR__ . '/lib/ApiResource.php';
 require __DIR__ . '/lib/SingletonApiResource.php';
+require __DIR__ . '/lib/Service/ServiceNavigatorTrait.php';
 require __DIR__ . '/lib/Service/AbstractService.php';
 require __DIR__ . '/lib/Service/AbstractServiceFactory.php';
 

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -7,6 +7,8 @@ namespace Stripe\Service;
  */
 abstract class AbstractService
 {
+    use ServiceNavigatorTrait;
+
     /**
      * @var \Stripe\StripeClientInterface
      */

--- a/lib/Service/AbstractServiceFactory.php
+++ b/lib/Service/AbstractServiceFactory.php
@@ -14,11 +14,7 @@ namespace Stripe\Service;
  */
 abstract class AbstractServiceFactory
 {
-    /** @var \Stripe\StripeClientInterface */
-    private $client;
-
-    /** @var array<string, AbstractService|AbstractServiceFactory> */
-    private $services;
+    use ServiceNavigatorTrait;
 
     /**
      * @param \Stripe\StripeClientInterface $client
@@ -26,34 +22,5 @@ abstract class AbstractServiceFactory
     public function __construct($client)
     {
         $this->client = $client;
-        $this->services = [];
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return null|string
-     */
-    abstract protected function getServiceClass($name);
-
-    /**
-     * @param string $name
-     *
-     * @return null|AbstractService|AbstractServiceFactory
-     */
-    public function __get($name)
-    {
-        $serviceClass = $this->getServiceClass($name);
-        if (null !== $serviceClass) {
-            if (!\array_key_exists($name, $this->services)) {
-                $this->services[$name] = new $serviceClass($this->client);
-            }
-
-            return $this->services[$name];
-        }
-
-        \trigger_error('Undefined property: ' . static::class . '::$' . $name);
-
-        return null;
     }
 }

--- a/lib/Service/ServiceNavigatorTrait.php
+++ b/lib/Service/ServiceNavigatorTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Stripe\Service;
+
+/**
+ * Trait for creatable resources. Adds a `create()` static method to the class.
+ *
+ * This trait should only be applied to classes that derive from StripeObject.
+ */
+trait ServiceNavigatorTrait
+{
+    /** @var array<string, AbstractService|AbstractServiceFactory> */
+    protected $services = [];
+
+    /** @var \Stripe\StripeClientInterface */
+    protected $client;
+
+    protected function getServiceClass($name)
+    {
+        \trigger_error('Undefined property: ' . static::class . '::$' . $name);
+    }
+
+    public function __get($name)
+    {
+        $serviceClass = $this->getServiceClass($name);
+        if (null !== $serviceClass) {
+            if (!\array_key_exists($name, $this->services)) {
+                $this->services[$name] = new $serviceClass($this->client);
+            }
+
+            return $this->services[$name];
+        }
+
+        \trigger_error('Undefined property: ' . static::class . '::$' . $name);
+
+        return null;
+    }
+}

--- a/lib/Service/ServiceNavigatorTrait.php
+++ b/lib/Service/ServiceNavigatorTrait.php
@@ -3,7 +3,10 @@
 namespace Stripe\Service;
 
 /**
- * Trait for creatable resources. Adds a `create()` static method to the class.
+ * Trait for creatable resources and auxiliary services.
+ * Adds a `create()` static method to the class for creatable resources.
+ * Adds custom properties named like nested classes to parent of
+ * auxiliary services.
  *
  * This trait should only be applied to classes that derive from StripeObject.
  */


### PR DESCRIPTION
Extracts `__get` method from `AbstractServiceFactory` into a trait can be used across `AbstractService` and `AbstractServiceFactory`. The method helps reading inaccessible, non-existent in our case, properties which will be utilized in future SDK releases for services beneath a namespace named identically to a resource.