### PR TITLE
Add support for SearchResult objects.

### DIFF
--- a/init.php
+++ b/init.php
@@ -54,6 +54,7 @@ require __DIR__ . '/lib/ApiOperations/Delete.php';
 require __DIR__ . '/lib/ApiOperations/NestedResource.php';
 require __DIR__ . '/lib/ApiOperations/Request.php';
 require __DIR__ . '/lib/ApiOperations/Retrieve.php';
+require __DIR__ . '/lib/ApiOperations/Search.php';
 require __DIR__ . '/lib/ApiOperations/Update.php';
 
 // Plumbing
@@ -142,6 +143,7 @@ require __DIR__ . '/lib/Refund.php';
 require __DIR__ . '/lib/Reporting/ReportRun.php';
 require __DIR__ . '/lib/Reporting/ReportType.php';
 require __DIR__ . '/lib/Review.php';
+require __DIR__ . '/lib/SearchResult.php';
 require __DIR__ . '/lib/SetupAttempt.php';
 require __DIR__ . '/lib/SetupIntent.php';
 require __DIR__ . '/lib/ShippingRate.php';

--- a/lib/ApiOperations/Search.php
+++ b/lib/ApiOperations/Search.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for searchable resources.
+ *
+ * This trait should only be applied to classes that derive from StripeObject.
+ */
+trait Search
+{
+    /**
+     * @param string $searchUrl
+     * @param null|array $params
+     * @param null|array|string $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\SearchResult of ApiResources
+     */
+    protected static function _searchResource($searchUrl, $params = null, $opts = null)
+    {
+        self::_validateParams($params);
+
+        list($response, $opts) = static::_staticRequest('get', $searchUrl, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        if (!($obj instanceof \Stripe\SearchResult)) {
+            throw new \Stripe\Exception\UnexpectedValueException(
+                'Expected type ' . \Stripe\SearchResult::class . ', got "' . \get_class($obj) . '" instead.'
+            );
+        }
+        $obj->setLastResponse($response);
+        $obj->setFilters($params);
+
+        return $obj;
+    }
+}

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -183,6 +183,30 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     }
 
     /**
+     * Sends a request to Stripe's API.
+     *
+     * @param string $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\SearchResult of ApiResources
+     */
+    public function requestSearchResult($method, $path, $params, $opts)
+    {
+        $obj = $this->request($method, $path, $params, $opts);
+        if (!($obj instanceof \Stripe\SearchResult)) {
+            $received_class = \get_class($obj);
+            $msg = "Expected to receive `Stripe\\SearchResult` object from Stripe API. Instead received `{$received_class}`.";
+
+            throw new \Stripe\Exception\UnexpectedValueException($msg);
+        }
+        $obj->setFilters($params);
+
+        return $obj;
+    }
+
+    /**
      * @param \Stripe\Util\RequestOptions $opts
      *
      * @throws \Stripe\Exception\AuthenticationException

--- a/lib/SearchResult.php
+++ b/lib/SearchResult.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Search results for an API resource.
+ *
+ * This behaves similarly to <code>Collection</code> in that they both wrap
+ * around a list of objects and provide pagination. However the
+ * <code>SearchResult</code> object paginates by relying on a
+ * <code>next_page</code> token included in the response rather than using
+ * object IDs and a <code>starting_before</code>/<code>ending_after</code>
+ * parameter. Thus, <code>SearchResult</code> only supports forwards pagination.
+ *
+ * @template TStripeObject of StripeObject
+ * @template-implements \IteratorAggregate<TStripeObject>
+ *
+ * @property string $object
+ * @property string $url
+ * @property string $next_page
+ * @property bool $has_more
+ * @property TStripeObject[] $data
+ */
+class SearchResult extends StripeObject implements \Countable, \IteratorAggregate
+{
+    const OBJECT_NAME = 'search_result';
+
+    use ApiOperations\Request;
+
+    /** @var array */
+    protected $filters = [];
+
+    /**
+     * @return string the base URL for the given class
+     */
+    public static function baseUrl()
+    {
+        return Stripe::$apiBase;
+    }
+
+    /**
+     * Returns the filters.
+     *
+     * @return array the filters
+     */
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+
+    /**
+     * Sets the filters, removing paging options.
+     *
+     * @param array $filters the filters
+     */
+    public function setFilters($filters)
+    {
+        $this->filters = $filters;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k)
+    {
+        if (\is_string($k)) {
+            return parent::offsetGet($k);
+        }
+        $msg = "You tried to access the {$k} index, but SearchResult " .
+                   'types only support string keys. (HINT: Search calls ' .
+                   'return an object with a `data` (which is the data ' .
+                   "array). You likely want to call ->data[{$k}])";
+
+        throw new Exception\InvalidArgumentException($msg);
+    }
+
+    /**
+     * @param null|array $params
+     * @param null|array|string $opts
+     *
+     * @throws Exception\ApiErrorException
+     *
+     * @return SearchResult<TStripeObject>
+     */
+    public function all($params = null, $opts = null)
+    {
+        self::_validateParams($params);
+        list($url, $params) = $this->extractPathAndUpdateParams($params);
+
+        list($response, $opts) = $this->_request('get', $url, $params, $opts);
+        $obj = Util\Util::convertToStripeObject($response, $opts);
+        if (!($obj instanceof \Stripe\SearchResult)) {
+            throw new \Stripe\Exception\UnexpectedValueException(
+                'Expected type ' . \Stripe\SearchResult::class . ', got "' . \get_class($obj) . '" instead.'
+            );
+        }
+        $obj->setFilters($params);
+
+        return $obj;
+    }
+
+    /**
+     * @return int the number of objects in the current page
+     */
+    #[\ReturnTypeWillChange]
+    public function count()
+    {
+        return \count($this->data);
+    }
+
+    /**
+     * @return \ArrayIterator an iterator that can be used to iterate
+     *    across objects in the current page
+     */
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
+    }
+
+    /**
+     * @return \Generator|TStripeObject[] A generator that can be used to
+     *    iterate across all objects across all pages. As page boundaries are
+     *    encountered, the next page will be fetched automatically for
+     *    continued iteration.
+     */
+    public function autoPagingIterator()
+    {
+        $page = $this;
+
+        while (true) {
+            foreach ($page as $item) {
+                yield $item;
+            }
+            $page = $page->nextPage();
+
+            if ($page->isEmpty()) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Returns an empty set of search results. This is returned from
+     * {@see nextPage()} when we know that there isn't a next page in order to
+     * replicate the behavior of the API when it attempts to return a page
+     * beyond the last.
+     *
+     * @param null|array|string $opts
+     *
+     * @return SearchResult
+     */
+    public static function emptySearchResult($opts = null)
+    {
+        return SearchResult::constructFrom(['data' => []], $opts);
+    }
+
+    /**
+     * Returns true if the page object contains no element.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->data);
+    }
+
+    /**
+     * Fetches the next page in the resource list (if there is one).
+     *
+     * This method will try to respect the limit of the current page. If none
+     * was given, the default limit will be fetched again.
+     *
+     * @param null|array $params
+     * @param null|array|string $opts
+     *
+     * @return SearchResult<TStripeObject>
+     */
+    public function nextPage($params = null, $opts = null)
+    {
+        if (!$this->has_more) {
+            return static::emptySearchResult($opts);
+        }
+
+        $params = \array_merge(
+            $this->filters ?: [],
+            ['page' => $this->next_page],
+            $params ?: []
+        );
+
+        return $this->all($params, $opts);
+    }
+
+    /**
+     * Gets the first item from the current page. Returns `null` if the current page is empty.
+     *
+     * @return null|TStripeObject
+     */
+    public function first()
+    {
+        return \count($this->data) > 0 ? $this->data[0] : null;
+    }
+
+    /**
+     * Gets the last item from the current page. Returns `null` if the current page is empty.
+     *
+     * @return null|TStripeObject
+     */
+    public function last()
+    {
+        return \count($this->data) > 0 ? $this->data[\count($this->data) - 1] : null;
+    }
+
+    private function extractPathAndUpdateParams($params)
+    {
+        $url = \parse_url($this->url);
+
+        if (!isset($url['path'])) {
+            throw new Exception\UnexpectedValueException("Could not parse list url into parts: {$url}");
+        }
+
+        if (isset($url['query'])) {
+            // If the URL contains a query param, parse it out into $params so they
+            // don't interact weirdly with each other.
+            $query = [];
+            \parse_str($url['query'], $query);
+            $params = \array_merge($params ?: [], $query);
+        }
+
+        return [$url['path'], $params];
+    }
+}

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -85,6 +85,11 @@ abstract class AbstractService
         return $this->getClient()->requestCollection($method, $path, static::formatParams($params), $opts);
     }
 
+    protected function requestSearchResult($method, $path, $params, $opts)
+    {
+        return $this->getClient()->requestSearchResult($method, $path, static::formatParams($params), $opts);
+    }
+
     protected function buildPath($basePath, ...$ids)
     {
         foreach ($ids as $id) {

--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -78,6 +78,7 @@ class ObjectTypes
         \Stripe\Reporting\ReportRun::OBJECT_NAME => \Stripe\Reporting\ReportRun::class,
         \Stripe\Reporting\ReportType::OBJECT_NAME => \Stripe\Reporting\ReportType::class,
         \Stripe\Review::OBJECT_NAME => \Stripe\Review::class,
+        \Stripe\SearchResult::OBJECT_NAME => \Stripe\SearchResult::class,
         \Stripe\SetupAttempt::OBJECT_NAME => \Stripe\SetupAttempt::class,
         \Stripe\SetupIntent::OBJECT_NAME => \Stripe\SetupIntent::class,
         \Stripe\ShippingRate::OBJECT_NAME => \Stripe\ShippingRate::class,

--- a/tests/Stripe/SearchResultTest.php
+++ b/tests/Stripe/SearchResultTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ * @covers \Stripe\SearchResult
+ */
+final class SearchResultTest extends \Stripe\TestCase
+{
+    use TestHelper;
+
+    /** @var \Stripe\SearchResult */
+    private $fixture;
+
+    /**
+     * @before
+     */
+    public function setUpFixture()
+    {
+        $this->fixture = SearchResult::constructFrom([
+            'data' => [['id' => '1']],
+            'has_more' => true,
+            'url' => '/things',
+            'next_page' => 'WzEuMl0=',
+        ]);
+    }
+
+    public function testOffsetGetNumericIndex()
+    {
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->compatExpectExceptionMessageMatches('/You tried to access the \\d index/');
+
+        $this->fixture[0];
+    }
+
+    public function testCanList()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '1']],
+                'has_more' => true,
+                'url' => '/things',
+            ]
+        );
+
+        $resources = $this->fixture->all();
+        $this->compatAssertIsArray($resources->data);
+    }
+
+    public function testCanCount()
+    {
+        $SearchResult = SearchResult::constructFrom([
+            'data' => [['id' => '1']],
+        ]);
+        static::assertCount(1, $SearchResult);
+
+        $SearchResult = SearchResult::constructFrom([
+            'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
+        ]);
+        static::assertCount(3, $SearchResult);
+    }
+
+    public function testCanIterate()
+    {
+        $SearchResult = SearchResult::constructFrom([
+            'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
+            'has_more' => true,
+            'url' => '/things',
+            'next_page' => 'WzEuMl0=',
+        ]);
+
+        $seen = [];
+        foreach ($SearchResult as $item) {
+            $seen[] = $item['id'];
+        }
+
+        static::assertSame(['1', '2', '3'], $seen);
+    }
+
+    public function testSupportsIteratorToArray()
+    {
+        $seen = [];
+        foreach (\iterator_to_array($this->fixture) as $item) {
+            $seen[] = $item['id'];
+        }
+
+        static::assertSame(['1'], $seen);
+    }
+
+    public function testProvidesAutoPagingIterator()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'page' => 'WzEuMl0=',
+            ],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '2'], ['id' => '3']],
+                'has_more' => false,
+            ]
+        );
+
+        $seen = [];
+        foreach ($this->fixture->autoPagingIterator() as $item) {
+            $seen[] = $item['id'];
+        }
+
+        static::assertSame(['1', '2', '3'], $seen);
+    }
+
+    public function testAutoPagingIteratorReusesFilters()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'query' => 'metadata["foo"]:"bar"',
+                'limit' => 3,
+                'page' => 'WzEuMl0=',
+            ],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '2'], ['id' => '3']],
+                'has_more' => false,
+            ]
+        );
+
+        $this->fixture->setFilters([
+            'query' => 'metadata["foo"]:"bar"',
+            'limit' => 3,
+        ]);
+
+        $seen = [];
+        foreach ($this->fixture->autoPagingIterator() as $item) {
+            $seen[] = $item['id'];
+        }
+
+        static::assertSame(['1', '2', '3'], $seen);
+    }
+
+    public function testAutoPagingIteratorSupportsIteratorToArray()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'page' => 'WzEuMl0=',
+            ],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '2'], ['id' => '3']],
+                'has_more' => false,
+            ]
+        );
+
+        $seen = [];
+        foreach (\iterator_to_array($this->fixture->autoPagingIterator()) as $item) {
+            $seen[] = $item['id'];
+        }
+
+        static::assertSame(['1', '2', '3'], $seen);
+    }
+
+    public function testEmptySearchResult()
+    {
+        $emptySearchResult = SearchResult::emptySearchResult();
+        static::assertSame([], $emptySearchResult->data);
+    }
+
+    public function testIsEmpty()
+    {
+        $empty = SearchResult::constructFrom(['data' => []]);
+        static::assertTrue($empty->isEmpty());
+
+        $notEmpty = SearchResult::constructFrom(['data' => [['id' => '1']]]);
+        static::assertFalse($notEmpty->isEmpty());
+    }
+
+    public function testNextPage()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'page' => 'WzEuMl0=',
+            ],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '2'], ['id' => '3']],
+                'has_more' => false,
+            ]
+        );
+
+        $nextPage = $this->fixture->nextPage();
+        $ids = [];
+        foreach ($nextPage->data as $element) {
+            $ids[] = $element['id'];
+        }
+        static::assertSame(['2', '3'], $ids);
+    }
+
+    public function testNextPageReusesFilters()
+    {
+        $this->stubRequest(
+            'GET',
+            '/things',
+            [
+                'query' => 'metadata["foo"]:"bar"',
+                'limit' => 3,
+                'page' => 'WzEuMl0=',
+            ],
+            null,
+            false,
+            [
+                'object' => 'search_result',
+                'data' => [['id' => '2'], ['id' => '3']],
+                'has_more' => false,
+            ]
+        );
+
+        $this->fixture->setFilters([
+            'query' => 'metadata["foo"]:"bar"',
+            'limit' => 3,
+        ]);
+
+        $nextPage = $this->fixture->nextPage();
+        $ids = [];
+        foreach ($nextPage->data as $element) {
+            $ids[] = $element['id'];
+        }
+        static::assertSame(['2', '3'], $ids);
+    }
+
+    public function testFirst()
+    {
+        $SearchResult = SearchResult::constructFrom([
+            'data' => [
+                ['content' => 'first'],
+                ['content' => 'middle'],
+                ['content' => 'last'],
+            ],
+        ]);
+        static::assertSame('first', $SearchResult->first()['content']);
+    }
+
+    public function testLast()
+    {
+        $SearchResult = SearchResult::constructFrom([
+            'data' => [
+                ['content' => 'first'],
+                ['content' => 'middle'],
+                ['content' => 'last'],
+            ],
+        ]);
+        static::assertSame('last', $SearchResult->last()['content']);
+    }
+}


### PR DESCRIPTION
### Notify

r? @pakrym-stripe 
cc @richardm-stripe 

### Summary

Adds support for `search_result` objects returned by the Stripe API, including adding a templated `SearchResult` class and a `Search` trait which can be added to resources to support invoking search APIs.

This behaves similarly to `Collection` in that they both wrap around a list of objects and provide pagination. However the `SearchResult` object paginates by relying on a `next_page` token included in the response rather than using object IDs + `starting_before`/`ending_after`. Thus, only forward pagination is supported

This was revived from https://github.com/stripe/stripe-php/pull/1134 with the following API changes:
- `page` is used in the request
- `next_page` is always returned, just null when there's no more page.

### Test plan

Added unit tests. We'll want to add some more rigorous tests once stripe-mock has been updated to include at least one API that returns this resource.

### Post-merge

The generation for `init.php` and `lib/Util/ObjectTypes.php` should be updated to include these new classes going forward.