### PR TITLE
Trigger workflows on beta branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - beta
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - beta
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Add `beta` branch to `push` and `pr` triggers.

r? @dcr-stripe 