### PR TITLE
Avoid using func_get_args

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -199,7 +199,7 @@ class CurlClient implements ClientInterface, StreamingClientInterface
 
         $opts = [];
         if (\is_callable($this->defaultOptions)) { // call defaultOptions callback, set options to return value
-            $opts = \call_user_func_array($this->defaultOptions, \func_get_args());
+            $opts = \call_user_func_array($this->defaultOptions, [$method, $absUrl, $headers, $params, $hasFile]);
             if (!\is_array($opts)) {
                 throw new Exception\UnexpectedValueException('Non-array value returned by defaultOptions CurlClient callback');
             }


### PR DESCRIPTION

Resolves the incompatibility issues with PHP 8.0 as described in https://github.com/stripe/stripe-php/issues/1739