### PR TITLE
change error thrown for null byte issues

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -519,7 +519,7 @@ class ApiRequestor
         // for some reason, PHP users will sometimes include null bytes in their paths, which leads to cryptic server 400s.
         // we'll be louder about this to help catch issues earlier.
         if (false !== \strpos($absUrl, "\0") || false !== \strpos($absUrl, '%00')) {
-            throw new Exception\BadMethodCallException("URLs may not contain null bytes ('\\0'); double check any IDs you're including with the request.");
+            throw new Exception\InvalidRequestException("URLs may not contain null bytes ('\\0'); double check any IDs you're including with the request.");
         }
 
         $requestStartMs = Util\Util::currentTimeMillis();

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -729,7 +729,7 @@ final class ApiRequestorTest extends \Stripe\TestCase
 
     public function testRaisesForNullBytesInResourceMethod()
     {
-        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+        $this->expectException(\Stripe\Exception\InvalidRequestException::class);
         $this->compatExpectExceptionMessageMatches('#null byte#');
 
         Charge::retrieve("abc_123\0");
@@ -737,7 +737,7 @@ final class ApiRequestorTest extends \Stripe\TestCase
 
     public function testRaisesForNullBytesInRawRequest()
     {
-        $this->expectException(\Stripe\Exception\BadMethodCallException::class);
+        $this->expectException(\Stripe\Exception\InvalidRequestException::class);
         $this->compatExpectExceptionMessageMatches('#null byte#');
 
         $client = new BaseStripeClient([


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

A follow up to https://github.com/stripe/stripe-php/pull/1811 that changes the error type thrown. It now matches the error you get when sending a null byte to the server, so any user code that handles this specific error will keep working. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- change exception throw for null byte issues
- update test

### See Also
<!-- Include any links or additional information that help explain this change. -->
