### PR TITLE
Pin setup-php action version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
 
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug


### PR DESCRIPTION
r? @pakrym-stripe 

## Summary

Pins the `setup-php` action to a major to avoid this breaking down the line accidentally.