### PR TITLE
Fix: Do not bother removing `friendsofphp/php-cs-fixer`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,6 @@ jobs:
           # that, so we hash on "composer.json" instead.
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}
 
-      # We run php-cs-fixer in a separate job, but the version we use is not compatible
-      # with all the versions of PHP that we want to execute PHPStan upon
-      - name: Trim dependency
-        run: composer remove --dev --no-update friendsofphp/php-cs-fixer
-
       - name: Validate composer.json
         run: composer validate
 


### PR DESCRIPTION
This pull request

- [x] stops removing `friendsofphp/php-cs-fixer` in a GitHub Actions job
