### PR TITLE
Address StripeClientInterface TODOs

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -170,54 +170,6 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     }
 
     /**
-     * Sends a request to Stripe's API.
-     *
-     * @param 'delete'|'get'|'post' $method the HTTP method
-     * @param string $path the path of the request
-     * @param array $params the parameters of the request
-     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
-     *
-     * @return \Stripe\Collection of ApiResources
-     */
-    public function requestCollection($method, $path, $params, $opts)
-    {
-        $obj = $this->request($method, $path, $params, $opts);
-        if (!($obj instanceof \Stripe\Collection)) {
-            $received_class = \get_class($obj);
-            $msg = "Expected to receive `Stripe\\Collection` object from Stripe API. Instead received `{$received_class}`.";
-
-            throw new \Stripe\Exception\UnexpectedValueException($msg);
-        }
-        $obj->setFilters($params);
-
-        return $obj;
-    }
-
-    /**
-     * Sends a request to Stripe's API.
-     *
-     * @param 'delete'|'get'|'post' $method the HTTP method
-     * @param string $path the path of the request
-     * @param array $params the parameters of the request
-     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
-     *
-     * @return \Stripe\SearchResult of ApiResources
-     */
-    public function requestSearchResult($method, $path, $params, $opts)
-    {
-        $obj = $this->request($method, $path, $params, $opts);
-        if (!($obj instanceof \Stripe\SearchResult)) {
-            $received_class = \get_class($obj);
-            $msg = "Expected to receive `Stripe\\SearchResult` object from Stripe API. Instead received `{$received_class}`.";
-
-            throw new \Stripe\Exception\UnexpectedValueException($msg);
-        }
-        $obj->setFilters($params);
-
-        return $obj;
-    }
-
-    /**
      * @param \Stripe\Util\RequestOptions $opts
      *
      * @throws \Stripe\Exception\AuthenticationException

--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -39,7 +39,7 @@ abstract class AbstractService
     }
 
     /**
-     * Gets the client used by this service to send requests.
+     * Gets the client used by this service to send streaming requests.
      *
      * @return \Stripe\StripeStreamingClientInterface
      */
@@ -77,23 +77,55 @@ abstract class AbstractService
 
     protected function requestStream($method, $path, $readBodyChunkCallable, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
         return $this->getStreamingClient()->requestStream($method, $path, $readBodyChunkCallable, self::formatParams($params), $opts);
     }
 
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param 'delete'|'get'|'post' $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\Collection of ApiResources
+     */
     protected function requestCollection($method, $path, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
-        return $this->getClient()->requestCollection($method, $path, self::formatParams($params), $opts);
+        $obj = $this->request($method, $path, $params, $opts);
+        if (!($obj instanceof \Stripe\Collection)) {
+            $received_class = \get_class($obj);
+            $msg = "Expected to receive `Stripe\\Collection` object from Stripe API. Instead received `{$received_class}`.";
+
+            throw new \Stripe\Exception\UnexpectedValueException($msg);
+        }
+        $obj->setFilters($params);
+
+        return $obj;
     }
 
+    /**
+     * Sends a request to Stripe's API.
+     *
+     * @param 'delete'|'get'|'post' $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return \Stripe\SearchResult of ApiResources
+     */
     protected function requestSearchResult($method, $path, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
-        return $this->getClient()->requestSearchResult($method, $path, self::formatParams($params), $opts);
+        $obj = $this->request($method, $path, $params, $opts);
+        if (!($obj instanceof \Stripe\SearchResult)) {
+            $received_class = \get_class($obj);
+            $msg = "Expected to receive `Stripe\\SearchResult` object from Stripe API. Instead received `{$received_class}`.";
+
+            throw new \Stripe\Exception\UnexpectedValueException($msg);
+        }
+        $obj->setFilters($params);
+
+        return $obj;
     }
 
     protected function buildPath($basePath, ...$ids)

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -18,4 +18,17 @@ interface StripeClientInterface extends BaseStripeClientInterface
      * @return \Stripe\StripeObject the object returned by Stripe's API
      */
     public function request($method, $path, $params, $opts);
+
+    /**
+     * Sends a request to Stripe's API, passing chunks of the streamed response
+     * into a user-provided $readBodyChunkCallable callback.
+     *
+     * @param 'delete'|'get'|'post' $method the HTTP method
+     * @param string $path the path of the request
+     * @param callable $readBodyChunkCallable a function that will be called
+     * @param array $params the parameters of the request
+     * @param array|\Stripe\Util\RequestOptions $opts the special modifiers of the request
+     * with chunks of bytes from the body if the request is successful
+     */
+    public function requestStream($method, $path, $readBodyChunkCallable, $params, $opts);
 }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -162,23 +162,6 @@ final class BaseStripeClientTest extends \Stripe\TestCase
         static::assertSame('acct_456', $this->optsReflector->getValue($charge)->headers['Stripe-Account']);
     }
 
-    public function testRequestCollectionWithClientApiKey()
-    {
-        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
-        $charges = $client->requestCollection('get', '/v1/charges', [], []);
-        static::assertNotNull($charges);
-        static::assertSame('sk_test_client', $this->optsReflector->getValue($charges)->apiKey);
-    }
-
-    public function testRequestCollectionThrowsForNonList()
-    {
-        $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Expected to receive `Stripe\Collection` object from Stripe API. Instead received `Stripe\Charge`.');
-
-        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
-        $client->requestCollection('get', '/v1/charges/ch_123', [], []);
-    }
-
     public function testRequestWithOptsInParamsWarns()
     {
         $this->compatExpectWarning(static::compatWarningClass());


### PR DESCRIPTION
## Summary
Resolves several TODOs inside BaseStripeClient.php -- although not exactly in the way the TODOs suggest.

## Changelog
* Add `requestStream` to `StripeClientInterface`
* Remove `BaseStripeClient->requestCollection` and `BaseStripeClient->requestSearchResult`. Moved these methods into `AbstractService`.