### PR TITLE
fix: Transform error StripeObjects to ErrorObject.

### DIFF
--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -116,5 +116,9 @@ class ObjectTypes
         \Stripe\UsageRecord::OBJECT_NAME => \Stripe\UsageRecord::class,
         \Stripe\UsageRecordSummary::OBJECT_NAME => \Stripe\UsageRecordSummary::class,
         \Stripe\WebhookEndpoint::OBJECT_NAME => \Stripe\WebhookEndpoint::class,
+        'api_error' => \Stripe\ErrorObject::class,
+        'card_error' => \Stripe\ErrorObject::class,
+        'idempotency_error' => \Stripe\ErrorObject::class,
+        'invalid_request_error' => \Stripe\ErrorObject::class,
     ];
 }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -55,6 +55,9 @@ abstract class Util
         if (\is_array($resp)) {
             if (isset($resp['object']) && \is_string($resp['object']) && isset($types[$resp['object']])) {
                 $class = $types[$resp['object']];
+            // Error objects are a special case and use the "type" field instead of "object".
+            } elseif (isset($resp['type']) && \is_string($resp['type']) && isset($types[$resp['type']]) && \Stripe\ErrorObject::class === $types[$resp['type']]) {
+                $class = \Stripe\ErrorObject::class;
             } else {
                 $class = \Stripe\StripeObject::class;
             }

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -106,4 +106,24 @@ final class PaymentIntentTest extends \Stripe\TestCase
         $resource->confirm();
         static::assertInstanceOf(\Stripe\PaymentIntent::class, $resource);
     }
+
+    public function testLastPaymentErrorIsStripeError()
+    {
+        $response = json_decode(\file_get_contents('tests/data/payment_intent_last_payment_error_fixture.json'), true);
+
+        $this->stubRequest(
+            'GET',
+            '/v1/payment_intents/' . self::TEST_RESOURCE_ID,
+            [],
+            null,
+            false,
+            $response,
+        );
+
+        $resource = PaymentIntent::retrieve(self::TEST_RESOURCE_ID);
+        $error = $resource->last_payment_error;
+        static::assertInstanceOf(\Stripe\ErrorObject::class, $error);
+        static::assertEquals('card_error', $error->type);
+        static::assertEquals('ch_123', $error->charge);
+    }
 }

--- a/tests/Stripe/PaymentIntentTest.php
+++ b/tests/Stripe/PaymentIntentTest.php
@@ -117,13 +117,13 @@ final class PaymentIntentTest extends \Stripe\TestCase
             [],
             null,
             false,
-            $response,
+            $response
         );
 
         $resource = PaymentIntent::retrieve(self::TEST_RESOURCE_ID);
         $error = $resource->last_payment_error;
         static::assertInstanceOf(\Stripe\ErrorObject::class, $error);
-        static::assertEquals('card_error', $error->type);
-        static::assertEquals('ch_123', $error->charge);
+        static::assertSame('card_error', $error->type);
+        static::assertSame('ch_123', $error->charge);
     }
 }

--- a/tests/data/payment_intent_last_payment_error_fixture.json
+++ b/tests/data/payment_intent_last_payment_error_fixture.json
@@ -1,0 +1,62 @@
+{
+  "id": "pi_123",
+  "object": "payment_intent",
+  "amount": 100,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "automatic",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_123",
+        "object": "charge"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/charges?payment_intent=pi_123"
+  },
+  "client_secret": null,
+  "confirmation_method": "publishable",
+  "created": 1541614878,
+  "currency": "eur",
+  "customer": "cus_DvnENrEbZJeIQE",
+  "description": "PaymentIntent Description",
+  "last_payment_error": {
+    "charge": "ch_123",
+    "code": "card_declined",
+    "decline_code": "generic_decline",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card was declined.",
+    "source": {
+      "id": "card_123",
+      "object": "card",
+      "brand": "Visa",
+      "country": "US",
+      "customer": "cus_123",
+      "exp_month": 9,
+      "exp_year": 2019,
+      "fingerprint": "fingerprint",
+      "last4": "0341"
+    },
+    "type": "card_error"
+  },
+  "livemode": false,
+  "next_source_action": null,
+  "on_behalf_of": null,
+  "payment_method_types": ["card"],
+  "receipt_email": null,
+  "return_url": null,
+  "review": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "status": "requires_source",
+  "transfer_data": null,
+  "transfer_group": null
+}


### PR DESCRIPTION
r? kamil-stripe

## Summary

Include the error types in the object type mapping and start transforming API objects returned with these types to `ErrorObject`.

## Motivation

Fixes https://github.com/stripe/stripe-php/issues/1353

We explicitly state in the type annotation that these are `ErrorObject`s but they weren't getting transformed appropriately.