### PR TITLE
Add support for updating the version of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,7 @@
-export PHPDOCUMENTOR_VERSION := v3.0.0
+.PHONY: codegen-format update-version
+update-version:
+	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|VERSION = '\''[.\d]+'\''|VERSION = '\''$(VERSION)'\''|' lib/Stripe.php
 
-vendor: composer.json
-	composer install
-
-vendor/bin/phpdoc: vendor
-	curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar -o vendor/bin/phpdoc
-	chmod +x vendor/bin/phpdoc
-
-test: vendor
-	vendor/bin/phpunit
-.PHONY: test
-
-fmt: vendor
-	vendor/bin/php-cs-fixer fix -v --using-cache=no .
-.PHONY: fmt
-
-fmtcheck: vendor
-	vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
-.PHONY: fmtcheck
-
-phpdoc: vendor/bin/phpdoc
-	vendor/bin/phpdoc
-
-phpstan: vendor
-	php -d memory_limit=512M vendor/bin/phpstan analyse lib tests
-.PHONY: phpstan
-
-phpstan-baseline: vendor/bin/phpstan
-	php -d memory_limit=512M vendor/bin/phpstan analyse lib tests --generate-baseline
-.PHONY: phpstan-baseline
+codegen-format:
+	composer install && ./vendor/bin/php-cs-fixer fix -v --using-cache=no .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,39 @@
-.PHONY: codegen-format update-version
+export PHPDOCUMENTOR_VERSION := v3.0.0
+
+vendor: composer.json
+	composer install
+
+vendor/bin/phpdoc: vendor
+	curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar -o vendor/bin/phpdoc
+	chmod +x vendor/bin/phpdoc
+
+test: vendor
+	vendor/bin/phpunit
+.PHONY: test
+
+fmt: vendor
+	vendor/bin/php-cs-fixer fix -v --using-cache=no .
+.PHONY: fmt
+
+fmtcheck: vendor
+	vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
+.PHONY: fmtcheck
+
+phpdoc: vendor/bin/phpdoc
+	vendor/bin/phpdoc
+
+phpstan: vendor
+	php -d memory_limit=512M vendor/bin/phpstan analyse lib tests
+.PHONY: phpstan
+
+phpstan-baseline: vendor/bin/phpstan
+	php -d memory_limit=512M vendor/bin/phpstan analyse lib tests --generate-baseline
+.PHONY: phpstan-baseline
+
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|VERSION = '\''[.\d]+'\''|VERSION = '\''$(VERSION)'\''|' lib/Stripe.php
+.PHONY: update-version
 
-codegen-format:
-	composer install && ./vendor/bin/php-cs-fixer fix -v --using-cache=no .
+codegen-format: fmt
+.PHONY: codegen-format


### PR DESCRIPTION
Encodes the logic for version updating as a Makefile. Simplifies what the generation tools needs to know about the repo.
The plan is to have the same interface across all the repos.

Sample usage:

```
make update-version VERSION=1.2.5
```

Also adds a target that codegen will use to format all our repos:

```
make codegen-format
```