### PR TITLE
Webhook: `getTimestamp()`: fixes `is_numeric()` issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ background terminal ([stripe-mock's README][stripe-mock] also contains
 instructions for installing via Homebrew and other methods):
 
 ```bash
-go get -u github.com/stripe/stripe-mock
+go install github.com/stripe/stripe-mock@latest
 stripe-mock
 ```
 

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -84,12 +84,15 @@ abstract class WebhookSignature
      */
     private static function getTimestamp($header)
     {
+        // NOTE: if multiple timestamps are given,
+        // only the first one is validated and others are silenty ignored
+
         $items = \explode(',', $header);
 
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
             if ('t' === $itemParts[0]) {
-                if (!\is_numeric($itemParts[1])) {
+                if (false === \filter_var($itemParts[1], \FILTER_VALIDATE_INT) || (int) $itemParts[1] < 0) {
                     return -1;
                 }
 

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -92,7 +92,7 @@ abstract class WebhookSignature
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
             if ('t' === $itemParts[0]) {
-                if ((string) \filter_var($itemParts[1], \FILTER_VALIDATE_INT) !== $itemParts[1] || (int) $itemParts[1] < 0) {
+                if ((string) \filter_var($itemParts[1], \FILTER_VALIDATE_INT) !== $itemParts[1] || $itemParts[1] < 0) {
                     return -1;
                 }
 

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -26,7 +26,7 @@ abstract class WebhookSignature
     public static function verifyHeader($payload, $header, $secret, $tolerance = null)
     {
         // Extract timestamp and validate header
-        if (1 !== \preg_match('/^t=([0-9]+)(?:,v[0-9]=[0-9a-z_]+)+$/', $header, $matches)) {
+        if (1 !== \preg_match('/^t=([1-9][0-9]{9})(?:,v[0-9]=[0-9a-z]{64})+$/', $header, $matches)) {
             throw Exception\SignatureVerificationException::factory(
                 'Unable to extract timestamp and signatures from header',
                 $payload,
@@ -46,7 +46,7 @@ abstract class WebhookSignature
         }
 
         // Extracts all signatures for the expected scheme
-        if (!\preg_match_all('/(?:' . self::EXPECTED_SCHEME . '=([0-9a-z_]+))+/', $header, $matches)) {
+        if (!\preg_match_all('/(?:' . self::EXPECTED_SCHEME . '=([0-9a-z]{64}))+/', $header, $matches)) {
             throw Exception\SignatureVerificationException::factory(
                 'No signatures found with expected scheme',
                 $payload,

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -16,7 +16,8 @@ abstract class WebhookSignature
      *  Stripe
      * @param string $secret secret used to generate the signature
      * @param int $tolerance maximum difference allowed between the header's
-     *  timestamp and the current time
+     *  timestamp and the current time in seconds, requires a value > 0 to
+     *  validate it against the current time
      *
      * @throws Exception\SignatureVerificationException if the verification fails
      *
@@ -24,17 +25,28 @@ abstract class WebhookSignature
      */
     public static function verifyHeader($payload, $header, $secret, $tolerance = null)
     {
-        // Extract timestamp and signatures from header
-        $timestamp = self::getTimestamp($header);
-        $signatures = self::getSignatures($header, self::EXPECTED_SCHEME);
-        if (-1 === $timestamp) {
+        // Extract timestamp and validate header
+        if (1 !== \preg_match('/^t=([0-9]+)(?:,v[0-9]=[0-9a-z_]+)+$/', $header, $matches)) {
             throw Exception\SignatureVerificationException::factory(
                 'Unable to extract timestamp and signatures from header',
                 $payload,
                 $header
             );
         }
-        if (empty($signatures)) {
+
+        $timestamp = $matches[1];
+
+        // Check if timestamp is within tolerance
+        if (($tolerance > 0) && (\abs(\time() - $timestamp) > $tolerance)) {
+            throw Exception\SignatureVerificationException::factory(
+                'Timestamp outside the tolerance zone',
+                $payload,
+                $header
+            );
+        }
+
+        // Extracts all signatures for the expected scheme
+        if (!\preg_match_all('/(?:' . self::EXPECTED_SCHEME . '=([0-9a-z_]+))+/', $header, $matches)) {
             throw Exception\SignatureVerificationException::factory(
                 'No signatures found with expected scheme',
                 $payload,
@@ -46,81 +58,18 @@ abstract class WebhookSignature
         // header
         $signedPayload = "{$timestamp}.{$payload}";
         $expectedSignature = self::computeSignature($signedPayload, $secret);
-        $signatureFound = false;
-        foreach ($signatures as $signature) {
+
+        foreach ($matches[1] as $signature) {
             if (Util\Util::secureCompare($expectedSignature, $signature)) {
-                $signatureFound = true;
-
-                break;
-            }
-        }
-        if (!$signatureFound) {
-            throw Exception\SignatureVerificationException::factory(
-                'No signatures found matching the expected signature for payload',
-                $payload,
-                $header
-            );
-        }
-
-        // Check if timestamp is within tolerance
-        if (($tolerance > 0) && (\abs(\time() - $timestamp) > $tolerance)) {
-            throw Exception\SignatureVerificationException::factory(
-                'Timestamp outside the tolerance zone',
-                $payload,
-                $header
-            );
-        }
-
-        return true;
-    }
-
-    /**
-     * Extracts the timestamp in a signature header.
-     *
-     * @param string $header the signature header
-     *
-     * @return int the timestamp contained in the header, or -1 if no valid
-     *  timestamp is found
-     */
-    private static function getTimestamp($header)
-    {
-        $items = \explode(',', $header);
-
-        foreach ($items as $item) {
-            $itemParts = \explode('=', $item, 2);
-            if ('t' === $itemParts[0]) {
-                if (!\is_numeric($itemParts[1])) {
-                    return -1;
-                }
-
-                return (int) ($itemParts[1]);
+                return true;
             }
         }
 
-        return -1;
-    }
-
-    /**
-     * Extracts the signatures matching a given scheme in a signature header.
-     *
-     * @param string $header the signature header
-     * @param string $scheme the signature scheme to look for
-     *
-     * @return array the list of signatures matching the provided scheme
-     */
-    private static function getSignatures($header, $scheme)
-    {
-        $signatures = [];
-        $items = \explode(',', $header);
-
-        foreach ($items as $item) {
-            $itemParts = \explode('=', $item, 2);
-            if (\trim($itemParts[0]) === $scheme) {
-                $signatures[] = $itemParts[1];
-            }
-        }
-
-        return $signatures;
+        throw Exception\SignatureVerificationException::factory(
+            'No signatures found matching the expected signature for payload',
+            $payload,
+            $header
+        );
     }
 
     /**

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -92,7 +92,7 @@ abstract class WebhookSignature
         foreach ($items as $item) {
             $itemParts = \explode('=', $item, 2);
             if ('t' === $itemParts[0]) {
-                if (false === \filter_var($itemParts[1], \FILTER_VALIDATE_INT) || (int) $itemParts[1] < 0) {
+                if ((string) \filter_var($itemParts[1], \FILTER_VALIDATE_INT) !== $itemParts[1] || (int) $itemParts[1] < 0) {
                     return -1;
                 }
 

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -109,7 +109,7 @@ final class WebhookTest extends \Stripe\TestCase
 
     public function testHeaderContainsValidSignature()
     {
-        $sigHeader = $this->generateHeader() . ',v1=bad_signature';
+        $sigHeader = $this->generateHeader() . ',' . WebhookSignature::EXPECTED_SCHEME . '=bad_signature';
         static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
     }
 

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -79,7 +79,7 @@ final class WebhookTest extends \Stripe\TestCase
         $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
-        $sigHeader = $this->generateHeader(['signature' => 'bad_signature']);
+        $sigHeader = $this->generateHeader(['signature' => \hash('sha256', 'bad_signature')]);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
@@ -109,13 +109,13 @@ final class WebhookTest extends \Stripe\TestCase
 
     public function testHeaderContainsValidSignature()
     {
-        $sigHeader = $this->generateHeader() . ',v1=bad_signature';
+        $sigHeader = $this->generateHeader() . ',v1=' . \hash('sha256', 'bad_signature');
         static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
     }
 
     public function testTimestampOffButNoTolerance()
     {
-        $sigHeader = $this->generateHeader(['timestamp' => 12345]);
+        $sigHeader = $this->generateHeader(['timestamp' => 1023456789]);
         static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET));
     }
 }

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -79,7 +79,7 @@ final class WebhookTest extends \Stripe\TestCase
         $this->expectException(\Stripe\Exception\SignatureVerificationException::class);
         $this->expectExceptionMessage('No signatures found matching the expected signature for payload');
 
-        $sigHeader = $this->generateHeader(['signature' => \hash('sha256', 'bad_signature')]);
+        $sigHeader = $this->generateHeader(['signature' => 'bad_signature']);
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
@@ -109,13 +109,13 @@ final class WebhookTest extends \Stripe\TestCase
 
     public function testHeaderContainsValidSignature()
     {
-        $sigHeader = $this->generateHeader() . ',v1=' . \hash('sha256', 'bad_signature');
+        $sigHeader = $this->generateHeader() . ',v1=bad_signature';
         static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET, 10));
     }
 
     public function testTimestampOffButNoTolerance()
     {
-        $sigHeader = $this->generateHeader(['timestamp' => 1023456789]);
+        $sigHeader = $this->generateHeader(['timestamp' => 12345]);
         static::assertTrue(WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET));
     }
 }


### PR DESCRIPTION
`is_numeric()` allows for invalid timestamps, for example: a negative integer

```php
<?php
// the following pass the validation with `is_numeric()`
$tests = array(
    "0x539",
    "02471",
    "9.1",
    " 42",
    "58635272821786587286382824657568871098287278276543219876543",
    "0.0",
    ".0",
    "0.",
    "1.8e617",
    "1337e0",
    "0E1",
    "2E1",
    "1e-2",
    "-1.3e3",
    " +3",
    " -1.1",
    "000",
    "-1",
);
?>
```
