### PR TITLE
Fix related object fetch

### DIFF
--- a/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
+++ b/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
@@ -4,19 +4,13 @@
 
 namespace Stripe\Events;
 
+/**
+ * @property \Stripe\RelatedObject Object containing the reference to API resource relevant to the event
+ * @property \Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData data associated with the event
+ */
 class V1BillingMeterErrorReportTriggeredEvent extends \Stripe\V2\Event
 {
     const LOOKUP_TYPE = 'v1.billing.meter.error_report_triggered';
-
-    /**
-     * @var \Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData data associated with the event
-     */
-    public $data;
-
-    /**
-     * @var \Stripe\RelatedObject Object containing the reference to API resource relevant to the event
-     */
-    public $related_object;
 
     /**
      * Retrieves the related object from the API. Make an API request on every call.

--- a/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
+++ b/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
@@ -5,8 +5,8 @@
 namespace Stripe\Events;
 
 /**
- * @property \Stripe\RelatedObject Object containing the reference to API resource relevant to the event
- * @property \Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData data associated with the event
+ * @property \Stripe\RelatedObject $related_object Object containing the reference to API resource relevant to the event
+ * @property \Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData $data data associated with the event
  */
 class V1BillingMeterErrorReportTriggeredEvent extends \Stripe\V2\Event
 {

--- a/lib/Events/V1BillingMeterNoMeterFoundEvent.php
+++ b/lib/Events/V1BillingMeterNoMeterFoundEvent.php
@@ -5,7 +5,7 @@
 namespace Stripe\Events;
 
 /**
- * @property \Stripe\EventData\V1BillingMeterNoMeterFoundEventData data associated with the event
+ * @property \Stripe\EventData\V1BillingMeterNoMeterFoundEventData $data data associated with the event
  */
 class V1BillingMeterNoMeterFoundEvent extends \Stripe\V2\Event
 {

--- a/lib/Events/V1BillingMeterNoMeterFoundEvent.php
+++ b/lib/Events/V1BillingMeterNoMeterFoundEvent.php
@@ -4,12 +4,10 @@
 
 namespace Stripe\Events;
 
+/**
+ * @property \Stripe\EventData\V1BillingMeterNoMeterFoundEventData data associated with the event
+ */
 class V1BillingMeterNoMeterFoundEvent extends \Stripe\V2\Event
 {
     const LOOKUP_TYPE = 'v1.billing.meter.no_meter_found';
-
-    /**
-     * @var \Stripe\EventData\V1BillingMeterNoMeterFoundEventData data associated with the event
-     */
-    public $data;
 }

--- a/tests/Stripe/V2/CollectionTest.php
+++ b/tests/Stripe/V2/CollectionTest.php
@@ -24,6 +24,7 @@ final class CollectionTest extends \Stripe\TestCase
                 ['id' => 'pm_456', 'object' => 'pageablemodel'],
             ],
             'next_page_url' => '/v2/pageablemodel?page=page_2',
+            'previous_page_url' => null,
         ], ['api_key' => 'sk_test', 'stripe_context' => 'wksp_123'], 'v2');
     }
 
@@ -52,7 +53,8 @@ final class CollectionTest extends \Stripe\TestCase
     {
         $collection = \Stripe\V2\Collection::constructFrom([
             'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
-            'next_page' => null,
+            'next_page_url' => null,
+            'previous_page_url' => null,
         ]);
 
         $seen = [];
@@ -67,7 +69,8 @@ final class CollectionTest extends \Stripe\TestCase
     {
         $collection = \Stripe\V2\Collection::constructFrom([
             'data' => [['id' => '1'], ['id' => '2'], ['id' => '3']],
-            'next_page' => null,
+            'next_page_url' => null,
+            'previous_page_url' => null,
         ]);
 
         $seen = [];
@@ -96,7 +99,8 @@ final class CollectionTest extends \Stripe\TestCase
                 ['id' => '2'],
                 ['id' => '3'],
             ],
-            'next_page' => null,
+            'next_page_url' => null,
+            'previous_page_url' => null,
         ]);
 
         $seen = [];
@@ -114,6 +118,7 @@ final class CollectionTest extends \Stripe\TestCase
                 ['id' => '1'],
             ],
             'next_page_url' => '/v2/pageablemodel?foo=bar&page=page_2',
+            'previous_page_url' => null,
         ]);
 
         $this->stubRequest(
@@ -128,6 +133,7 @@ final class CollectionTest extends \Stripe\TestCase
                     ['id' => '3'],
                 ],
                 'next_page_url' => null,
+                'previous_page_url' => null,
             ]
         );
 
@@ -150,6 +156,7 @@ final class CollectionTest extends \Stripe\TestCase
             [
                 'data' => [['id' => 'pm_789']],
                 'next_page_url' => null,
+                'previous_page_url' => null,
             ]
         );
 
@@ -170,11 +177,11 @@ final class CollectionTest extends \Stripe\TestCase
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturnOnConsecutiveCalls([
-                '{"data": [{"id": "pm_777"}], "next_page_url": "page_3"}',
+                '{"data": [{"id": "pm_777"}], "next_page_url": "/v2/pageablemodel?page_3", "previous_page_url": "/v2/pageablemodel?page_1"}',
                 200,
                 [],
             ], [
-                '{"data": [{"id": "pm_888"}], "next_page_url": null}',
+                '{"data": [{"id": "pm_888"}], "next_page_url": null, "previous_page_url": "/v2/pageablemodel?page_2"}',
                 200,
                 [],
             ])


### PR DESCRIPTION
This fixes fetching related_object in PHP

<img width="1053" alt="Screenshot 2024-09-30 at 12 30 24 PM" src="https://github.com/user-attachments/assets/c14e60af-6358-410d-8c92-0e1cbdd5187f">
