### PR TITLE
retrievePaymentMethod's return type is wrong.

### DIFF
--- a/lib/Service/CustomerService.php
+++ b/lib/Service/CustomerService.php
@@ -337,7 +337,7 @@ class CustomerService extends \Stripe\Service\AbstractService
      *
      * @throws \Stripe\Exception\ApiErrorException if the request fails
      *
-     * @return \Stripe\Customer
+     * @return \Stripe\PaymentMethod
      */
     public function retrievePaymentMethod($parentId, $id, $params = null, $opts = null)
     {


### PR DESCRIPTION
### summary
`retrievePaymentMethod`'s return type is wrong.

```
++ @return \Stripe\Customer
-- @return \Stripe\PaymentMethod
```
