### PR TITLE
Add paginated requests helper function and use in Search and All

### DIFF
--- a/lib/ApiOperations/All.php
+++ b/lib/ApiOperations/All.php
@@ -19,19 +19,8 @@ trait All
      */
     public static function all($params = null, $opts = null)
     {
-        self::_validateParams($params);
         $url = static::classUrl();
 
-        list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);
-        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
-        if (!($obj instanceof \Stripe\Collection)) {
-            throw new \Stripe\Exception\UnexpectedValueException(
-                'Expected type ' . \Stripe\Collection::class . ', got "' . \get_class($obj) . '" instead.'
-            );
-        }
-        $obj->setLastResponse($response);
-        $obj->setFilters($params);
-
-        return $obj;
+        return static::_requestPage($url, \Stripe\Collection::class, $params, $opts);
     }
 }

--- a/lib/ApiOperations/Search.php
+++ b/lib/ApiOperations/Search.php
@@ -20,18 +20,6 @@ trait Search
      */
     protected static function _searchResource($searchUrl, $params = null, $opts = null)
     {
-        self::_validateParams($params);
-
-        list($response, $opts) = static::_staticRequest('get', $searchUrl, $params, $opts);
-        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
-        if (!($obj instanceof \Stripe\SearchResult)) {
-            throw new \Stripe\Exception\UnexpectedValueException(
-                'Expected type ' . \Stripe\SearchResult::class . ', got "' . \get_class($obj) . '" instead.'
-            );
-        }
-        $obj->setLastResponse($response);
-        $obj->setFilters($params);
-
-        return $obj;
+        return static::_requestPage($searchUrl, \Stripe\SearchResult::class, $params, $opts);
     }
 }


### PR DESCRIPTION
For the purpose of de-magicking PHP search / all. This simplifies what the codegen will have to generate per resource (e.g. for search the body will just call the function _requestPage.)