### PR TITLE
Fix type of Billing Meter Event

### DIFF
--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -161,7 +161,7 @@ class ObjectTypes
      */
     const v2Mapping = [
         // V1 Class needed for fetching the right related object
-        // TODO: Make a more standardized fix in codegen for all languages
+        // TODO: https://go/j/DEVSDK-2204 Make a more standardized fix in codegen for all languages
         \Stripe\Billing\Meter::OBJECT_NAME => \Stripe\Billing\Meter::class,
 
         // v2 object classes: The beginning of the section generated from our OpenAPI spec

--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -160,6 +160,10 @@ class ObjectTypes
      * @var array Mapping from v2 object types to resource classes
      */
     const v2Mapping = [
+        // V1 Class needed for fetching the right related object
+        // TODO: Make a more standardized fix in codegen for all languages
+        \Stripe\Billing\Meter::OBJECT_NAME => \Stripe\Billing\Meter::class,
+
         // v2 object classes: The beginning of the section generated from our OpenAPI spec
         \Stripe\V2\Billing\MeterEvent::OBJECT_NAME => \Stripe\V2\Billing\MeterEvent::class,
         \Stripe\V2\Billing\MeterEventAdjustment::OBJECT_NAME => \Stripe\V2\Billing\MeterEventAdjustment::class,


### PR DESCRIPTION
fetchRelatedObject could not correctly return v1 objects. Therefore I had to manually add that type in v2mapping.

```php
$baseEvent = $stripeClient->v2->core->events->retrieve('evt_test_65RD9HQIXX53rfbiu8116QQCIX1TSQbbOu5RHvml0KWLTM');

//print_r($baseEvent);
if ($baseEvent instanceof \Stripe\Events\V1BillingMeterErrorReportTriggeredEvent) {
    print_r($baseEvent->fetchRelatedObject()); // Returns StripeObject. Should return \Stripe\Billing\Meter
}
```

Followup to move this to codegen: https://jira.corp.stripe.com/browse/DEVSDK-2204