### PR TITLE
Fix: Configure finder for `friendsofphp/php-cs-fixer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: PHP-CS-Fixer
         uses: docker://oskarstark/php-cs-fixer-ga:3.4.0
         with:
-          args: --format=txt --diff --dry-run --using-cache=no --verbose .
+          args: --format=txt --diff --dry-run --using-cache=no --verbose
 
   phpstan:
     name: PHPStan

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,6 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
     ->notPath('tests/TestCase.php');
 
 $config = new PhpCsFixer\Config();

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test: vendor
 .PHONY: test
 
 fmt: vendor
-	vendor/bin/php-cs-fixer fix -v --using-cache=no .
+	vendor/bin/php-cs-fixer fix -v --using-cache=no
 .PHONY: fmt
 
 fmtcheck: vendor
-	vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no .
+	vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no
 .PHONY: fmtcheck
 
 phpdoc: vendor/bin/phpdoc


### PR DESCRIPTION
This pull request

- [x] configures the finder for `friendsofphp/php-cs-fixer`

Running

```shell
vendor/bin/php-cs-fixer fix
```

on current `master` yields

```
Loaded config default from "/Users/am/Sites/stripe/stripe-php/.php-cs-fixer.php".
Using cache file ".php-cs-fixer.cache".

In Finder.php line 611:

  You must call one of in() or append() methods before iterating over a Finder.


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>...]
```
