### PR TITLE
Fixed empty response from v2 meter event stream endpoint

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -184,6 +184,11 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
         list($response, $opts->apiKey) = $requestor->request($method, $path, $params, $opts->headers, $apiMode, ['stripe_client']);
         $opts->discardNonPersistentHeaders();
         $obj = \Stripe\Util\Util::convertToStripeObject($response->json, $opts, $apiMode);
+        if (\is_array($obj)) {
+            // Edge case for v2 endpoints that return empty/void response
+            // Example: client->v2->billing->meterEventStream->create
+            $obj = new \Stripe\StripeObject();
+        }
         $obj->setLastResponse($response);
 
         return $obj;

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -833,4 +833,29 @@ final class BaseStripeClientTest extends \Stripe\TestCase
         static::assertNotNull($meterEvent);
         static::assertInstanceOf(\Stripe\Billing\MeterEvent::class, $meterEvent);
     }
+
+    public function testV2RequestWithEmptyResponse()
+    {
+        $this->curlClientStub->method('executeRequestWithRetries')
+            ->willReturn(['{}', 200, []])
+        ;
+
+        $this->curlClientStub->expects(static::once())
+            ->method('executeRequestWithRetries')
+            ->with(static::callback(function ($opts) {
+                return true;
+            }), MOCK_URL . '/v2/billing/meter_event_stream')
+        ;
+
+        ApiRequestor::setHttpClient($this->curlClientStub);
+        $client = new BaseStripeClient([
+            'api_key' => 'sk_test_client',
+            'stripe_version' => '2222-22-22.preview-v2',
+            'api_base' => MOCK_URL,
+        ]);
+
+        $meterEventStream = $client->request('post', '/v2/billing/meter_event_stream', [], []);
+        static::assertNotNull($meterEventStream);
+        static::assertInstanceOf(\Stripe\StripeObject::class, $meterEventStream);
+    }
 }


### PR DESCRIPTION
MeterEventStream returns a void response.
As part of request handling we setLastResponse on the returned object from `\Stripe\Util\Util::convertToStripeObject`. Empty response meant we were getting back an array.

### Fix
If the returned object is an array, we create a new empty StripeObject and set the response on it. 

Another option would've been to skip setting the response itself. Open to hearing your opinions based on how this is handled in other languages. 

### Sample code that caused this issue.
```php
$meterClient = new \Stripe\StripeClient([
        'api_key' => $meterEventSession->authentication_token,
    ]);

    $meterEvent = [
        'event_name' => 'new_meter',
        'payload'    => [
            'stripe_customer_id' => 'cus_Qv....,
            'value'              => '25',
        ],
    ];
    $createMeterEventResponse = $meterClient->v2->billing->meterEventStream->create([
            'events' => [$meterEvent],
        ]
    );
    print_r($createMeterEventResponse);
```