### PR TITLE
Make `httpClient()` a public, static method

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -436,8 +436,8 @@ class ApiRequestor
         // X-Stripe-Client-User-Agent header via the optional getUserAgentInfo()
         // method
         $clientUAInfo = null;
-        if (\method_exists($this->httpClient(), 'getUserAgentInfo')) {
-            $clientUAInfo = $this->httpClient()->getUserAgentInfo();
+        if (\method_exists(self::httpClient(), 'getUserAgentInfo')) {
+            $clientUAInfo = self::httpClient()->getUserAgentInfo();
         }
 
         if ($params && \is_array($params)) {
@@ -518,7 +518,7 @@ class ApiRequestor
 
         $requestStartMs = Util\Util::currentTimeMillis();
 
-        list($rbody, $rcode, $rheaders) = $this->httpClient()->request(
+        list($rbody, $rcode, $rheaders) = self::httpClient()->request(
             $method,
             $absUrl,
             $rawHeaders,
@@ -673,7 +673,7 @@ class ApiRequestor
     /**
      * @return HttpClient\ClientInterface
      */
-    private function httpClient()
+    public static function httpClient()
     {
         if (!self::$_httpClient) {
             self::$_httpClient = HttpClient\CurlClient::instance();

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -562,7 +562,7 @@ class ApiRequestor
 
         $requestStartMs = Util\Util::currentTimeMillis();
 
-        list($rbody, $rcode, $rheaders) = $this->streamingHttpClient()->requestStream(
+        list($rbody, $rcode, $rheaders) = self::streamingHttpClient()->requestStream(
             $method,
             $absUrl,
             $rawHeaders,
@@ -685,7 +685,7 @@ class ApiRequestor
     /**
      * @return HttpClient\StreamingClientInterface
      */
-    private function streamingHttpClient()
+    public static function streamingHttpClient()
     {
         if (!self::$_streamingHttpClient) {
             self::$_streamingHttpClient = HttpClient\CurlClient::instance();


### PR DESCRIPTION
### Why?
I want to do something like this with `ApiRequestor::setHttpClient()`:

in tests:

```php
ApiRequestor::setHttpClient($this->createMock(...));
```

in application code:

```php
ApiRequestor::setHttpClient(new LoggingHttpClient($this->logger))
```

If you first execute the `ApiRequestor::setHttpClient` in test, and then afterwards the `ApiRequestor::setHttpClient()` in application code, then the mocked http client is gone and this goes wrong. What I think would be a nice solution: allow me to decorate the configured http client:

```php
class LoggingHttpClient implements ClientInterface
{
    public function __construct(
        private LoggerInterface $logger,
        private ClientInterface $decorated,
    ) {
    }

    /**
     * @see ClientInterface::request()
     */
    public function request($method, $absUrl, $headers, $params, $hasFile): array
    {
        [$rawResponseBody, $statusCode, $responseHeaders] = $this->decorated->request(
            $method,
            $absUrl,
            $headers,
            $params,
            $hasFile,
        );

        // $this->logger->...

        return [$rawResponseBody, $statusCode, $responseHeaders];
    }
}
```

And then wherever I configure the logging http client I can instantiate this class decorating the previously configured http client:

```php
ApiRequestor::setHttpClient(new LoggingHttpClient($this->logger, ApiRequestor::httpClient());
```

Now `LoggingHttpClient` decorates the mock client and things work as intended. It kinda becomes a middleware pattern, and opens the door for other middleware, e.g.:

```php
ApiRequestor::setHttpClient(
    new MetricsHttpClient(
        new RetryingHttpClient(
            new CachingHttpClient(
                new LoggingHttpClient(
                    $this->logger,
                    ApiRequestor::httpClient()
                ),
                $this->cache
            )
        ),
        $this->metrics
    )
);
```

### What?
- Make `httpClient()` public and static 

### See Also
NA