### PR TITLE
Removed parseSnapshotEvent

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -463,38 +463,4 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
             return new \Stripe\ThinEvent();
         }
     }
-
-    /**
-     * Returns an Events instance using the provided JSON payload. Throws an
-     * Exception\UnexpectedValueException if the payload is not valid JSON, and
-     * an Exception\SignatureVerificationException if the signature
-     * verification fails for any reason.
-     *
-     * @param string $payload the payload sent by Stripe
-     * @param string $sigHeader the contents of the signature header sent by
-     *  Stripe
-     * @param string $secret secret used to generate the signature
-     * @param int $tolerance maximum difference allowed between the header's
-     *  timestamp and the current time
-     *
-     * @throws Exception\UnexpectedValueException if the payload is not valid JSON,
-     * @throws Exception\SignatureVerificationException if the verification fails
-     *
-     * @return Event the Event instance
-     */
-    public function parseSnapshotEvent($payload, $sigHeader, $secret, $tolerance = Webhook::DEFAULT_TOLERANCE)
-    {
-        WebhookSignature::verifyHeader($payload, $sigHeader, $secret, $tolerance);
-
-        $data = \json_decode($payload, true);
-        $jsonError = \json_last_error();
-        if (null === $data && \JSON_ERROR_NONE !== $jsonError) {
-            $msg = "Invalid payload: {$payload} "
-              . "(json_last_error() was {$jsonError})";
-
-            throw new Exception\UnexpectedValueException($msg);
-        }
-
-        return Event::constructFrom($data);
-    }
 }

--- a/lib/ThinEvent.php
+++ b/lib/ThinEvent.php
@@ -12,6 +12,8 @@ namespace Stripe;
  * @property string             $created  Time at which the object was created.
  * @property null|string        $context  Authentication context needed to fetch the event or related object.
  * @property null|RelatedObject $related_object Object containing the reference to API resource relevant to the event.
+ * @property null|Reason $reason Reason for the event.
+ * @property bool $livemode Livemode indicates if the event is from a production(true) or test(false) account.
  */
 class ThinEvent
 {
@@ -20,4 +22,6 @@ class ThinEvent
     public $created;
     public $context;
     public $related_object;
+    public $reason;
+    public $livemode;
 }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -101,6 +101,11 @@ abstract class Util
                     $related_object->url = $json['related_object']['url'];
                     $related_object->type = $json['related_object']['type'];
                     $property->setValue($instance, $related_object);
+                } elseif ('reason' === $property->getName()) {
+                    $reason = new \Stripe\Reason();
+                    $reason->id = $json['reason']['id'];
+                    $reason->idempotency_key = $json['reason']['idempotency_key'];
+                    $property->setValue($instance, $reason);
                 } else {
                     $property->setAccessible(true);
                     $property->setValue($instance, $json[$property->getName()]);

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -172,6 +172,10 @@ final class UtilTest extends \Stripe\TestCase
                 'type' => 'financial_account',
                 'url' => '/v2/financial_accounts/fa_123',
             ],
+            'reason' => [
+                'id' => 'id_123',
+                'idempotency_key' => 'key_123',
+            ],
         ]);
 
         $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
@@ -182,6 +186,8 @@ final class UtilTest extends \Stripe\TestCase
         static::assertSame('fa_123', $event->related_object->id);
         static::assertSame('financial_account', $event->related_object->type);
         static::assertSame('/v2/financial_accounts/fa_123', $event->related_object->url);
+        static::assertSame('id_123', $event->reason->id);
+        static::assertSame('key_123', $event->reason->idempotency_key);
     }
 
     public function testJsonDecodeThinEventObjectWithNoRelatedObject()
@@ -199,5 +205,22 @@ final class UtilTest extends \Stripe\TestCase
         static::assertSame('financial_account.balance.opened', $event->type);
         static::assertSame('2022-02-15T00:27:45.330Z', $event->created);
         static::assertNull($event->related_object);
+    }
+
+    public function testJsonDecodeThinEventObjectWithNoReasonObject()
+    {
+        $eventData = json_encode([
+            'id' => 'evt_234',
+            'object' => 'event',
+            'type' => 'financial_account.balance.opened',
+            'created' => '2022-02-15T00:27:45.330Z',
+        ]);
+
+        $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
+        static::assertInstanceOf(ThinEvent::class, $event);
+        static::assertSame('evt_234', $event->id);
+        static::assertSame('financial_account.balance.opened', $event->type);
+        static::assertSame('2022-02-15T00:27:45.330Z', $event->created);
+        static::assertNull($event->reason);
     }
 }


### PR DESCRIPTION
- Removed parseSnapshotEvent since we already have Webhook.constructEvent.
- Added Reason and Livemode back to ThinEvent class.