### PR TITLE
stripe-php v11 release

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -348,6 +348,7 @@ class ApiRequestor
             'X-Stripe-Client-User-Agent' => \json_encode($ua),
             'User-Agent' => $uaString,
             'Authorization' => 'Bearer ' . $apiKey,
+            'Stripe-Version' => Stripe::getApiVersion(),
         ];
     }
 
@@ -393,9 +394,6 @@ class ApiRequestor
         $absUrl = $this->_apiBase . $url;
         $params = self::_encodeObjects($params);
         $defaultHeaders = $this->_defaultHeaders($myApiKey, $clientUAInfo);
-        if (Stripe::$apiVersion) {
-            $defaultHeaders['Stripe-Version'] = Stripe::$apiVersion;
-        }
 
         if (Stripe::$accountId) {
             $defaultHeaders['Stripe-Account'] = Stripe::$accountId;

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -18,6 +18,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
         'api_key' => null,
         'client_id' => null,
         'stripe_account' => null,
+        // Note, even if null, ApiRequestor will default this to Stripe::$apiVersion
         'stripe_version' => null,
         'api_base' => self::DEFAULT_API_BASE,
         'connect_base' => self::DEFAULT_CONNECT_BASE,

--- a/lib/Invoice.php
+++ b/lib/Invoice.php
@@ -158,9 +158,6 @@ class Invoice extends ApiResource
     const BILLING_CHARGE_AUTOMATICALLY = 'charge_automatically';
     const BILLING_SEND_INVOICE = 'send_invoice';
 
-    /** @deprecated */
-    const STATUS_DELETED = 'deleted';
-
     /**
      * @param null|array $params
      * @param null|array|string $opts

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -119,7 +119,7 @@ class Stripe
     }
 
     /**
-     * @return string The API version used for requests.
+     * @return string the API version used for requests
      */
     public static function getApiVersion()
     {

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -23,7 +23,7 @@ class Stripe
     public static $apiUploadBase = 'https://files.stripe.com';
 
     /** @var null|string The version of the Stripe API to use for requests. */
-    public static $apiVersion = null;
+    public static $apiVersion = \Stripe\Util\ApiVersion::CURRENT;
 
     /** @var null|string The account ID for connected accounts requests. */
     public static $accountId = null;

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -22,7 +22,7 @@ class Stripe
     /** @var string The base URL for the Stripe API uploads endpoint. */
     public static $apiUploadBase = 'https://files.stripe.com';
 
-    /** @var null|string The version of the Stripe API to use for requests. */
+    /** @var string The version of the Stripe API to use for requests. */
     public static $apiVersion = \Stripe\Util\ApiVersion::CURRENT;
 
     /** @var null|string The account ID for connected accounts requests. */
@@ -119,8 +119,7 @@ class Stripe
     }
 
     /**
-     * @return string The API version used for requests. null if we're using the
-     *    latest version.
+     * @return string The API version used for requests.
      */
     public static function getApiVersion()
     {

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -82,6 +82,11 @@ final class ApiRequestorTest extends \Stripe\TestCase
             'Stripe/v1 PhpBindings/' . Stripe::VERSION . ' MyTestApp/1.2.34 (https://mytestapp.example)'
         );
 
+        static::assertSame(
+            $headers['Stripe-Version'],
+            Stripe::getApiVersion()
+        );
+
         static::assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
 

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -43,7 +43,6 @@ trait TestHelper
         Stripe::$apiUploadBase = \defined('MOCK_URL') ? MOCK_URL : 'http://localhost:12111';
         Stripe::setApiKey('sk_test_123');
         Stripe::setClientId('ca_123');
-        Stripe::setApiVersion(null);
         Stripe::setAccountId(null);
 
         // Set up the HTTP client mocker
@@ -63,7 +62,6 @@ trait TestHelper
         Stripe::setEnableTelemetry(false);
         Stripe::setApiKey($this->origApiKey);
         Stripe::setClientId($this->origClientId);
-        Stripe::setApiVersion($this->origApiVersion);
         Stripe::setAccountId($this->origAccountId);
     }
 


### PR DESCRIPTION
## Changelog
**⚠️ ACTION REQUIRED: the breaking change in this release likely affects you ⚠️**

* ⚠️ Pin API version to `2023-08-16`
  In this release, Stripe API Version `2023-08-16` (the latest at time of release) will be sent by default on all requests.
  The previous default was to use your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version).

  To successfully upgrade to stripe-php v11, you must either

  1. **(Recommended) Upgrade your integration to be compatible with API Version `2023-08-16`.**

     Please read the API Changelog carefully for each API Version from `2023-08-16` back to your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version). Determine if you are using any of the APIs that have changed in a breaking way, and adjust your integration accordingly. Carefully test your changes with Stripe [Test Mode](https://stripe.com/docs/keys#test-live-modes) before deploying them to production.

     You can read the [v11 migration guide](https://github.com/stripe/stripe-php/wiki/Migration-guide-for-v11) for more detailed instructions.
  2. **(Alternative option) Specify a version other than `2023-08-16` when initializing `stripe-php`.**

     If you were previously initializing stripe-php without an explicit API Version, you can postpone modifying your integration by specifying a version equal to your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version). For example:

     ```diff
       // if using StripeClient
     - $stripe = new \Stripe\StripeClient('sk_test_xyz');
     + $stripe = new \Stripe\StripeClient([
     +   'api_key' => 'sk_test_xyz',
         'stripe_version' => '2020-08-27',
     + ]);

       // if using the global client
       Stripe.apiKey = "sk_test_xyz";
     + Stripe::setApiVersion('2020-08-27');
     ```

     If you were already initializing stripe-php with an explicit API Version, upgrading to v11 will not affect your integration.

     Read the [v11 migration guide](https://github.com/stripe-php/wiki/Migration-guide-for-v11) for more details.

  Going forward, each major release of this library will be *pinned* by default to the latest Stripe API Version at the time of release.

  That is, instead of upgrading stripe-php and separately upgrading your Stripe API Version through the Stripe Dashboard. whenever you upgrade major versions of stripe-php, you should also upgrade your integration to be compatible with the latest Stripe API version.

* ⚠️ Remove Invoice.STATUS_DELETE
