### PR TITLE
Add justfile, remove coveralls, and fix AUTOLOAD in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Run test suite
         run: |
           php --version
-          make ci-test
-          just ci-test
+          echo "autoload is: $AUTOLOAD"
+          AUTOLOAD=1 just ci-test
 
   publish:
     # Doesn't actually publish. The publish happens via a packagist webhook configured in the Github UI. But we still display a message here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,6 @@ jobs:
         run: just lint
 
   tests:
-    name: Tests
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -93,6 +91,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+    name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }})
 
     steps:
       - uses: extractions/setup-just@v2
@@ -126,14 +125,11 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run test suite
-        env:
-          AUTOLOAD: ${{ matrix.autoload }}
         # --yes skips the confirmation dialogue for the CI test, which modifies files
         run: |
           php --version
           echo "autoload is: $AUTOLOAD"
-          make ci-test
-          just --yes ci-test
+          just --yes ci-test ${{ matrix.autoload }}
 
   publish:
     # Doesn't actually publish. The publish happens via a packagist webhook configured in the Github UI. But we still display a message here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
         # --yes skips the confirmation dialogue for the CI test, which modifies files
         run: |
           php --version
-          echo "autoload is: $AUTOLOAD"
           just --yes ci-test ${{ matrix.autoload }}
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - "8.2"
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
 
       - name: Setup PHP
@@ -69,7 +70,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpstan
-        run: make phpstan
+        run: just lint
 
   tests:
     name: Tests
@@ -94,13 +95,13 @@ jobs:
           - "8.2"
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: xdebug
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -127,15 +128,7 @@ jobs:
       - name: Run test suite
         run: |
           php --version
-          make ci-test
-
-      - name: Coveralls
-        if: matrix.php-version == '8.2' && matrix.env == 'AUTOLOAD=1'
-        uses: coverallsapp/github-action@v2
-        with:
-          files: clover.xml
-          flag-name: php-${{ matrix.php-version }}-${{ matrix.env }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          just ci-test
 
   publish:
     # Doesn't actually publish. The publish happens via a packagist webhook configured in the Github UI. But we still display a message here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           php --version
           echo "autoload is: $AUTOLOAD"
-          AUTOLOAD=1 just ci-test
+          just ci-test
 
   publish:
     # Doesn't actually publish. The publish happens via a packagist webhook configured in the Github UI. But we still display a message here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,11 @@ jobs:
     name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }})
 
     steps:
-      - uses: extractions/setup-just@v2
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install just
+
       - uses: actions/checkout@v3
 
       - name: Setup PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        autload:
+        autoload:
           - "0"
           - "1"
         php-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - AUTOLOAD=0
-          - AUTOLOAD=1
+        autload:
+          - "0"
+          - "1"
         php-version:
           - "5.6"
           - "7.0"
@@ -126,6 +126,8 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run test suite
+        env:
+          AUTOLOAD: ${{ matrix.autoload }}
         # --yes skips the confirmation dialogue for the CI test, which modifies files
         run: |
           php --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        php-version:
-          - "8.2"
-
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
@@ -49,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: "8.2"
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,12 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Run test suite
+        # --yes skips the confirmation dialogue for the CI test, which modifies files
         run: |
           php --version
           echo "autoload is: $AUTOLOAD"
-          just ci-test
+          make ci-test
+          just --yes ci-test
 
   publish:
     # Doesn't actually publish. The publish happens via a packagist webhook configured in the Github UI. But we still display a message here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Run test suite
         run: |
           php --version
+          make ci-test
           just ci-test
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,7 @@ jobs:
     name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }})
 
     steps:
-      - name: Install just
-        run: |
-          sudo apt-get update
-          sudo apt-get install just
-
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v3
 
       - name: Setup PHP

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ build/*
 # If the vendor directory isn't being commited the composer.lock file should also be ignored
 composer.lock
 
-# Ignore PHPUnit coverage file
-clover.xml
-
 # Ignore IDE's configuration files
 .idea
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# NOTE: this file is deprecated and slated for deletion; prefer using the equivalent `just` commands.
+
 export PHPDOCUMENTOR_VERSION := v3.0.0
 
 vendor: composer.json

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test: vendor
 .PHONY: test
 
 ci-test: vendor
+	echo "calling build with $$AUTOLOAD"
 	./build.php $$AUTOLOAD
 .PHONY: ci-test
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Latest Stable Version](https://poser.pugx.org/stripe/stripe-php/v/stable.svg)](https://packagist.org/packages/stripe/stripe-php)
 [![Total Downloads](https://poser.pugx.org/stripe/stripe-php/downloads.svg)](https://packagist.org/packages/stripe/stripe-php)
 [![License](https://poser.pugx.org/stripe/stripe-php/license.svg)](https://packagist.org/packages/stripe/stripe-php)
-[![Code Coverage](https://coveralls.io/repos/stripe/stripe-php/badge.svg?branch=master)](https://coveralls.io/r/stripe/stripe-php?branch=master)
 
 The Stripe PHP library provides convenient access to the Stripe API from
 applications written in the PHP language. It includes a pre-defined set of
@@ -249,7 +248,9 @@ New features and bug fixes are released on the latest major version of the Strip
 
 ## Development
 
-Get [Composer][composer]. For example, on Mac OS:
+We use [just](https://github.com/casey/just) for conveniently running development tasks. You can use them directly, or copy the commands out of the `justfile`. To our help docs, run `just`.
+
+To get started, install [Composer][composer]. For example, on Mac OS:
 
 ```bash
 brew install composer
@@ -258,7 +259,8 @@ brew install composer
 Install dependencies:
 
 ```bash
-composer install
+just install
+# or: composer install
 ```
 
 The test suite depends on [stripe-mock], so make sure to fetch and run it from a
@@ -273,13 +275,15 @@ stripe-mock
 Install dependencies as mentioned above (which will resolve [PHPUnit](http://packagist.org/packages/phpunit/phpunit)), then you can run the test suite:
 
 ```bash
-./vendor/bin/phpunit
+just test
+# or: ./vendor/bin/phpunit
 ```
 
 Or to run an individual test file:
 
 ```bash
-./vendor/bin/phpunit tests/Stripe/UtilTest.php
+just test tests/Stripe/UtilTest.php
+# or: ./vendor/bin/phpunit tests/Stripe/UtilTest.php
 ```
 
 Update bundled CA certificates from the [Mozilla cURL release][curl]:
@@ -291,7 +295,8 @@ Update bundled CA certificates from the [Mozilla cURL release][curl]:
 The library uses [PHP CS Fixer][php-cs-fixer] for code formatting. Code must be formatted before PRs are submitted, otherwise CI will fail. Run the formatter with:
 
 ```bash
-./vendor/bin/php-cs-fixer fix -v .
+just format
+# or: ./vendor/bin/php-cs-fixer fix -v .
 ```
 
 ## Attention plugin developers

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,46 @@
 {
-    "name": "stripe\/stripe-php",
-    "description": "Stripe PHP Library",
-    "keywords": [
-        "stripe",
-        "payment processing",
-        "api"
-    ],
-    "homepage": "https:\/\/stripe.com\/",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Stripe and contributors",
-            "homepage": "https:\/\/github.com\/stripe\/stripe-php\/contributors"
-        }
-    ],
-    "require": {
-        "php": ">=5.6.0",
-        "ext-curl": "*",
-        "ext-json": "*",
-        "ext-mbstring": "*"
-    },
-    "require-dev": {
-        "phpunit\/phpunit": "^5.7 || ^9.0",
-        "friendsofphp\/php-cs-fixer": "3.5.0",
-        "phpstan\/phpstan": "^1.2"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.0-dev"
-        }
+  "name": "stripe/stripe-php",
+  "description": "Stripe PHP Library",
+  "keywords": [
+    "stripe",
+    "payment processing",
+    "api"
+  ],
+  "homepage": "https://stripe.com/",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Stripe and contributors",
+      "homepage": "https://github.com/stripe/stripe-php/contributors"
     }
+  ],
+  "require": {
+    "php": ">=5.6.0",
+    "ext-curl": "*",
+    "ext-json": "*",
+    "ext-mbstring": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7 || ^9.0",
+    "friendsofphp/php-cs-fixer": "3.5.0",
+    "phpstan/phpstan": "^1.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "Stripe\\": "lib/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Stripe\\": [
+        "tests/",
+        "tests/Stripe/"
+      ]
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "2.0-dev"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,46 +1,33 @@
 {
-  "name": "stripe/stripe-php",
-  "description": "Stripe PHP Library",
-  "keywords": [
-    "stripe",
-    "payment processing",
-    "api"
-  ],
-  "homepage": "https://stripe.com/",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Stripe and contributors",
-      "homepage": "https://github.com/stripe/stripe-php/contributors"
+    "name": "stripe\/stripe-php",
+    "description": "Stripe PHP Library",
+    "keywords": [
+        "stripe",
+        "payment processing",
+        "api"
+    ],
+    "homepage": "https:\/\/stripe.com\/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Stripe and contributors",
+            "homepage": "https:\/\/github.com\/stripe\/stripe-php\/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.0",
+        "ext-curl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*"
+    },
+    "require-dev": {
+        "phpunit\/phpunit": "^5.7 || ^9.0",
+        "friendsofphp\/php-cs-fixer": "3.5.0",
+        "phpstan\/phpstan": "^1.2"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
     }
-  ],
-  "require": {
-    "php": ">=5.6.0",
-    "ext-curl": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7 || ^9.0",
-    "friendsofphp/php-cs-fixer": "3.5.0",
-    "phpstan/phpstan": "^1.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "Stripe\\": "lib/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Stripe\\": [
-        "tests/",
-        "tests/Stripe/"
-      ]
-    }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "2.0-dev"
-    }
-  }
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,63 @@
+import? '../sdk-codegen/justfile'
+
+set quiet
+
+export PATH := "./vendor/bin:" + env_var('PATH')
+PHPDOCUMENTOR_VERSION := "v3.0.0"
+
+_default:
+    just --list --unsorted
+
+# install vendored dependencies; only used locally
+[group('useful')]
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    composer install
+
+    if [ ! -f vendor/bin/phpdoc ]; then
+        curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar -o vendor/bin/phpdoc
+        chmod +x vendor/bin/phpdoc
+    fi
+
+[no-exit-message]
+[group('useful')]
+test *options:
+    phpunit {{ options }}
+
+[group('CI')]
+ci-test:
+    ./build.php $AUTOLOAD
+
+[group('useful')]
+format *options:
+    PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --using-cache=no {{ options }}
+
+# for backwards compatibility; ideally removed later
+[private]
+alias codegen-format := format
+
+[group('CI')]
+format-check: (format "--dry-run")
+
+[group('CI')]
+lint *options:
+    php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{options}}
+
+# for backwards compatibility; ideally removed later
+[private]
+alias phpstan := lint
+
+[group('misc')]
+phpstan-baseline: (lint "--generate-baseline")
+
+# called by tooling
+[private]
+update-version version:
+    echo "{{ version }}" > VERSION
+    perl -pi -e 's|VERSION = '\''[.\-\w\d]+'\''|VERSION = '\''{{ version }}'\''|' lib/Stripe.php
+
+[group('misc')]
+phpdoc:
+    phpdoc

--- a/justfile
+++ b/justfile
@@ -27,6 +27,7 @@ test *options:
     phpunit {{ options }}
 
 [group('CI')]
+[confirm("This will modify local and is mostly just for CI; do you want to proceed?")]
 ci-test:
     echo "got $AUTOLOAD"
     ./build.php $AUTOLOAD

--- a/justfile
+++ b/justfile
@@ -11,15 +11,7 @@ _default:
 # install vendored dependencies; only used locally
 [group('useful')]
 install:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
     composer install
-
-    if [ ! -f vendor/bin/phpdoc ]; then
-        curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar -o vendor/bin/phpdoc
-        chmod +x vendor/bin/phpdoc
-    fi
 
 [no-exit-message]
 [group('useful')]
@@ -62,4 +54,12 @@ update-version version:
 
 [group('misc')]
 phpdoc:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ ! -f vendor/bin/phpdoc ]; then
+        curl -sfL https://github.com/phpDocumentor/phpDocumentor/releases/download/{{ PHPDOCUMENTOR_VERSION }}/phpDocumentor.phar -o vendor/bin/phpdoc
+        chmod +x vendor/bin/phpdoc
+    fi
+
     phpdoc

--- a/justfile
+++ b/justfile
@@ -19,9 +19,9 @@ test *options:
     phpunit {{ options }}
 
 [group('CI')]
-[confirm("This will modify local and is mostly just for CI; do you want to proceed?")]
+[confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
 ci-test autoload:
-    echo "got {{ autoload }}"
+    echo "running build.php with argument: {{ autoload }}"
     ./build.php {{ autoload }}
 
 [group('useful')]

--- a/justfile
+++ b/justfile
@@ -20,9 +20,9 @@ test *options:
 
 [group('CI')]
 [confirm("This will modify local and is mostly just for CI; do you want to proceed?")]
-ci-test:
-    echo "got $AUTOLOAD"
-    ./build.php $AUTOLOAD
+ci-test autoload:
+    echo "got {{ autoload }}"
+    ./build.php {{ autoload }}
 
 [group('useful')]
 format *options:

--- a/justfile
+++ b/justfile
@@ -21,7 +21,6 @@ test *options:
 [group('CI')]
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
 ci-test autoload:
-    echo "running build.php with argument: {{ autoload }}"
     ./build.php {{ autoload }}
 
 [group('useful')]

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ test *options:
 
 [group('CI')]
 ci-test:
+    echo "got $AUTOLOAD"
     ./build.php $AUTOLOAD
 
 [group('useful')]

--- a/justfile
+++ b/justfile
@@ -12,14 +12,17 @@ _default:
 install:
     composer install
 
+# ⭐ run full unit test suite; needs stripe-mock
 [no-exit-message]
 test *args:
     phpunit {{ args }}
 
+# run tests in CI; can use autoload mode (or not)
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
 ci-test autoload:
     ./build.php {{ autoload }}
 
+# ⭐ format all files
 format *args:
     PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --using-cache=no {{ args }}
 
@@ -27,8 +30,10 @@ format *args:
 [private]
 alias codegen-format := format
 
+# check formatting for, but don't modify, files
 format-check: (format "--dry-run")
 
+# ⭐ statically analyze code
 lint *args:
     php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{args}}
 

--- a/justfile
+++ b/justfile
@@ -2,48 +2,39 @@ import? '../sdk-codegen/justfile'
 
 set quiet
 
-export PATH := "./vendor/bin:" + env_var('PATH')
-PHPDOCUMENTOR_VERSION := "v3.0.0"
+# make vendored executables callable directly
+export PATH := "vendor/bin:" + env_var('PATH')
 
 _default:
     just --list --unsorted
 
 # install vendored dependencies; only used locally
-[group('useful')]
 install:
     composer install
 
 [no-exit-message]
-[group('useful')]
-test *options:
-    phpunit {{ options }}
+test *args:
+    phpunit {{ args }}
 
-[group('CI')]
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
 ci-test autoload:
     ./build.php {{ autoload }}
 
-[group('useful')]
-format *options:
-    PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --using-cache=no {{ options }}
+format *args:
+    PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --using-cache=no {{ args }}
 
 # for backwards compatibility; ideally removed later
 [private]
 alias codegen-format := format
 
-[group('CI')]
 format-check: (format "--dry-run")
 
-[group('CI')]
-lint *options:
-    php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{options}}
+lint *args:
+    php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{args}}
 
 # for backwards compatibility; ideally removed later
 [private]
 alias phpstan := lint
-
-[group('misc')]
-phpstan-baseline: (lint "--generate-baseline")
 
 # called by tooling
 [private]
@@ -51,7 +42,10 @@ update-version version:
     echo "{{ version }}" > VERSION
     perl -pi -e 's|VERSION = '\''[.\-\w\d]+'\''|VERSION = '\''{{ version }}'\''|' lib/Stripe.php
 
-[group('misc')]
+
+PHPDOCUMENTOR_VERSION := "v3.0.0"
+# generates docs; currently broken? can unhide if working
+[private]
 phpdoc:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/phpunit.no_autoload.xml
+++ b/phpunit.no_autoload.xml
@@ -17,7 +17,4 @@
             <directory>lib</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,4 @@
             <directory>lib</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In an effort to modernize and simplify our local tooling, we're moving our dev commands from makefiles to [justfiles](https://github.com/casey/just). This is intended to be mostly a drop-in replacement, but some command names may change per standardization efforts.

Namely, I renamed `fmt` to `format`, added `lint` in place of `phpstan`, and swapped `vendor` to `install`.

One actual change is that dependencies won't auto-install before running tests like they did before. Users will have to `just install` before `just test`.

Also, I didn't add a ton of docstrings, since the recipes are mostly self explanatory. But, we could add some. The recipes are also grouped, so the help output looks like:

```
Available recipes:
    [useful]
    install            # install vendored dependencies; only used locally
    test *options
    format *options

    [CI]
    ci-test
    format-check
    lint *options

    [misc]
    phpstan-baseline
    phpdoc
```

Without groups, output of `just` is:

```
Available recipes:
    install            # install vendored dependencies; only used locally
    test *options
    ci-test
    format *options
    format-check
    lint *options
    phpstan-baseline
    phpdoc
```

Which isn't bad either. I could go either way on the groups. If nothing else, I think it makes the `justfile` itself harder to grok, so i'm fine to pull them too.

### CI

Also, there was an issue where we weren't correctly setting the `AUTOLOAD` env var, so we were never running tests with `autoload=1`. The justfile flagged this issue and I changed the way the matrix was loaded to acommodate it.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added `justfile`
- added warning to top of makefile
- tweaked CI to use `just` instead of `make`
- fixed CI so AUTOLOAD was correctly set
- removed PHPstan from a matrix and just hardcoded the version we wanted.

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2325](https://go/j/DEVSDK-2325)