### PR TITLE
Raise a more descriptive error if null bytes are found in the path

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -224,8 +224,8 @@ class ApiRequestor
                     return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
                 }
 
-                // fall through in generic 400 or 404, returns InvalidRequestException by default
-                // no break
+            // fall through in generic 400 or 404, returns InvalidRequestException by default
+            // no break
             case 404:
                 return Exception\InvalidRequestException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
 
@@ -266,7 +266,7 @@ class ApiRequestor
         switch ($type) {
             case 'idempotency_error':
                 return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
-                // The beginning of the section generated from our OpenAPI spec
+            // The beginning of the section generated from our OpenAPI spec
             case 'temporary_session_expired':
                 return Exception\TemporarySessionExpiredException::factory(
                     $msg,
@@ -277,7 +277,7 @@ class ApiRequestor
                     $code
                 );
 
-                // The end of the section generated from our OpenAPI spec
+            // The end of the section generated from our OpenAPI spec
             default:
                 return self::_specificV1APIError($rbody, $rcode, $rheaders, $resp, $errorData);
         }

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -224,8 +224,8 @@ class ApiRequestor
                     return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
                 }
 
-            // fall through in generic 400 or 404, returns InvalidRequestException by default
-            // no break
+                // fall through in generic 400 or 404, returns InvalidRequestException by default
+                // no break
             case 404:
                 return Exception\InvalidRequestException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code, $param);
 
@@ -266,7 +266,7 @@ class ApiRequestor
         switch ($type) {
             case 'idempotency_error':
                 return Exception\IdempotencyException::factory($msg, $rcode, $rbody, $resp, $rheaders, $code);
-            // The beginning of the section generated from our OpenAPI spec
+                // The beginning of the section generated from our OpenAPI spec
             case 'temporary_session_expired':
                 return Exception\TemporarySessionExpiredException::factory(
                     $msg,
@@ -277,7 +277,7 @@ class ApiRequestor
                     $code
                 );
 
-            // The end of the section generated from our OpenAPI spec
+                // The end of the section generated from our OpenAPI spec
             default:
                 return self::_specificV1APIError($rbody, $rcode, $rheaders, $resp, $errorData);
         }
@@ -515,6 +515,12 @@ class ApiRequestor
     private function _requestRaw($method, $url, $params, $headers, $apiMode, $usage)
     {
         list($absUrl, $rawHeaders, $params, $hasFile, $myApiKey) = $this->_prepareRequest($method, $url, $params, $headers, $apiMode);
+
+        // for some reason, PHP users will sometimes include null bytes in their paths, which leads to cryptic server 400s.
+        // we'll be louder about this to help catch issues earlier.
+        if (false !== \strpos($absUrl, "\0") || false !== \strpos($absUrl, '%00')) {
+            throw new Exception\BadMethodCallException("URLs may not contain null bytes ('\\0'); double check any IDs you're including with the request.");
+        }
 
         $requestStartMs = Util\Util::currentTimeMillis();
 

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -726,4 +726,23 @@ final class ApiRequestorTest extends \Stripe\TestCase
         $result = $method->invoke(null, 'procopen, php_uname, exec', 'php_uname');
         static::assertTrue($result);
     }
+
+    public function testRaisesForNullBytesInResourceMethod()
+    {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+        $this->compatExpectExceptionMessageMatches('#null byte#');
+
+        Charge::retrieve("abc_123\0");
+    }
+
+    public function testRaisesForNullBytesInRawRequest()
+    {
+        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+        $this->compatExpectExceptionMessageMatches('#null byte#');
+
+        $client = new BaseStripeClient([
+            'api_key' => 'sk_test_client',
+        ]);
+        $client->rawRequest('get', "/v1/xyz\0");
+    }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are reports of cryptic 400 errors when PHP users include null bytes in API urls. We're not sure why this happens with PHP more often than other languages, but it seems to be the case. 

Because we can't customize the error on the server side, we raise a more proactive error in the SDK to help users self-debug their issues.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- throw error if there's a null byte in `$absUrl` right before making a request
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-1474](https://go/j/RUN_DEVSDK-1474)
