### PR TITLE
Remove deprecated events

### DIFF
--- a/lib/Climate/Supplier.php
+++ b/lib/Climate/Supplier.php
@@ -25,5 +25,4 @@ class Supplier extends \Stripe\ApiResource
     const REMOVAL_PATHWAY_BIOMASS_CARBON_REMOVAL_AND_STORAGE = 'biomass_carbon_removal_and_storage';
     const REMOVAL_PATHWAY_DIRECT_AIR_CAPTURE = 'direct_air_capture';
     const REMOVAL_PATHWAY_ENHANCED_WEATHERING = 'enhanced_weathering';
-    const REMOVAL_PATHWAY_VARIOUS = 'various';
 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -140,7 +140,6 @@ class Event extends ApiResource
     const IDENTITY_VERIFICATION_SESSION_VERIFIED = 'identity.verification_session.verified';
     const INVOICEITEM_CREATED = 'invoiceitem.created';
     const INVOICEITEM_DELETED = 'invoiceitem.deleted';
-    const INVOICEITEM_UPDATED = 'invoiceitem.updated';
     const INVOICE_CREATED = 'invoice.created';
     const INVOICE_DELETED = 'invoice.deleted';
     const INVOICE_FINALIZATION_FAILED = 'invoice.finalization_failed';
@@ -171,7 +170,6 @@ class Event extends ApiResource
     const ISSUING_TRANSACTION_CREATED = 'issuing_transaction.created';
     const ISSUING_TRANSACTION_UPDATED = 'issuing_transaction.updated';
     const MANDATE_UPDATED = 'mandate.updated';
-    const ORDER_CREATED = 'order.created';
     const PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED = 'payment_intent.amount_capturable_updated';
     const PAYMENT_INTENT_CANCELED = 'payment_intent.canceled';
     const PAYMENT_INTENT_CREATED = 'payment_intent.created';
@@ -212,9 +210,6 @@ class Event extends ApiResource
     const QUOTE_FINALIZED = 'quote.finalized';
     const RADAR_EARLY_FRAUD_WARNING_CREATED = 'radar.early_fraud_warning.created';
     const RADAR_EARLY_FRAUD_WARNING_UPDATED = 'radar.early_fraud_warning.updated';
-    const RECIPIENT_CREATED = 'recipient.created';
-    const RECIPIENT_DELETED = 'recipient.deleted';
-    const RECIPIENT_UPDATED = 'recipient.updated';
     const REFUND_CREATED = 'refund.created';
     const REFUND_UPDATED = 'refund.updated';
     const REPORTING_REPORT_RUN_FAILED = 'reporting.report_run.failed';
@@ -228,9 +223,6 @@ class Event extends ApiResource
     const SETUP_INTENT_SETUP_FAILED = 'setup_intent.setup_failed';
     const SETUP_INTENT_SUCCEEDED = 'setup_intent.succeeded';
     const SIGMA_SCHEDULED_QUERY_RUN_CREATED = 'sigma.scheduled_query_run.created';
-    const SKU_CREATED = 'sku.created';
-    const SKU_DELETED = 'sku.deleted';
-    const SKU_UPDATED = 'sku.updated';
     const SOURCE_CANCELED = 'source.canceled';
     const SOURCE_CHARGEABLE = 'source.chargeable';
     const SOURCE_FAILED = 'source.failed';
@@ -375,7 +367,6 @@ class Event extends ApiResource
     const TYPE_IDENTITY_VERIFICATION_SESSION_VERIFIED = 'identity.verification_session.verified';
     const TYPE_INVOICEITEM_CREATED = 'invoiceitem.created';
     const TYPE_INVOICEITEM_DELETED = 'invoiceitem.deleted';
-    const TYPE_INVOICEITEM_UPDATED = 'invoiceitem.updated';
     const TYPE_INVOICE_CREATED = 'invoice.created';
     const TYPE_INVOICE_DELETED = 'invoice.deleted';
     const TYPE_INVOICE_FINALIZATION_FAILED = 'invoice.finalization_failed';
@@ -406,7 +397,6 @@ class Event extends ApiResource
     const TYPE_ISSUING_TRANSACTION_CREATED = 'issuing_transaction.created';
     const TYPE_ISSUING_TRANSACTION_UPDATED = 'issuing_transaction.updated';
     const TYPE_MANDATE_UPDATED = 'mandate.updated';
-    const TYPE_ORDER_CREATED = 'order.created';
     const TYPE_PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED = 'payment_intent.amount_capturable_updated';
     const TYPE_PAYMENT_INTENT_CANCELED = 'payment_intent.canceled';
     const TYPE_PAYMENT_INTENT_CREATED = 'payment_intent.created';
@@ -447,9 +437,6 @@ class Event extends ApiResource
     const TYPE_QUOTE_FINALIZED = 'quote.finalized';
     const TYPE_RADAR_EARLY_FRAUD_WARNING_CREATED = 'radar.early_fraud_warning.created';
     const TYPE_RADAR_EARLY_FRAUD_WARNING_UPDATED = 'radar.early_fraud_warning.updated';
-    const TYPE_RECIPIENT_CREATED = 'recipient.created';
-    const TYPE_RECIPIENT_DELETED = 'recipient.deleted';
-    const TYPE_RECIPIENT_UPDATED = 'recipient.updated';
     const TYPE_REFUND_CREATED = 'refund.created';
     const TYPE_REFUND_UPDATED = 'refund.updated';
     const TYPE_REPORTING_REPORT_RUN_FAILED = 'reporting.report_run.failed';
@@ -463,9 +450,6 @@ class Event extends ApiResource
     const TYPE_SETUP_INTENT_SETUP_FAILED = 'setup_intent.setup_failed';
     const TYPE_SETUP_INTENT_SUCCEEDED = 'setup_intent.succeeded';
     const TYPE_SIGMA_SCHEDULED_QUERY_RUN_CREATED = 'sigma.scheduled_query_run.created';
-    const TYPE_SKU_CREATED = 'sku.created';
-    const TYPE_SKU_DELETED = 'sku.deleted';
-    const TYPE_SKU_UPDATED = 'sku.updated';
     const TYPE_SOURCE_CANCELED = 'source.canceled';
     const TYPE_SOURCE_CHARGEABLE = 'source.chargeable';
     const TYPE_SOURCE_FAILED = 'source.failed';


### PR DESCRIPTION
Below Event types were removed from the API in the last year

[On Sept 22, 2023](https://docs.stripe.com/changelog#september-22,-2023)

> Remove support for values order.created, recipient.created, recipient.deleted, recipient.updated, sku.created, sku.deleted, and sku.updated from enum Event.type

[On Sept 4th, 2023](https://docs.stripe.com/changelog#september-4,-2023)

> Remove support for value invoiceitem.updated from enum Event.type

And the enum Climate.Supplier.removal_pathway was updated on [Dec 6th , 2023](https://docs.stripe.com/changelog#december-6,-2023)

> Remove support for value various from enum Climate.Supplier.removal_pathway

This PR removes the same from the SDKs

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1740



