### PR TITLE
Restore testCoreEventsGet generated test

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -64,7 +64,7 @@ abstract class Util
                     if (\array_key_exists('type', $resp) && \array_key_exists($resp['type'], $eventTypes)) {
                         $class = $eventTypes[$resp['type']];
                     } else {
-                        $class = \Stripe\StripeObject::class;
+                        $class = \Stripe\V2\Event::class;
                     }
                 }
             } elseif (\array_key_exists('data', $resp) && \array_key_exists('next_page_url', $resp)) {

--- a/lib/V2/Event.php
+++ b/lib/V2/Event.php
@@ -3,6 +3,11 @@
 namespace Stripe\V2;
 
 /**
+ * Base class for V2 events.
+ *
+ * This is concrete for use in our generated tests. Events returned from the \Stripe\V2\Core\EventService
+ * will be a subtype of \Stripe\V2\Event.
+ *
  * @property string $id Unique identifier for the event.
  * @property string $object String representing the object's type. Objects of the same type share the same value of the object field.
  * @property int $created Time at which the object was created.
@@ -10,7 +15,7 @@ namespace Stripe\V2;
  * @property string $type The type of the event.
  * @property null|string $context The Stripe account of the event
  */
-abstract class Event extends \Stripe\ApiResource
+class Event extends \Stripe\ApiResource
 {
     const OBJECT_NAME = 'v2.core.event';
 }

--- a/tests/Stripe/GeneratedExamplesTest.php
+++ b/tests/Stripe/GeneratedExamplesTest.php
@@ -577,6 +577,20 @@ final class GeneratedExamplesTest extends \Stripe\TestCase
         static::assertInstanceOf(\Stripe\Checkout\Session::class, $result);
     }
 
+    public function testCoreEventsGet()
+    {
+        $this->stubRequest(
+            'get',
+            '/v2/core/events/ll_123',
+            [],
+            [],
+            false,
+            ['object' => \Stripe\V2\Event::OBJECT_NAME]
+        );
+        $result = $this->client->v2->core->events->retrieve('ll_123', []);
+        static::assertInstanceOf(\Stripe\V2\Event::class, $result);
+    }
+
     public function testCountrySpecsGet()
     {
         $this->expectsRequest('get', '/v1/country_specs');


### PR DESCRIPTION
### Why?
We have generated example tests that test service endpoints.  \Stripe\V2\Event is an abstract base class for V2 events, and the return type of EventService.retrieve.  Because the Event class was abstract, we could not include it in convertToStripeObject and therefore could not include this generated test.

### What?
- made v2 event class concrete, and changed convertToStripeObject to use it if we cannot find the identified event subclass
- add comment on event class explaining its role
- added generated test testCoreEventsGet