### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/lib/V2/Billing/MeterEvent.php
+++ b/lib/V2/Billing/MeterEvent.php
@@ -17,5 +17,5 @@ namespace Stripe\V2\Billing;
  */
 class MeterEvent extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = 'billing.meter_event';
+    const OBJECT_NAME = 'v2.billing.meter_event';
 }

--- a/lib/V2/Billing/MeterEventAdjustment.php
+++ b/lib/V2/Billing/MeterEventAdjustment.php
@@ -16,7 +16,7 @@ namespace Stripe\V2\Billing;
  */
 class MeterEventAdjustment extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = 'billing.meter_event_adjustment';
+    const OBJECT_NAME = 'v2.billing.meter_event_adjustment';
 
     const STATUS_COMPLETE = 'complete';
     const STATUS_PENDING = 'pending';

--- a/lib/V2/Billing/MeterEventSession.php
+++ b/lib/V2/Billing/MeterEventSession.php
@@ -14,5 +14,5 @@ namespace Stripe\V2\Billing;
  */
 class MeterEventSession extends \Stripe\ApiResource
 {
-    const OBJECT_NAME = 'billing.meter_event_session';
+    const OBJECT_NAME = 'v2.billing.meter_event_session';
 }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -43,7 +43,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $this->curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
     }
 
     public function testCtorDoesNotThrowWhenNoParams()
@@ -566,7 +567,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -604,7 +606,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -637,7 +640,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -668,7 +672,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -43,8 +43,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $this->curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     public function testCtorDoesNotThrowWhenNoParams()
@@ -416,7 +415,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     public function testV2GetRequest()
     {
         $this->curlClientStub->method('executeRequestWithRetries')
-            ->willReturn(['{"object": "billing.meter_event_session"}', 200, []])
+            ->willReturn(['{"object": "v2.billing.meter_event_session"}', 200, []])
         ;
 
         $this->curlClientStub->expects(static::once())
@@ -446,7 +445,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     public function testV2PostRequest()
     {
         $this->curlClientStub->method('executeRequestWithRetries')
-            ->willReturn(['{"object": "billing.meter_event_session"}', 200, []])
+            ->willReturn(['{"object": "v2.billing.meter_event_session"}', 200, []])
         ;
 
         $this->curlClientStub->expects(static::once())
@@ -475,7 +474,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     public function testV2PostRequestWithEmptyParams()
     {
         $this->curlClientStub->method('executeRequestWithRetries')
-            ->willReturn(['{"object": "billing.meter_event_session"}', 200, []])
+            ->willReturn(['{"object": "v2.billing.meter_event_session"}', 200, []])
         ;
 
         $this->curlClientStub->expects(static::once())
@@ -567,8 +566,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -606,8 +604,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -640,8 +637,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -672,8 +668,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     {
         $curlClientStub = $this->getMockBuilder(\Stripe\HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -777,7 +772,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     public function testV2OverridesPreviewVersionIfPassedInRequestOptions()
     {
         $this->curlClientStub->method('executeRequestWithRetries')
-            ->willReturn(['{"object": "billing.meter_event_session"}', 200, []])
+            ->willReturn(['{"object": "v2.billing.meter_event_session"}', 200, []])
         ;
 
         $this->curlClientStub->expects(static::once())
@@ -802,7 +797,7 @@ final class BaseStripeClientTest extends \Stripe\TestCase
     public function testV1AndV2Request()
     {
         $this->curlClientStub->method('executeRequestWithRetries')
-            ->willReturnOnConsecutiveCalls(['{"object": "billing.meter_event_session"}', 200, []], ['{"object": "billing.meter_event"}', 200, []])
+            ->willReturnOnConsecutiveCalls(['{"object": "v2.billing.meter_event_session"}', 200, []], ['{"object": "billing.meter_event"}', 200, []])
         ;
 
         $this->curlClientStub
@@ -816,7 +811,8 @@ final class BaseStripeClientTest extends \Stripe\TestCase
                     $this->assertContains('Stripe-Version: ' . ApiVersion::CURRENT, $opts[\CURLOPT_HTTPHEADER]);
 
                     return true;
-                }), MOCK_URL . '/v1/billing/meter_event/bmes_123',
+                }),
+                MOCK_URL . '/v1/billing/meter_event/bmes_123',
             ])
         ;
 


### PR DESCRIPTION
CI failures are expected because stripe-mock doesn't yet have the changes these this PR is responding to

## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.