### PR TITLE
Remove parts of the API that is no longer publicly documented

### DIFF
--- a/lib/BalanceTransaction.php
+++ b/lib/BalanceTransaction.php
@@ -48,12 +48,8 @@ class BalanceTransaction extends ApiResource
     const TYPE_ISSUING_AUTHORIZATION_RELEASE = 'issuing_authorization_release';
     const TYPE_ISSUING_DISPUTE = 'issuing_dispute';
     const TYPE_ISSUING_TRANSACTION = 'issuing_transaction';
-    const TYPE_OBLIGATION_INBOUND = 'obligation_inbound';
     const TYPE_OBLIGATION_OUTBOUND = 'obligation_outbound';
-    const TYPE_OBLIGATION_PAYOUT = 'obligation_payout';
-    const TYPE_OBLIGATION_PAYOUT_FAILURE = 'obligation_payout_failure';
     const TYPE_OBLIGATION_REVERSAL_INBOUND = 'obligation_reversal_inbound';
-    const TYPE_OBLIGATION_REVERSAL_OUTBOUND = 'obligation_reversal_outbound';
     const TYPE_PAYMENT = 'payment';
     const TYPE_PAYMENT_FAILURE_REFUND = 'payment_failure_refund';
     const TYPE_PAYMENT_NETWORK_RESERVE_HOLD = 'payment_network_reserve_hold';

--- a/lib/Climate/Supplier.php
+++ b/lib/Climate/Supplier.php
@@ -25,5 +25,4 @@ class Supplier extends \Stripe\ApiResource
     const REMOVAL_PATHWAY_BIOMASS_CARBON_REMOVAL_AND_STORAGE = 'biomass_carbon_removal_and_storage';
     const REMOVAL_PATHWAY_DIRECT_AIR_CAPTURE = 'direct_air_capture';
     const REMOVAL_PATHWAY_ENHANCED_WEATHERING = 'enhanced_weathering';
-    const REMOVAL_PATHWAY_VARIOUS = 'various';
 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -140,7 +140,6 @@ class Event extends ApiResource
     const IDENTITY_VERIFICATION_SESSION_VERIFIED = 'identity.verification_session.verified';
     const INVOICEITEM_CREATED = 'invoiceitem.created';
     const INVOICEITEM_DELETED = 'invoiceitem.deleted';
-    const INVOICEITEM_UPDATED = 'invoiceitem.updated';
     const INVOICE_CREATED = 'invoice.created';
     const INVOICE_DELETED = 'invoice.deleted';
     const INVOICE_FINALIZATION_FAILED = 'invoice.finalization_failed';
@@ -171,7 +170,6 @@ class Event extends ApiResource
     const ISSUING_TRANSACTION_CREATED = 'issuing_transaction.created';
     const ISSUING_TRANSACTION_UPDATED = 'issuing_transaction.updated';
     const MANDATE_UPDATED = 'mandate.updated';
-    const ORDER_CREATED = 'order.created';
     const PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED = 'payment_intent.amount_capturable_updated';
     const PAYMENT_INTENT_CANCELED = 'payment_intent.canceled';
     const PAYMENT_INTENT_CREATED = 'payment_intent.created';
@@ -212,9 +210,6 @@ class Event extends ApiResource
     const QUOTE_FINALIZED = 'quote.finalized';
     const RADAR_EARLY_FRAUD_WARNING_CREATED = 'radar.early_fraud_warning.created';
     const RADAR_EARLY_FRAUD_WARNING_UPDATED = 'radar.early_fraud_warning.updated';
-    const RECIPIENT_CREATED = 'recipient.created';
-    const RECIPIENT_DELETED = 'recipient.deleted';
-    const RECIPIENT_UPDATED = 'recipient.updated';
     const REFUND_CREATED = 'refund.created';
     const REFUND_UPDATED = 'refund.updated';
     const REPORTING_REPORT_RUN_FAILED = 'reporting.report_run.failed';
@@ -228,9 +223,6 @@ class Event extends ApiResource
     const SETUP_INTENT_SETUP_FAILED = 'setup_intent.setup_failed';
     const SETUP_INTENT_SUCCEEDED = 'setup_intent.succeeded';
     const SIGMA_SCHEDULED_QUERY_RUN_CREATED = 'sigma.scheduled_query_run.created';
-    const SKU_CREATED = 'sku.created';
-    const SKU_DELETED = 'sku.deleted';
-    const SKU_UPDATED = 'sku.updated';
     const SOURCE_CANCELED = 'source.canceled';
     const SOURCE_CHARGEABLE = 'source.chargeable';
     const SOURCE_FAILED = 'source.failed';
@@ -375,7 +367,6 @@ class Event extends ApiResource
     const TYPE_IDENTITY_VERIFICATION_SESSION_VERIFIED = 'identity.verification_session.verified';
     const TYPE_INVOICEITEM_CREATED = 'invoiceitem.created';
     const TYPE_INVOICEITEM_DELETED = 'invoiceitem.deleted';
-    const TYPE_INVOICEITEM_UPDATED = 'invoiceitem.updated';
     const TYPE_INVOICE_CREATED = 'invoice.created';
     const TYPE_INVOICE_DELETED = 'invoice.deleted';
     const TYPE_INVOICE_FINALIZATION_FAILED = 'invoice.finalization_failed';
@@ -406,7 +397,6 @@ class Event extends ApiResource
     const TYPE_ISSUING_TRANSACTION_CREATED = 'issuing_transaction.created';
     const TYPE_ISSUING_TRANSACTION_UPDATED = 'issuing_transaction.updated';
     const TYPE_MANDATE_UPDATED = 'mandate.updated';
-    const TYPE_ORDER_CREATED = 'order.created';
     const TYPE_PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED = 'payment_intent.amount_capturable_updated';
     const TYPE_PAYMENT_INTENT_CANCELED = 'payment_intent.canceled';
     const TYPE_PAYMENT_INTENT_CREATED = 'payment_intent.created';
@@ -447,9 +437,6 @@ class Event extends ApiResource
     const TYPE_QUOTE_FINALIZED = 'quote.finalized';
     const TYPE_RADAR_EARLY_FRAUD_WARNING_CREATED = 'radar.early_fraud_warning.created';
     const TYPE_RADAR_EARLY_FRAUD_WARNING_UPDATED = 'radar.early_fraud_warning.updated';
-    const TYPE_RECIPIENT_CREATED = 'recipient.created';
-    const TYPE_RECIPIENT_DELETED = 'recipient.deleted';
-    const TYPE_RECIPIENT_UPDATED = 'recipient.updated';
     const TYPE_REFUND_CREATED = 'refund.created';
     const TYPE_REFUND_UPDATED = 'refund.updated';
     const TYPE_REPORTING_REPORT_RUN_FAILED = 'reporting.report_run.failed';
@@ -463,9 +450,6 @@ class Event extends ApiResource
     const TYPE_SETUP_INTENT_SETUP_FAILED = 'setup_intent.setup_failed';
     const TYPE_SETUP_INTENT_SUCCEEDED = 'setup_intent.succeeded';
     const TYPE_SIGMA_SCHEDULED_QUERY_RUN_CREATED = 'sigma.scheduled_query_run.created';
-    const TYPE_SKU_CREATED = 'sku.created';
-    const TYPE_SKU_DELETED = 'sku.deleted';
-    const TYPE_SKU_UPDATED = 'sku.updated';
     const TYPE_SOURCE_CANCELED = 'source.canceled';
     const TYPE_SOURCE_CHARGEABLE = 'source.chargeable';
     const TYPE_SOURCE_FAILED = 'source.failed';

--- a/lib/PaymentMethodConfiguration.php
+++ b/lib/PaymentMethodConfiguration.php
@@ -43,7 +43,6 @@ namespace Stripe;
  * @property null|\Stripe\StripeObject $giropay
  * @property null|\Stripe\StripeObject $google_pay
  * @property null|\Stripe\StripeObject $grabpay
- * @property null|\Stripe\StripeObject $id_bank_transfer
  * @property null|\Stripe\StripeObject $ideal
  * @property bool $is_default The default configuration is used whenever a payment method configuration is not specified.
  * @property null|\Stripe\StripeObject $jcb
@@ -51,20 +50,16 @@ namespace Stripe;
  * @property null|\Stripe\StripeObject $konbini
  * @property null|\Stripe\StripeObject $link
  * @property bool $livemode Has the value <code>true</code> if the object exists in live mode or the value <code>false</code> if the object exists in test mode.
- * @property null|\Stripe\StripeObject $multibanco
  * @property string $name The configuration's name.
- * @property null|\Stripe\StripeObject $netbanking
  * @property null|\Stripe\StripeObject $oxxo
  * @property null|\Stripe\StripeObject $p24
  * @property null|string $parent For child configs, the configuration's parent configuration.
- * @property null|\Stripe\StripeObject $pay_by_bank
  * @property null|\Stripe\StripeObject $paynow
  * @property null|\Stripe\StripeObject $paypal
  * @property null|\Stripe\StripeObject $promptpay
  * @property null|\Stripe\StripeObject $revolut_pay
  * @property null|\Stripe\StripeObject $sepa_debit
  * @property null|\Stripe\StripeObject $sofort
- * @property null|\Stripe\StripeObject $upi
  * @property null|\Stripe\StripeObject $us_bank_account
  * @property null|\Stripe\StripeObject $wechat_pay
  */

--- a/lib/TaxRate.php
+++ b/lib/TaxRate.php
@@ -53,6 +53,5 @@ class TaxRate extends ApiResource
     const TAX_TYPE_QST = 'qst';
     const TAX_TYPE_RST = 'rst';
     const TAX_TYPE_SALES_TAX = 'sales_tax';
-    const TAX_TYPE_SERVICE_TAX = 'service_tax';
     const TAX_TYPE_VAT = 'vat';
 }


### PR DESCRIPTION
This PR contains the changes generated after removing the shared overides from our code generator that were added for backcompat

## Changelog

* Remove the below deprecated values on the enum `BalanceTransaction.Type`
    * `obligation_inbound`
    * `obligation_payout`
    * `obligation_payout_failure`
    * `obligation_reversal_outbound`
 * Remove the deprecated value `various` on the enum `Climate.Supplier.RemovalPathway` 
 * Remove deprecated events 
   * `invoiceitem.updated`
   * `order.created`
   * `recipient.created`
   * `recipient.deleted`
   * `recipient.updated`
   * `sku.created`
   * `sku.deleted`
   * `sku.updated`
 * Remove the deprecated value `service_tax` on the enum `TaxRate.TaxType`
 * PHP Docs
   * Remove support for `id_bank_transfer`, `multibanco`, `netbanking`, `pay_by_bank`, and `upi` on `PaymentMethodConfiguration`




 
 