### PR TITLE
Introduce StripeClient.rawRequest as a canonical way to request Stripe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you use Composer, these dependencies should be handled automatically. If you 
 Simple usage looks like:
 
 ```php
-$stripe = new \Stripe\StripeClient('sk_test_BQokikJOvBiI2HlWgH4olfQ2');
+$stripe = new \Stripe\StripeClient('sk_test_xyz');
 $customer = $stripe->customers->create([
     'description' => 'example customer',
     'email' => 'email@example.com',
@@ -221,6 +221,31 @@ If your beta feature requires a `Stripe-Version` header to be sent, set the `api
 
 ```php
 Stripe::addBetaVersion("feature_beta", "v3");
+```
+
+### Custom requests
+
+If you
+- would like to send a request to an undocumented API (for example you are in a private beta)
+- prefer to bypass the method definitions in the library and specify your request details directly,
+- used the method `_request` on `\Stripe\ApiOperation\Request` trait to specify your own requests.
+
+you can use the `rawRequest` method on the StripeClient. `_request` would soon be deprecated and removed.
+
+```php
+$stripe = new \Stripe\StripeClient('sk_test_xyz');
+$response = $stripe->rawRequest('post', '/v1/beta_endpoint', [
+  "caveat": "emptor"
+], [
+  "stripe_version" => "2024-06-20",
+]);
+// $response->body is a string, you can call $stripe->deserialize to get a \Stripe\StripeObject.
+$obj = $stripe->deserialize($response->body);
+
+// For GET requests, the params argument must be null, and you should write the query string explicitly.
+$get_response = $stripe->rawRequest('get', '/v1/beta_endpoint?caveat=emptor', null, [
+  "stripe_version" => "2022-11_15",
+]);
 ```
 
 ## Support

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -366,6 +366,12 @@ class ApiRequestor
         ];
     }
 
+    /**
+     * @param 'delete'|'get'|'post' $method
+     * @param string $url
+     * @param array $params
+     * @param array $headers
+     */
     private function _prepareRequest($method, $url, $params, $headers)
     {
         $myApiKey = $this->_apiKey;

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -9,8 +9,7 @@ interface ClientInterface
      * @param string $absUrl The URL being requested, including domain and protocol
      * @param array $headers Headers to be used in the request (full strings, not KV pairs)
      * @param array $params KV pairs for parameters. Can be nested for arrays and hashes
-     * @param bool $hasFile Whether or not $params references a file (via an @ prefix or
-     *                         CURLFile)
+     * @param bool $hasFile Whether $params references a file (via an @ prefix or CURLFile)
      *
      * @throws \Stripe\Exception\ApiConnectionException
      * @throws \Stripe\Exception\UnexpectedValueException


### PR DESCRIPTION
Introducing `StripeClient.rawRequest`, a new way to request Stripe APIs. Previously available only in beta, `StripeClient.rawRequest` now has general availability. 

If you
- would like to send a request to an undocumented API (for example you are in a private beta)
- prefer to bypass the method definitions in the library and specify your request details directly
- used the method `_request` on `\Stripe\ApiOperation\Request` trait to specify your own requests. 

you can use the `rawRequest` method on the StripeClient.

## Changelog
- Adds the ability to make raw requests to the Stripe API, by providing an HTTP method and url. This is an alternative to using the trait `\Stripe\ApiOperation\Request` to make custom requests, which is discouraged and will be broken in a future major version.
```php
$stripe = new \Stripe\StripeClient('sk_test_xyz');
$response = $stripe->rawRequest('post', '/v1/undocumented_endpoint', [
  "caveat": "emptor"
], [
  "stripe_version" => "2024-06-20",
]);
// $response->body is a string, you can call $stripe->deserialize to get a \Stripe\StripeObject.
$obj = $stripe->deserialize($response->body);

// For GET requests, the params argument must be null, and you should write the query string explicitly.
$get_response = $stripe->rawRequest('get', '/v1/beta_endpoint?caveat=emptor', null, [
  "stripe_version" => "2022-11_15",
]);
```