### PR TITLE
Do not force resolution to IPV4 addresses

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -271,15 +271,6 @@ class CurlClient implements ClientInterface, StreamingClientInterface
             $opts[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2TLS;
         }
 
-        // If the user didn't explicitly specify a CURLOPT_IPRESOLVE option, we
-        // force IPv4 resolving as Stripe's API servers are only accessible over
-        // IPv4 (see. https://github.com/stripe/stripe-php/issues/1045).
-        // We let users specify a custom option in case they need to say proxy
-        // through an IPv6 proxy.
-        if (!isset($opts[\CURLOPT_IPRESOLVE])) {
-            $opts[\CURLOPT_IPRESOLVE] = \CURL_IPRESOLVE_V4;
-        }
-
         return [$opts, $absUrl];
     }
 


### PR DESCRIPTION
Stripe does not have an AAAA record so it's impossible to resolve an IPv6 address for `api.stripe.com`.

Forcing resolution to IPv4 via `CURL_IPRESOLVE_V4` [interferes with IPv4 over IPv6 proxy network setups and DNS64](https://github.com/stripe/stripe-php/pull/1046#issuecomment-1886833339).

We also don't enforce the same setting in any of the other libraries. 

## Changelog

* Do not force resolution to IPv4 - Forcing IPv4 was causing hard-to-understand failures for users in IPv6-only environments. If you want to force IPv4 yourself, you can do so by telling the API client to use a CurlClient other than the default
```
$curl = new \Stripe\HttpClient\CurlClient([CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4]);
\Stripe\ApiRequestor::setHttpClient($curl);
```
