### PR TITLE
Enhancement: Run tests on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request

- [x] runs tests on PHP 8.3

💁‍♂️ PHP 8.3 is planned to be released on [November 23, 2023](https://wiki.php.net/todo/php83) - so this might be a little early. 