### PR TITLE
Deserialize into correct v2 EventData types

### DIFF
--- a/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
+++ b/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
@@ -32,4 +32,14 @@ class V1BillingMeterErrorReportTriggeredEvent extends \Stripe\V2\Event
 
         return \Stripe\Util\Util::convertToStripeObject($object, $options, 'v2');
     }
+
+    public static function constructFrom($values, $opts = null, $apiMode = 'v2')
+    {
+        $evt = parent::constructFrom($values, $opts, $apiMode);
+        if (null !== $evt->data) {
+            $evt->data = \Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData::constructFrom($evt->data, $opts, $apiMode);
+        }
+
+        return $evt;
+    }
 }

--- a/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
+++ b/lib/Events/V1BillingMeterErrorReportTriggeredEvent.php
@@ -21,16 +21,17 @@ class V1BillingMeterErrorReportTriggeredEvent extends \Stripe\V2\Event
      */
     public function fetchRelatedObject()
     {
+        $apiMode = \Stripe\Util\Util::getApiMode($this->related_object->url);
         list($object, $options) = $this->_request(
             'get',
             $this->related_object->url,
             [],
             ['stripe_account' => $this->context],
             [],
-            'v2'
+            $apiMode
         );
 
-        return \Stripe\Util\Util::convertToStripeObject($object, $options, 'v2');
+        return \Stripe\Util\Util::convertToStripeObject($object, $options, $apiMode);
     }
 
     public static function constructFrom($values, $opts = null, $apiMode = 'v2')

--- a/lib/Events/V1BillingMeterNoMeterFoundEvent.php
+++ b/lib/Events/V1BillingMeterNoMeterFoundEvent.php
@@ -10,4 +10,14 @@ namespace Stripe\Events;
 class V1BillingMeterNoMeterFoundEvent extends \Stripe\V2\Event
 {
     const LOOKUP_TYPE = 'v1.billing.meter.no_meter_found';
+
+    public static function constructFrom($values, $opts = null, $apiMode = 'v2')
+    {
+        $evt = parent::constructFrom($values, $opts, $apiMode);
+        if (null !== $evt->data) {
+            $evt->data = \Stripe\EventData\V1BillingMeterNoMeterFoundEventData::constructFrom($evt->data, $opts, $apiMode);
+        }
+
+        return $evt;
+    }
 }

--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -88,7 +88,6 @@ class ObjectTypes
             \Stripe\LineItem::OBJECT_NAME => \Stripe\LineItem::class,
             \Stripe\LoginLink::OBJECT_NAME => \Stripe\LoginLink::class,
             \Stripe\Mandate::OBJECT_NAME => \Stripe\Mandate::class,
-            \Stripe\Margin::OBJECT_NAME => \Stripe\Margin::class,
             \Stripe\PaymentIntent::OBJECT_NAME => \Stripe\PaymentIntent::class,
             \Stripe\PaymentLink::OBJECT_NAME => \Stripe\PaymentLink::class,
             \Stripe\PaymentMethod::OBJECT_NAME => \Stripe\PaymentMethod::class,

--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -159,10 +159,6 @@ class ObjectTypes
      * @var array Mapping from v2 object types to resource classes
      */
     const v2Mapping = [
-        // V1 Class needed for fetching the right related object
-        // TODO: https://go/j/DEVSDK-2204 Make a more standardized fix in codegen for all languages
-        \Stripe\Billing\Meter::OBJECT_NAME => \Stripe\Billing\Meter::class,
-
         // v2 object classes: The beginning of the section generated from our OpenAPI spec
         \Stripe\V2\Billing\MeterEvent::OBJECT_NAME => \Stripe\V2\Billing\MeterEvent::class,
         \Stripe\V2\Billing\MeterEventAdjustment::OBJECT_NAME => \Stripe\V2\Billing\MeterEventAdjustment::class,

--- a/lib/Util/ObjectTypes.php
+++ b/lib/Util/ObjectTypes.php
@@ -88,6 +88,7 @@ class ObjectTypes
             \Stripe\LineItem::OBJECT_NAME => \Stripe\LineItem::class,
             \Stripe\LoginLink::OBJECT_NAME => \Stripe\LoginLink::class,
             \Stripe\Mandate::OBJECT_NAME => \Stripe\Mandate::class,
+            \Stripe\Margin::OBJECT_NAME => \Stripe\Margin::class,
             \Stripe\PaymentIntent::OBJECT_NAME => \Stripe\PaymentIntent::class,
             \Stripe\PaymentLink::OBJECT_NAME => \Stripe\PaymentLink::class,
             \Stripe\PaymentMethod::OBJECT_NAME => \Stripe\PaymentMethod::class,

--- a/tests/Stripe/EventTest.php
+++ b/tests/Stripe/EventTest.php
@@ -5,6 +5,7 @@ namespace Stripe;
 /**
  * @internal
  * @covers \Stripe\Event
+ * @covers \Stripe\V2\Event
  */
 final class EventTest extends \Stripe\TestCase
 {
@@ -31,5 +32,76 @@ final class EventTest extends \Stripe\TestCase
         );
         $resource = Event::retrieve(self::TEST_RESOURCE_ID);
         static::assertInstanceOf(\Stripe\Event::class, $resource);
+    }
+
+    public function testV2EventDataDeserializesIntoType()
+    {
+        $jsonEvent = [
+            'id' => 'evt_123',
+            'object' => 'v2.core.event',
+            'type' => 'v1.billing.meter.error_report_triggered',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'related_object' => [
+                'id' => 'mtr_123',
+                'type' => 'billing.meter',
+                'url' => '/v1/billing/meters/mtr_123',
+            ],
+            'data' => [
+                'reason' => [
+                    'error_count' => 1,
+                ],
+            ],
+        ];
+
+        $this->stubRequest(
+            'GET',
+            '/v2/core/events/evt_123',
+            [],
+            null,
+            false,
+            $jsonEvent,
+            200,
+            BaseStripeClient::DEFAULT_API_BASE
+        );
+        $client = new StripeClient(['api_key' => 'sk_test_client']);
+
+        $event = $client->v2->core->events->retrieve('evt_123');
+
+        static::assertInstanceOf(\Stripe\Events\V1BillingMeterErrorReportTriggeredEvent::class, $event);
+        static::assertInstanceOf(\Stripe\EventData\V1BillingMeterErrorReportTriggeredEventData::class, $event->data);
+    }
+
+    public function testV2EventFetchRelatedObject()
+    {
+        $jsonEvent = [
+            'id' => 'evt_123',
+            'object' => 'v2.core.event',
+            'type' => 'v1.billing.meter.error_report_triggered',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => 'acct_123',
+            'related_object' => [
+                'id' => 'mtr_123',
+                'type' => 'billing.meter',
+                'url' => '/v1/billing/meters/mtr_123',
+            ],
+            'data' => [],
+        ];
+
+        // right now PHP only supports one request per unit test
+        $fullEvent = \Stripe\Util\Util::convertToStripeObject($jsonEvent, [], 'v2');
+        static::assertInstanceOf(\Stripe\Events\V1BillingMeterErrorReportTriggeredEvent::class, $fullEvent);
+        $this->stubRequest(
+            'GET',
+            '/v1/billing/meters/mtr_123',
+            [],
+            null,
+            false,
+            ['object' => 'billing.meter', 'id' => 'mtr_123'],
+            200,
+            MOCK_URL
+        );
+        $meter = $fullEvent->fetchRelatedObject();
+        static::assertInstanceOf(\Stripe\Billing\Meter::class, $meter);
+        static::assertSame('mtr_123', $meter->id);
     }
 }


### PR DESCRIPTION
Currently we return generic StripeObjects for the EventData in our v2 events. This correctly calls construct_from when making v2 events (retrieve) to make sure they are typed appropriately.

This also makes it so we do not need to have BillingMeter in v2 mapping by using api mode to deserialize events.

## Changelog
* Fixes a bug where v2 EventData was not being deserialized into the appropriate type for `V1BillingMeterErrorReportTriggeredEvent` and `V1BillingMeterNoMeterFoundEvent`
