### PR TITLE
Add idempotency_key constant

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -24,6 +24,8 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
         'files_base' => self::DEFAULT_FILES_BASE,
     ];
 
+    const IDEMPOTENCY_KEY = 'idempotency_key';
+
     /** @var array<string, mixed> */
     private $config;
 


### PR DESCRIPTION
I've found it rather easy to mistype and misremember the idempotecy key option while performing Stripe integrations. By adding the value as a constant, that class of error can be avoided during development by aid of IDEs, static analysis tools, etc. This gives a bit of a faster feedback cycle during development as well.

e.g. this:
```php
use Stripe\StripeClient;
// ...
$customer = $stripe->customers->create([
  'description' => '...',
], [
  'idempotency_key' => 'KG5LxwFBepaKHyUD'
]);
```

Could (but is not forced) to become this:
```php
use Stripe\StripeClient;
// ...
$customer = $stripe->customers->create([
  'description' => '...',
], [
  StripeClient::IDEMPOTENCY_KEY => 'KG5LxwFBepaKHyUD'
]);
```
