### PR TITLE
Fix: Remove `squizlabs/php_codesniffer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7 || ^9.0",
-    "squizlabs/php_codesniffer": "^3.3",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.2",
     "php-coveralls/php-coveralls": "^2.5"


### PR DESCRIPTION
This pull request

- [x] removes `squizlabs/php_codesniffer`

💁‍♂️ This dependency does not appear to be used anywhere in this project.