### PR TITLE
Fix \Stripe\Tax\Settings::update

### DIFF
--- a/lib/Tax/Settings.php
+++ b/lib/Tax/Settings.php
@@ -21,8 +21,27 @@ class Settings extends \Stripe\SingletonApiResource
     const OBJECT_NAME = 'tax.settings';
 
     use \Stripe\ApiOperations\SingletonRetrieve;
-    use \Stripe\ApiOperations\Update;
 
     const STATUS_ACTIVE = 'active';
     const STATUS_PENDING = 'pending';
+
+    /**
+     * @param null|array $params
+     * @param null|array|string $opts
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return static the updated resource
+     */
+    public static function update($params = null, $opts = null)
+    {
+        self::_validateParams($params);
+        $url = '/v1/tax/settings';
+
+        list($response, $opts) = static::_staticRequest('post', $url, $params, $opts);
+        $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts);
+        $obj->setLastResponse($response);
+
+        return $obj;
+    }
 }

--- a/tests/Stripe/Tax/SettingsTest.php
+++ b/tests/Stripe/Tax/SettingsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Stripe\Tax;
+
+/**
+ * @internal
+ * @covers \Stripe\Terminal\ConnectionToken
+ */
+final class SettingsTest extends \Stripe\TestCase
+{
+    use \Stripe\TestHelper;
+
+    public function testIsUpdateable()
+    {
+        $this->expectsRequest(
+            'post',
+            '/v1/tax/settings'
+        );
+        $resource = Settings::update([
+            'defaults' => [
+                'tax_behavior' => 'exclusive',
+            ],
+        ]);
+        static::assertInstanceOf(\Stripe\Tax\Settings::class, $resource);
+    }
+}


### PR DESCRIPTION
Unlike typical update methods, it doesn't accept an id.

Fixes #1645 