### PR TITLE
Fix url and context in fetchRelatedObject

### DIFF
--- a/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
+++ b/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
@@ -29,9 +29,9 @@ class V1BillingMeterErrorReportTriggeredEvent extends \Stripe\V2\Event
     {
         list($object, $options) = $this->_request(
             'get',
-            $this->related_object->url,
+            $this['related_object']['url'],
             [],
-            ['stripe_account' => $this->context],
+            ['stripe_account' => $this['context']],
             [],
             'v2'
         );


### PR DESCRIPTION
To access the property while calling fetchRelatedObject we need to use different syntax.

Related: https://github.com/stripe/sdk-codegen/pull/1786