### PR TITLE
Fix Stripe::setAccountId parameter type

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -185,7 +185,7 @@ class Stripe
     }
 
     /**
-     * @param string $accountId the Stripe account ID to set for connected
+     * @param null|string $accountId the Stripe account ID to set for connected
      *   account requests
      */
     public static function setAccountId($accountId)


### PR DESCRIPTION
The account ID is a nullable property but, according the PHPDoc, the related setter method doesn't accept `null` as an argument (while in fact passing `null` works fine).
I think it's correct to accept `null` to be able to reset this static property.

Updating the PHPDoc will fix the PHPStan errors of the form `Parameter #1 $accountId of method Stripe\Stripe::setAccountId() expects string, null given.`.