### PR TITLE
ensure dependencies are installed for format and test recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,13 +8,13 @@ export PATH := "vendor/bin:" + env_var('PATH')
 _default:
     just --list --unsorted
 
-# install vendored dependencies; only used locally
-install:
-    composer install
+# install vendored dependencies
+install *args:
+    composer install {{ if is_dependency() == "true" {"--quiet"} else {""} }} {{ args }}
 
 # ⭐ run full unit test suite; needs stripe-mock
 [no-exit-message]
-test *args:
+test *args: install
     phpunit {{ args }}
 
 # run tests in CI; can use autoload mode (or not)
@@ -23,7 +23,7 @@ ci-test autoload:
     ./build.php {{ autoload }}
 
 # ⭐ format all files
-format *args:
+format *args: install
     PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix -v --using-cache=no {{ args }}
 
 # for backwards compatibility; ideally removed later


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

When `just format` is run from CI jobs in other repos, it doesn't install the dependencies. So the justfile needs to ensure that happens.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- declare `install` as a pre-req for `format` and `test` recipes.

### See Also
<!-- Include any links or additional information that help explain this change. -->
