### PR TITLE
Deprecate save()

### DIFF
--- a/lib/ApiOperations/Update.php
+++ b/lib/ApiOperations/Update.php
@@ -38,7 +38,9 @@ trait Update
      *
      * @return static the saved resource
      *
-     * @deprecated The `save` method is deprecated and will be removed in future major version of the library. Use the static method `update` on the resource instead.
+     * @deprecated The `save` method is deprecated and will be removed in a
+     *     future major version of the library. Use the static method `update`
+     *     on the resource instead.
      */
     public function save($opts = null)
     {

--- a/lib/ApiOperations/Update.php
+++ b/lib/ApiOperations/Update.php
@@ -37,6 +37,8 @@ trait Update
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
      * @return static the saved resource
+     *
+     * @deprecated The save method is deprecated and for backwards compatibility only. Use the update method with the resource ID instead.
      */
     public function save($opts = null)
     {

--- a/lib/ApiOperations/Update.php
+++ b/lib/ApiOperations/Update.php
@@ -38,7 +38,7 @@ trait Update
      *
      * @return static the saved resource
      *
-     * @deprecated The save method is deprecated and for backwards compatibility only. Use the update method with the resource ID instead.
+     * @deprecated The `save` method is deprecated and will be removed in future major version of the library. Use the static method `update` on the resource instead.
      */
     public function save($opts = null)
     {


### PR DESCRIPTION
## Summary
Mark `save()` method as deprecated.

## Changelog
* Deprecate `save` method on resources in favor of `update`.