### PR TITLE
Remove broken methods on CustomerCashBalanceTransaction

### DIFF
--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -134,37 +134,6 @@ class Customer extends ApiResource
         return static::_requestPage($url, \Stripe\SearchResult::class, $params, $opts);
     }
 
-    const PATH_CASH_BALANCE = '/cash_balance';
-
-    /**
-     * @param string $id the ID of the customer to which the cash balance belongs
-     * @param null|array $params
-     * @param null|array|string $opts
-     * @param mixed $cashBalanceId
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return \Stripe\CashBalance
-     */
-    public static function retrieveCashBalance($id, $cashBalanceId, $params = null, $opts = null)
-    {
-        return self::_retrieveNestedResource($id, static::PATH_CASH_BALANCE, $params, $opts);
-    }
-
-    /**
-     * @param string $id the ID of the customer to which the cash balance belongs
-     * @param null|array $params
-     * @param null|array|string $opts
-     * @param mixed $cashBalanceId
-     *
-     * @throws \Stripe\Exception\ApiErrorException if the request fails
-     *
-     * @return \Stripe\CashBalance
-     */
-    public static function updateCashBalance($id, $cashBalanceId, $params = null, $opts = null)
-    {
-        return self::_updateNestedResource($id, static::PATH_CASH_BALANCE, $params, $opts);
-    }
     const PATH_BALANCE_TRANSACTIONS = '/balance_transactions';
 
     /**
@@ -327,6 +296,37 @@ class Customer extends ApiResource
     public static function updateSource($id, $sourceId, $params = null, $opts = null)
     {
         return self::_updateNestedResource($id, static::PATH_SOURCES, $sourceId, $params, $opts);
+    }
+    const PATH_CASH_BALANCE = '/cash_balance';
+
+    /**
+     * @param string $id the ID of the customer to which the cash balance belongs
+     * @param null|array $params
+     * @param null|array|string $opts
+     * @param mixed $cashBalanceId
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CashBalance
+     */
+    public static function retrieveCashBalance($id, $cashBalanceId, $params = null, $opts = null)
+    {
+        return self::_retrieveNestedResource($id, static::PATH_CASH_BALANCE, $params, $opts);
+    }
+
+    /**
+     * @param string $id the ID of the customer to which the cash balance belongs
+     * @param null|array $params
+     * @param null|array|string $opts
+     * @param mixed $cashBalanceId
+     *
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     *
+     * @return \Stripe\CashBalance
+     */
+    public static function updateCashBalance($id, $cashBalanceId, $params = null, $opts = null)
+    {
+        return self::_updateNestedResource($id, static::PATH_CASH_BALANCE, $params, $opts);
     }
     const PATH_TAX_IDS = '/tax_ids';
 

--- a/lib/CustomerCashBalanceTransaction.php
+++ b/lib/CustomerCashBalanceTransaction.php
@@ -30,9 +30,6 @@ class CustomerCashBalanceTransaction extends ApiResource
 {
     const OBJECT_NAME = 'customer_cash_balance_transaction';
 
-    use ApiOperations\All;
-    use ApiOperations\Retrieve;
-
     const TYPE_ADJUSTED_FOR_OVERDRAFT = 'adjusted_for_overdraft';
     const TYPE_APPLIED_TO_PAYMENT = 'applied_to_payment';
     const TYPE_FUNDED = 'funded';


### PR DESCRIPTION
## Changelog
* Bugfix: remove support for `CustomerCashBalanceTransaction::all` and `CustomerCashBalanceTransaction::retrieve`. These methods were included in the library unintentionally and never functioned.