### PR TITLE
Add missing constant for payment_behavior

### DIFF
--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -57,6 +57,7 @@ class Subscription extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
+    const PAYMENT_BEHAVIOR_DEFAULT_INCOMPLETE = 'default_incomplete';
     const PAYMENT_BEHAVIOR_ALLOW_INCOMPLETE = 'allow_incomplete';
     const PAYMENT_BEHAVIOR_ERROR_IF_INCOMPLETE = 'error_if_incomplete';
     const PAYMENT_BEHAVIOR_PENDING_IF_INCOMPLETE = 'pending_if_incomplete';

--- a/lib/Subscription.php
+++ b/lib/Subscription.php
@@ -57,8 +57,8 @@ class Subscription extends ApiResource
     use ApiOperations\Retrieve;
     use ApiOperations\Update;
 
-    const PAYMENT_BEHAVIOR_DEFAULT_INCOMPLETE = 'default_incomplete';
     const PAYMENT_BEHAVIOR_ALLOW_INCOMPLETE = 'allow_incomplete';
+    const PAYMENT_BEHAVIOR_DEFAULT_INCOMPLETE = 'default_incomplete';
     const PAYMENT_BEHAVIOR_ERROR_IF_INCOMPLETE = 'error_if_incomplete';
     const PAYMENT_BEHAVIOR_PENDING_IF_INCOMPLETE = 'pending_if_incomplete';
 


### PR DESCRIPTION
For subscriptions, there is also `payment_behavior=default_incomplete`, of which the constant was missing.

See: https://stripe.com/docs/api/subscriptions/create#create_subscription-payment_behavior
And: https://stripe.com/docs/api/subscriptions/update#update_subscription-payment_behavior

Also note that the API documentation could really use some improving here. The difference between 'default_incomplete' and 'allow_incomplete' in the scope of updating subscriptions is unclear to me.