### PR TITLE
Add SingletonRetrieve that can be used in generated code

### DIFF
--- a/init.php
+++ b/init.php
@@ -57,6 +57,7 @@ require __DIR__ . '/lib/ApiOperations/NestedResource.php';
 require __DIR__ . '/lib/ApiOperations/Request.php';
 require __DIR__ . '/lib/ApiOperations/Retrieve.php';
 require __DIR__ . '/lib/ApiOperations/Search.php';
+require __DIR__ . '/lib/ApiOperations/SingletonRetrieve.php';
 require __DIR__ . '/lib/ApiOperations/Update.php';
 
 // Plumbing

--- a/lib/ApiOperations/SingletonRetrieve.php
+++ b/lib/ApiOperations/SingletonRetrieve.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stripe\ApiOperations;
+
+/**
+ * Trait for retrievable singleton resources. Adds a `retrieve()` static method to the
+ * class.
+ *
+ * This trait should only be applied to classes that derive from SingletonApiResource.
+ */
+trait SingletonRetrieve
+{
+    /**
+     * @param array|string $id the ID of the API resource to retrieve,
+     *     or an options array containing an `id` key
+     * @param null|array|string $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return static
+     */
+    public static function retrieve($opts = null)
+    {
+        $opts = Util\RequestOptions::parse($opts);
+        $instance = new static(null, $opts);
+        $instance->refresh();
+
+        return $instance;
+    }
+}

--- a/lib/ApiOperations/SingletonRetrieve.php
+++ b/lib/ApiOperations/SingletonRetrieve.php
@@ -21,7 +21,7 @@ trait SingletonRetrieve
      */
     public static function retrieve($opts = null)
     {
-        $opts = Util\RequestOptions::parse($opts);
+        $opts = \Stripe\Util\RequestOptions::parse($opts);
         $instance = new static(null, $opts);
         $instance->refresh();
 

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -31,15 +31,5 @@ class Balance extends SingletonApiResource
 {
     const OBJECT_NAME = 'balance';
 
-    /**
-     * @param null|array|string $opts
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return \Stripe\Balance
-     */
-    public static function retrieve($opts = null)
-    {
-        return self::_singletonRetrieve($opts);
-    }
+    use ApiOperations\SingletonRetrieve;
 }

--- a/lib/SingletonApiResource.php
+++ b/lib/SingletonApiResource.php
@@ -7,15 +7,6 @@ namespace Stripe;
  */
 abstract class SingletonApiResource extends ApiResource
 {
-    protected static function _singletonRetrieve($options = null)
-    {
-        $opts = Util\RequestOptions::parse($options);
-        $instance = new static(null, $opts);
-        $instance->refresh();
-
-        return $instance;
-    }
-
     /**
      * @return string the endpoint associated with this singleton class
      */


### PR DESCRIPTION
Move `_singletonRetrieve` into a trait that can be used similarly to other standard method traits.