### PR TITLE
Switch to mb_convert_encoding to fix utf8_encode deprecation warning

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -85,7 +85,7 @@ abstract class Util
         }
 
         if (\is_string($value) && self::$isMbstringAvailable && 'UTF-8' !== \mb_detect_encoding($value, 'UTF-8', true)) {
-            return mb_convert_encoding($value, 'UTF-8', mb_list_encodings());
+            return mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1');
         }
 
         return $value;

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -85,7 +85,7 @@ abstract class Util
         }
 
         if (\is_string($value) && self::$isMbstringAvailable && 'UTF-8' !== \mb_detect_encoding($value, 'UTF-8', true)) {
-            return \utf8_encode($value);
+            return mb_convert_encoding($value, 'UTF-8', mb_list_encodings());
         }
 
         return $value;

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -74,7 +74,7 @@ abstract class Util
     public static function utf8($value)
     {
         if (null === self::$isMbstringAvailable) {
-            self::$isMbstringAvailable = \function_exists('mb_detect_encoding');
+            self::$isMbstringAvailable = \function_exists('mb_detect_encoding') && \function_exists('mb_convert_encoding');
 
             if (!self::$isMbstringAvailable) {
                 \trigger_error('It looks like the mbstring extension is not enabled. ' .


### PR DESCRIPTION
Fix for https://github.com/stripe/stripe-php/issues/1415

Following https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated#utf8_encode-iso8859-mbstring, this PR replaces our previous usage of `utf8_encode` with `mb_convert_encoding`.

`utf8_encode` previously converted character encodings from ISO-8859-1 to UTF-8, even if the source text was not encoded in ISO-8859-1. This fix retains that functionality.