### PR TITLE
Fix: Remove parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ composer require stripe/stripe-php
 To use the bindings, use Composer's [autoload](https://getcomposer.org/doc/01-basic-usage.md#autoloading):
 
 ```php
-require_once('vendor/autoload.php');
+require_once 'vendor/autoload.php';
 ```
 
 ## Manual Installation
@@ -35,7 +35,7 @@ require_once('vendor/autoload.php');
 If you do not wish to use Composer, you can download the [latest release](https://github.com/stripe/stripe-php/releases). Then, to use the bindings, include the `init.php` file.
 
 ```php
-require_once('/path/to/stripe-php/init.php');
+require_once '/path/to/stripe-php/init.php';
 ```
 
 ## Dependencies


### PR DESCRIPTION
This pull request

- [x] removes unnecessary parentheses from `require_once` statements in `README.md`