### PR TITLE
Fall back to InvalidRequestException when code is `invalid_fields`

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -278,6 +278,10 @@ class ApiRequestor
 
             // The end of the section generated from our OpenAPI spec
             default:
+                if ('invalid_fields' === $code) {
+                    $param = isset($errorData['param']) ? $errorData['param'] : null;
+                    return Exception\InvalidRequestException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
+                }
                 return self::_specificV1APIError($rbody, $rcode, $rheaders, $resp, $errorData);
         }
     }

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -542,6 +542,39 @@ final class ApiRequestorTest extends \Stripe\TestCase
         }
     }
 
+    public function testV2WithInvalidFieldsReturnsInvalidRequest()
+    {
+        $this->stubRequest(
+            'GET',
+            '/v2/core/events/evt_123',
+            [],
+            null,
+            false,
+            [
+                'error' => [
+                    'code' => 'invalid_fields',
+                    'message' => 'your request is invalid',
+                    'param' => 'invalid_param',
+                ],
+            ],
+            400,
+            BaseStripeClient::DEFAULT_API_BASE
+        );
+
+        try {
+            $client = new StripeClient('sk_test_123');
+            $client->v2->core->events->retrieve('evt_123');
+            static::fail('Did not raise error');
+        } catch (Exception\InvalidRequestException $e) {
+            static::assertSame(400, $e->getHttpStatus());
+            static::assertSame('invalid_param', $e->getStripeParam());
+            static::assertSame('invalid_fields', $e->getStripeCode());
+            static::assertSame('your request is invalid', $e->getMessage());
+        } catch (\Exception $e) {
+            static::fail('Unexpected exception: ' . \get_class($e));
+        }
+    }
+
     public function testV2CallsFallBackToV1Errors()
     {
         $this->stubRequest(


### PR DESCRIPTION
For v2 APIs, when an error has code `invalid_fields`, it should fail with `InvalidRequestException`. This addresses that for V2, but V1 behavior remains unchanged.