### PR TITLE
Fix Event typing

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -59,7 +59,7 @@ abstract class Util
                 && isset($types[$resp['object']])
             ) {
                 $class = $types[$resp['object']];
-                if ('v2' === $apiMode && 'event' === $resp['object']) {
+                if ('v2' === $apiMode && ($resp['object'] == 'v2.core.event')) {
                     $eventTypes = \Stripe\Util\EventTypes::thinEventMapping;
                     if (\array_key_exists('type', $resp) && \array_key_exists($resp['type'], $eventTypes)) {
                         $class = $eventTypes[$resp['type']];

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -59,7 +59,7 @@ abstract class Util
                 && isset($types[$resp['object']])
             ) {
                 $class = $types[$resp['object']];
-                if ('v2' === $apiMode && ($resp['object'] == 'v2.core.event')) {
+                if ('v2' === $apiMode && ('v2.core.event' === $resp['object'])) {
                     $eventTypes = \Stripe\Util\EventTypes::thinEventMapping;
                     if (\array_key_exists('type', $resp) && \array_key_exists($resp['type'], $eventTypes)) {
                         $class = $eventTypes[$resp['type']];

--- a/lib/V2/Event.php
+++ b/lib/V2/Event.php
@@ -12,5 +12,5 @@ namespace Stripe\V2;
  */
 abstract class Event extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = 'event';
+    const OBJECT_NAME = 'v2.core.event';
 }

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -37,11 +37,11 @@ final class StripeClientTest extends \Stripe\TestCase
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturnOnConsecutiveCalls([
-                '{"data": [{"id": "evnt_123", "object": "event", "type": "v1.billing.meter.no_meter_found"}, {"id": "evnt_456", "object": "event", "type": "v1.billing.meter.no_meter_found"}], "next_page_url": "/v2/core/events?limit=2&page=page_2"}',
+                '{"data": [{"id": "evnt_123", "object": "v2.core.event", "type": "v1.billing.meter.no_meter_found"}, {"id": "evnt_456", "object": "v2.core.event", "type": "v1.billing.meter.no_meter_found"}], "next_page_url": "/v2/core/events?limit=2&page=page_2"}',
                 200,
                 [],
             ], [
-                '{"data": [{"id": "evnt_789", "object": "event", "type": "v1.billing.meter.no_meter_found"}], "next_page_url": null}',
+                '{"data": [{"id": "evnt_789", "object": "v2.core.event", "type": "v1.billing.meter.no_meter_found"}], "next_page_url": null}',
                 200,
                 [],
             ])
@@ -71,7 +71,7 @@ final class StripeClientTest extends \Stripe\TestCase
 
         $events = $client->v2->core->events->all(['limit' => 2]);
         static::assertInstanceOf(\Stripe\V2\Collection::class, $events);
-        static::assertInstanceOf(\Stripe\V2\Event::class, $events->data[0]);
+        static::assertInstanceOf(\Stripe\Events\V1BillingMeterNoMeterFoundEvent::class, $events->data[0]);
 
         $seen = [];
         foreach ($events->autoPagingIterator() as $event) {


### PR DESCRIPTION
Events have a changed object tag`v2.core.event`. This PR allows the types to be correctly assigned after the change.  