### PR TITLE
Handle developer message in preview error responses

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -194,7 +194,7 @@ class ApiRequestor
      */
     private static function _specificAPIError($rbody, $rcode, $rheaders, $resp, $errorData)
     {
-        $msg = isset($errorData['message']) ? $errorData['message'] : null;
+        $msg = isset($errorData['message']) ? $errorData['message'] : (isset($errorData['developer_message']) ? $errorData['developer_message'] : null);
         $param = isset($errorData['param']) ? $errorData['param'] : null;
         $code = isset($errorData['code']) ? $errorData['code'] : null;
         $type = isset($errorData['type']) ? $errorData['type'] : null;

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -503,6 +503,33 @@ final class ApiRequestorTest extends \Stripe\TestCase
         }
     }
 
+    public function testHandlesErrorWithDeveloperMessage()
+    {
+        $this->stubRequest(
+            'POST',
+            '/v1/charges',
+            [],
+            null,
+            false,
+            [
+                'error' => [
+                    'developer_message' => 'Unacceptable',
+                ],
+            ],
+            400
+        );
+
+        try {
+            Charge::create();
+            static::fail('Did not raise error');
+        } catch (Exception\InvalidRequestException $e) {
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('Unacceptable', $e->getMessage());
+        } catch (\Exception $e) {
+            static::fail('Unexpected exception: ' . \get_class($e));
+        }
+    }
+
     public function testHeaderStripeVersionGlobal()
     {
         Stripe::setApiVersion('2222-22-22');


### PR DESCRIPTION
The error message can be returned in a developer_message field, handle this case and throw a useful error.