### PR TITLE
fix: Update RequestOptions#redactedApiKey to stop exploding null.

### DIFF
--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -154,8 +154,13 @@ class RequestOptions
         throw new \Stripe\Exception\InvalidArgumentException($message);
     }
 
+    /** @return string */
     private function redactedApiKey()
     {
+        if (is_null($this->apiKey)) {
+            return '';
+        }
+
         $pieces = \explode('_', $this->apiKey, 3);
         $last = \array_pop($pieces);
         $redactedLast = \strlen($last) > 4

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -157,7 +157,7 @@ class RequestOptions
     /** @return string */
     private function redactedApiKey()
     {
-        if (is_null($this->apiKey)) {
+        if (null === $this->apiKey) {
             return '';
         }
 

--- a/tests/Stripe/Util/RequestOptionsTest.php
+++ b/tests/Stripe/Util/RequestOptionsTest.php
@@ -168,5 +168,9 @@ final class RequestOptionsTest extends \Stripe\TestCase
         $opts = RequestOptions::parse(['api_key' => '1234567890abcdefghijklmn']);
         $debugInfo = \print_r($opts, true);
         static::compatAssertStringContainsString('[apiKey] => ********************klmn', $debugInfo);
+
+        $opts = RequestOptions::parse([]);
+        $debugInfo = \print_r($opts, true);
+        static::compatAssertStringContainsString("[apiKey] => \n", $debugInfo);
     }
 }


### PR DESCRIPTION
r? @kamil-stripe 

## Summary

Updates `RequestOptions#redactedApiKey` to handle the null case properly, otherwise this shows a warning in PHP 8.1 as passing null to explode is deprecated.

## Motivation

https://github.com/stripe/stripe-php/issues/1237