### PR TITLE
API Updates

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -22,7 +22,7 @@ namespace Stripe;
  * @property \Stripe\StripeObject $company
  * @property \Stripe\StripeObject $controller
  * @property string $country The account's country.
- * @property int $created Time at which the object was created. Measured in seconds since the Unix epoch.
+ * @property int $created Time at which the account was connected. Measured in seconds since the Unix epoch.
  * @property string $default_currency Three-letter ISO currency code representing the default currency for the account. This must be a currency that <a href="https://stripe.com/docs/payouts">Stripe supports in the account's country</a>.
  * @property bool $details_submitted Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.
  * @property null|string $email An email address associated with the account. You can treat this as metadata: it is not used for authentication or messaging account holders.

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -32,6 +32,7 @@ namespace Stripe;
  * @property null|string|\Stripe\Account $destination ID of an existing, connected Stripe account to transfer funds to if <code>transfer_data</code> was specified in the charge request.
  * @property null|string|\Stripe\Dispute $dispute Details about the dispute if the charge has been disputed.
  * @property bool $disputed Whether the charge has been disputed.
+ * @property null|string|\Stripe\BalanceTransaction $failure_balance_transaction ID of the balance transaction that describes the reversal of the balance on your account due to payment failure.
  * @property null|string $failure_code Error code explaining reason for charge failure if available (see <a href="https://stripe.com/docs/api#errors">the errors section</a> for a list of codes).
  * @property null|string $failure_message Message to user further explaining reason for charge failure if available.
  * @property null|\Stripe\StripeObject $fraud_details Information on fraud assessments for the charge.

--- a/lib/PaymentMethod.php
+++ b/lib/PaymentMethod.php
@@ -42,9 +42,11 @@ namespace Stripe;
  * @property null|\Stripe\StripeObject $metadata Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
  * @property \Stripe\StripeObject $oxxo
  * @property \Stripe\StripeObject $p24
+ * @property \Stripe\StripeObject $paynow
  * @property \Stripe\StripeObject $sepa_debit
  * @property \Stripe\StripeObject $sofort
  * @property string $type The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+ * @property \Stripe\StripeObject $us_bank_account
  * @property \Stripe\StripeObject $wechat_pay
  */
 class PaymentMethod extends ApiResource


### PR DESCRIPTION
Codegen for openapi dc3ef48.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for PayNow and US Bank Accounts Debits payments
    * Add support for `paynow` and `us_bank_account` on `PaymentMethod`
    * Add support for new values `paynow` and `us_bank_account` on enum `PaymentMethod.type`
* Add support for `failure_balance_transaction` on `Charge`