### PR TITLE
chore: Remove coveralls and Travis references.

### DIFF
--- a/.coveralls.github-actions.yml
+++ b/.coveralls.github-actions.yml
@@ -1,3 +1,0 @@
-service_name: github-actions
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,0 @@
-service_name: travis-ci
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,8 @@
 
 # A list of files and folders those will be excluded from archives and the
 # Composer package (for purposes of making it smaller).
-/.coveralls.yml export-ignore
 /.github export-ignore
 /.gitattributes export-ignore
-/.travis.yml export-ignore
 /.vscode export-ignore
 /examples export-ignore
 /phpunit.xml export-ignore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stripe PHP bindings
 
-[![Build Status](https://travis-ci.org/stripe/stripe-php.svg?branch=master)](https://travis-ci.org/stripe/stripe-php)
+[![Build Status](https://github.com/stripe/stripe-php/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-php/actions?query=branch%3Amaster)
 [![Latest Stable Version](https://poser.pugx.org/stripe/stripe-php/v/stable.svg)](https://packagist.org/packages/stripe/stripe-php)
 [![Total Downloads](https://poser.pugx.org/stripe/stripe-php/downloads.svg)](https://packagist.org/packages/stripe/stripe-php)
 [![License](https://poser.pugx.org/stripe/stripe-php/license.svg)](https://packagist.org/packages/stripe/stripe-php)


### PR DESCRIPTION
Removes references to Travis + Coveralls.

Coveralls was removed in https://github.com/stripe/stripe-php/pull/1211
Travis was removed in https://github.com/stripe/stripe-php/pull/1138

r? @pakrym-stripe 