### PR TITLE
Allow users to pass a custom IPRESOLVE cURL option.

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -271,9 +271,14 @@ class CurlClient implements ClientInterface, StreamingClientInterface
             $opts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2TLS;
         }
 
-        // Stripe's API servers are only accessible over IPv4. Force IPv4 resolving to avoid
-        // potential issues (cf. https://github.com/stripe/stripe-php/issues/1045).
-        $opts[\CURLOPT_IPRESOLVE] = \CURL_IPRESOLVE_V4;
+        // If the user didn't explicitly specify a CURLOPT_IPRESOLVE option, we
+        // force IPv4 resolving as Stripe's API servers are only accessible over
+        // IPv4 (see. https://github.com/stripe/stripe-php/issues/1045).
+        // We let users specify a custom option in case they need to say proxy
+        // through an IPv6 proxy.
+        if (!isset($opts[\CURLOPT_IPRESOLVE])) {
+            $opts[\CURLOPT_IPRESOLVE] = \CURL_IPRESOLVE_V4;
+        }
 
         return [$opts, $absUrl];
     }

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -165,6 +165,14 @@ final class CurlClientTest extends \Stripe\TestCase
         static::assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
     }
 
+    public function testIpResolveOption()
+    {
+        // make sure options array loads/saves properly
+        $optionsArray = [\CURLOPT_IPRESOLVE => \CURL_IPRESOLVE_WHATEVER];
+        $withOptionsArray = new CurlClient($optionsArray);
+        static::assertSame($withOptionsArray->getDefaultOptions(), $optionsArray);
+    }
+
     public function testShouldRetryOnTimeout()
     {
         \Stripe\Stripe::setMaxNetworkRetries(2);


### PR DESCRIPTION
r? @richardm-stripe 

## Summary

Allow users to pass a custom IPRESOLVE cURL option. **Note: Stripe API currently only supports IPv4**. 

```
$optionsArray = [\CURLOPT_IPRESOLVE => \CURL_IPRESOLVE_WHATEVER];
$client = new CurlClient($optionsArray);
```

This lets users pass `IPRESOLVE_WHATEVER` if they are proxying to Stripe through an IPv6 proxy or some other approach rather than connecting directly.

## Motivation

https://github.com/stripe/stripe-php/pull/1046#issuecomment-1107444105