### PR TITLE
Fixed empty param for v2 requests

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -209,6 +209,13 @@ class CurlClient implements ClientInterface, StreamingClientInterface
                 return [$absUrl, $params];
             }
             if ('v2' === $apiMode) {
+                if (\is_array($params) && 0 === \count($params)) {
+                    // Send a request with empty body if we have no params set
+                    // Setting the second parameter as null prevents the CURLOPT_POSTFIELDS
+                    // from being set with the '[]', which is result of `json_encode([]).
+                    return [$absUrl, null];
+                }
+
                 return [$absUrl, \json_encode($params)];
             }
 

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -472,6 +472,35 @@ final class BaseStripeClientTest extends \Stripe\TestCase
         static::assertInstanceOf(\Stripe\V2\Billing\MeterEventSession::class, $meterEventSession);
     }
 
+    public function testV2PostRequestWithEmptyParams()
+    {
+        $this->curlClientStub->method('executeRequestWithRetries')
+            ->willReturn(['{"object": "billing.meter_event_session"}', 200, []])
+        ;
+
+        $this->curlClientStub->expects(static::once())
+            ->method('executeRequestWithRetries')
+            ->with(static::callback(function ($opts) {
+                $this->assertSame(1, $opts[\CURLOPT_POST]);
+                $this->assertArrayNotHasKey(\CURLOPT_POSTFIELDS, $opts);
+                $this->assertContains('Content-Type: application/json', $opts[\CURLOPT_HTTPHEADER]);
+
+                return true;
+            }), MOCK_URL . '/v2/billing/meter_event_session')
+        ;
+
+        ApiRequestor::setHttpClient($this->curlClientStub);
+        $client = new BaseStripeClient([
+            'api_key' => 'sk_test_client',
+            'stripe_version' => '2222-22-22.preview-v2',
+            'api_base' => MOCK_URL,
+        ]);
+
+        $meterEventSession = $client->request('post', '/v2/billing/meter_event_session', [], []);
+        static::assertNotNull($meterEventSession);
+        static::assertInstanceOf(\Stripe\V2\Billing\MeterEventSession::class, $meterEventSession);
+    }
+
     public function testV2RequestWithClientStripeContext()
     {
         $this->curlClientStub->method('executeRequestWithRetries')


### PR DESCRIPTION
Creating a meter event session was failing(400) because we were trying to send an invalid json body in the request. 
```php
$stripeClient->v2->billing->meterEventSession->create([]);
```

```php
json_encode([]) // '[]' - string brackets
json_encode(null) // 'null' - String null
```

In order to fix this, I added a check to skip encoding params when the params are empty. 