### PR TITLE
Allow to pass params to autoPagingIterator method

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -165,12 +165,14 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
     }
 
     /**
+     * @param null|array $params
+     *
      * @return \Generator|TStripeObject[] A generator that can be used to
      *    iterate across all objects across all pages. As page boundaries are
      *    encountered, the next page will be fetched automatically for
      *    continued iteration.
      */
-    public function autoPagingIterator()
+    public function autoPagingIterator($params = null)
     {
         $page = $this;
 
@@ -181,12 +183,12 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
                 foreach ($page->getReverseIterator() as $item) {
                     yield $item;
                 }
-                $page = $page->previousPage();
+                $page = $page->previousPage($params);
             } else {
                 foreach ($page as $item) {
                     yield $item;
                 }
-                $page = $page->nextPage();
+                $page = $page->nextPage($params);
             }
 
             if ($page->isEmpty()) {


### PR DESCRIPTION
This PR resolves https://github.com/stripe/stripe-php/issues/1400

By allowing to pass params to the underlying `nextPage` or `previousPage` methods we can expand data for the resources that are retrieved.

Example:

```php
$stripe = new \Stripe\StripeClient('stripe-secret');

$invoice = $stripe->invoices->retrieve('in_xxx', [
    'expand' => ['lines.data.tax_amounts.tax_rate'],
]);

foreach ($invoice->lines->autoPagingIterator(['expand' => ['data.tax_amounts.tax_rate']) as $line) {
    foreach ($line->tax_amounts as $tax_amount) {
        $tax_rate = $tax_amount->tax_rate;
        echo $tax_rate->display_name . ' ' . $tax_rate->percentage . '%' . PHP_EOL;
    }
}
```
