### PR TITLE
configure max_nextwork_retries at the client level

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -133,7 +133,7 @@ class ApiRequestor
         $params = $params ?: [];
         $headers = $headers ?: [];
         list($rbody, $rcode, $rheaders, $myApiKey)
-            = $this->_requestRaw($method, $url, $params, $headers, $apiMode, $usage);
+            = $this->_requestRaw($method, $url, $params, $headers, $apiMode, $usage, $maxNetworkRetries);
         $json = $this->_interpretResponse($rbody, $rcode, $rheaders, $apiMode);
         $resp = new ApiResponse($rbody, $rcode, $rheaders, $json);
 
@@ -148,15 +148,16 @@ class ApiRequestor
      * @param null|array $headers
      * @param 'v1'|'v2' $apiMode
      * @param string[] $usage
+     * @param null|int $maxNetworkRetries
      *
      * @throws Exception\ApiErrorException
      */
-    public function requestStream($method, $url, $readBodyChunkCallable, $params = null, $headers = null, $apiMode = 'v1', $usage = [])
+    public function requestStream($method, $url, $readBodyChunkCallable, $params = null, $headers = null, $apiMode = 'v1', $usage = [], $maxNetworkRetries = null)
     {
         $params = $params ?: [];
         $headers = $headers ?: [];
         list($rbody, $rcode, $rheaders, $myApiKey)
-            = $this->_requestRawStreaming($method, $url, $params, $headers, $apiMode, $usage, $readBodyChunkCallable);
+            = $this->_requestRawStreaming($method, $url, $params, $headers, $apiMode, $usage, $readBodyChunkCallable, $maxNetworkRetries);
         if ($rcode >= 300) {
             $this->_interpretResponse($rbody, $rcode, $rheaders, $apiMode);
         }
@@ -508,13 +509,14 @@ class ApiRequestor
      * @param array $headers
      * @param 'v1'|'v2' $apiMode
      * @param string[] $usage
+     * @param null|int $maxNetworkRetries
      *
      * @return array
      *
      * @throws Exception\AuthenticationException
      * @throws Exception\ApiConnectionException
      */
-    private function _requestRaw($method, $url, $params, $headers, $apiMode, $usage)
+    private function _requestRaw($method, $url, $params, $headers, $apiMode, $usage, $maxNetworkRetries)
     {
         list($absUrl, $rawHeaders, $params, $hasFile, $myApiKey) = $this->_prepareRequest($method, $url, $params, $headers, $apiMode);
 
@@ -532,7 +534,8 @@ class ApiRequestor
             $rawHeaders,
             $params,
             $hasFile,
-            $apiMode
+            $apiMode,
+            $maxNetworkRetries
         );
 
         if (
@@ -558,13 +561,14 @@ class ApiRequestor
      * @param string[] $usage
      * @param callable $readBodyChunkCallable
      * @param 'v1'|'v2' $apiMode
+     * @param int $maxNetworkRetries
      *
      * @return array
      *
      * @throws Exception\AuthenticationException
      * @throws Exception\ApiConnectionException
      */
-    private function _requestRawStreaming($method, $url, $params, $headers, $apiMode, $usage, $readBodyChunkCallable)
+    private function _requestRawStreaming($method, $url, $params, $headers, $apiMode, $usage, $readBodyChunkCallable, $maxNetworkRetries)
     {
         list($absUrl, $rawHeaders, $params, $hasFile, $myApiKey) = $this->_prepareRequest($method, $url, $params, $headers, $apiMode);
 
@@ -576,7 +580,8 @@ class ApiRequestor
             $rawHeaders,
             $params,
             $hasFile,
-            $readBodyChunkCallable
+            $readBodyChunkCallable,
+            $maxNetworkRetries
         );
 
         if (

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -122,12 +122,13 @@ class ApiRequestor
      * @param null|array $headers
      * @param 'v1'|'v2' $apiMode
      * @param string[] $usage
+     * @param null|int $maxNetworkRetries
      *
      * @return array tuple containing (ApiReponse, API key)
      *
      * @throws Exception\ApiErrorException
      */
-    public function request($method, $url, $params = null, $headers = null, $apiMode = 'v1', $usage = [])
+    public function request($method, $url, $params = null, $headers = null, $apiMode = 'v1', $usage = [], $maxNetworkRetries = null)
     {
         $params = $params ?: [];
         $headers = $headers ?: [];

--- a/lib/HttpClient/ClientInterface.php
+++ b/lib/HttpClient/ClientInterface.php
@@ -12,6 +12,7 @@ interface ClientInterface
      * @param bool $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CURLFile)
      * @param 'v1'|'v2' $apiMode Specifies if this is a v1 or v2 request
+     * @param null|int $maxNetworkRetries
      *
      * @return array an array whose first element is raw request body, second
      *    element is HTTP status code and third array of HTTP headers
@@ -19,5 +20,5 @@ interface ClientInterface
      * @throws \Stripe\Exception\ApiConnectionException
      * @throws \Stripe\Exception\UnexpectedValueException
      */
-    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1');
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1', $maxNetworkRetries = null);
 }

--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -340,11 +340,12 @@ class CurlClient implements ClientInterface, StreamingClientInterface
      * @param array $params
      * @param bool $hasFile
      * @param 'v1'|'v2' $apiMode
+     * @param null|int $maxNetworkRetries
      */
-    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1')
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1', $maxNetworkRetries = null)
     {
         list($opts, $absUrl) = $this->constructRequest($method, $absUrl, $headers, $params, $hasFile, $apiMode);
-        list($rbody, $rcode, $rheaders) = $this->executeRequestWithRetries($opts, $absUrl);
+        list($rbody, $rcode, $rheaders) = $this->executeRequestWithRetries($opts, $absUrl, $maxNetworkRetries);
 
         return [$rbody, $rcode, $rheaders];
     }
@@ -426,10 +427,11 @@ class CurlClient implements ClientInterface, StreamingClientInterface
      * @param array $opts cURL options
      * @param string $absUrl
      * @param callable $readBodyChunk
+     * @param null|int $maxNetworkRetries
      *
      * @return array
      */
-    public function executeStreamingRequestWithRetries($opts, $absUrl, $readBodyChunk)
+    public function executeStreamingRequestWithRetries($opts, $absUrl, $readBodyChunk, $maxNetworkRetries = null)
     {
         /** @var bool */
         $shouldRetry = false;
@@ -452,7 +454,7 @@ class CurlClient implements ClientInterface, StreamingClientInterface
         $errno = null;
         $message = null;
 
-        $determineWriteCallback = function ($rheaders) use (&$readBodyChunk, &$shouldRetry, &$rbody, &$numRetries, &$rcode, &$lastRHeaders, &$errno) {
+        $determineWriteCallback = function ($rheaders) use (&$readBodyChunk, &$shouldRetry, &$rbody, &$numRetries, &$rcode, &$lastRHeaders, &$errno, &$maxNetworkRetries) {
             $lastRHeaders = $rheaders;
             $errno = \curl_errno($this->curlHandle);
 
@@ -471,7 +473,7 @@ class CurlClient implements ClientInterface, StreamingClientInterface
                 };
             }
 
-            $shouldRetry = $this->shouldRetry($errno, $rcode, $rheaders, $numRetries);
+            $shouldRetry = $this->shouldRetry($errno, $rcode, $rheaders, $numRetries, $maxNetworkRetries);
 
             // Discard the body from an unsuccessful request that should be retried.
             if ($shouldRetry) {
@@ -535,8 +537,9 @@ class CurlClient implements ClientInterface, StreamingClientInterface
     /**
      * @param array $opts cURL options
      * @param string $absUrl
+     * @param null|int $maxNetworkRetries
      */
-    public function executeRequestWithRetries($opts, $absUrl)
+    public function executeRequestWithRetries($opts, $absUrl, $maxNetworkRetries = null)
     {
         $numRetries = 0;
 
@@ -566,7 +569,7 @@ class CurlClient implements ClientInterface, StreamingClientInterface
                 $this->closeCurlHandle();
             }
 
-            $shouldRetry = $this->shouldRetry($errno, $rcode, $rheaders, $numRetries);
+            $shouldRetry = $this->shouldRetry($errno, $rcode, $rheaders, $numRetries, $maxNetworkRetries);
 
             if (\is_callable($this->getRequestStatusCallback())) {
                 \call_user_func_array(
@@ -645,12 +648,17 @@ class CurlClient implements ClientInterface, StreamingClientInterface
      * @param int $rcode
      * @param array|Util\CaseInsensitiveArray $rheaders
      * @param int $numRetries
+     * @param null|int $maxNetworkRetries
      *
      * @return bool
      */
-    private function shouldRetry($errno, $rcode, $rheaders, $numRetries)
+    private function shouldRetry($errno, $rcode, $rheaders, $numRetries, $maxNetworkRetries)
     {
-        if ($numRetries >= Stripe::getMaxNetworkRetries()) {
+        if (null === $maxNetworkRetries) {
+            $maxNetworkRetries = Stripe::getMaxNetworkRetries();
+        }
+
+        if ($numRetries >= $maxNetworkRetries) {
             return false;
         }
 

--- a/lib/HttpClient/StreamingClientInterface.php
+++ b/lib/HttpClient/StreamingClientInterface.php
@@ -12,6 +12,7 @@ interface StreamingClientInterface
      * @param bool $hasFile Whether or not $params references a file (via an @ prefix or
      *                         CURLFile)
      * @param callable $readBodyChunkCallable a function that will be called with chunks of bytes from the body if the request is successful
+     * @param null|int $maxNetworkRetries
      *
      * @return array an array whose first element is raw request body, second
      *    element is HTTP status code and third array of HTTP headers
@@ -19,5 +20,5 @@ interface StreamingClientInterface
      * @throws \Stripe\Exception\ApiConnectionException
      * @throws \Stripe\Exception\UnexpectedValueException
      */
-    public function requestStream($method, $absUrl, $headers, $params, $hasFile, $readBodyChunkCallable);
+    public function requestStream($method, $absUrl, $headers, $params, $hasFile, $readBodyChunkCallable, $maxNetworkRetries = null);
 }

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -230,7 +230,12 @@ class Stripe
     }
 
     /**
-     * @param int $maxNetworkRetries Maximum number of request retries
+     * > NOTE: this value is only read during client creation, so creating a client and _then_ calling this method won't affect your client's behavior.
+     *
+     * @param int $maxNetworkRetries Maximum number of request retries.
+     *
+     * @deprecated The `setMaxNetworkRetries` method is deprecated and will be removed in a
+     *     future major version of the library. Configure the number of max retries at the client level or a per-request level.
      */
     public static function setMaxNetworkRetries($maxNetworkRetries)
     {

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -33,6 +33,7 @@ class RequestOptions
      * @param null|string $key
      * @param array<string, string> $headers
      * @param null|string $base
+     * @param null|int $maxNetworkRetries
      */
     public function __construct($key = null, $headers = [], $base = null, $maxNetworkRetries = null)
     {

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -881,7 +881,7 @@ final class BaseStripeClientTest extends TestCase
     public function testClientThrowsForNullRetriesValue()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/max_network_retries.*int/');
+        $this->compatExpectExceptionMessageMatches('/max_network_retries.*int/');
 
         new BaseStripeClient(['max_network_retries' => null, 'stripe_api_key' => 'sk_test_123']);
     }

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -44,8 +44,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $this->curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     public function testCtorDoesNotThrowWhenNoParams()
@@ -568,8 +567,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -607,8 +605,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -641,8 +638,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -673,8 +669,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -859,5 +854,35 @@ final class BaseStripeClientTest extends TestCase
         $meterEventStream = $client->request('post', '/v2/billing/meter_event_stream', [], []);
         self::assertNotNull($meterEventStream);
         self::assertInstanceOf(StripeObject::class, $meterEventStream);
+    }
+
+    public function testRetriesIs0ByDefault()
+    {
+        $client = new BaseStripeClient('sk_test_123');
+        self::assertSame(0, $client->getMaxNetworkRetries());
+    }
+
+    public function testClientReadsGlobalRetriesIfNoneProvided()
+    {
+        Stripe::setMaxNetworkRetries(2);
+        $client = new BaseStripeClient('sk_test_123');
+
+        self::assertSame(2, $client->getMaxNetworkRetries());
+    }
+
+    public function testClientPrefersLocalConfig()
+    {
+        Stripe::setMaxNetworkRetries(2);
+        $client = new BaseStripeClient(['max_network_retries' => 3, 'api_key' => 'sk_test_123']);
+
+        self::assertSame(3, $client->getMaxNetworkRetries());
+    }
+
+    public function testClientThrowsForNullRetriesValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/max_network_retries.*int/');
+
+        new BaseStripeClient(['max_network_retries' => null, 'stripe_api_key' => 'sk_test_123']);
     }
 }

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -186,7 +186,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0, null));
     }
 
     public function testShouldRetryOnConnectionFailure()
@@ -195,7 +195,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0, null));
     }
 
     public function testShouldRetryOnConflict()
@@ -204,7 +204,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0, null));
     }
 
     public function testShouldNotRetryOn429()
@@ -213,7 +213,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0, null));
     }
 
     public function testShouldRetryOn500()
@@ -222,7 +222,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, null));
     }
 
     public function testShouldRetryOn503()
@@ -231,7 +231,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0, null));
     }
 
     public function testShouldRetryOnStripeShouldRetryTrue()
@@ -240,8 +240,8 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0));
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0, null));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0, null));
     }
 
     public function testShouldNotRetryOnStripeShouldRetryFalse()
@@ -250,8 +250,8 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0));
-        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, null));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0, null));
     }
 
     public function testShouldNotRetryAtMaximumCount()
@@ -260,7 +260,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries()));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries(), null));
     }
 
     public function testShouldNotRetryOnCertValidationError()
@@ -269,7 +269,7 @@ final class CurlClientTest extends \Stripe\TestCase
 
         $curlClient = new CurlClient();
 
-        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0, null));
     }
 
     public function testSleepTimeShouldGrowExponentially()

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -182,93 +182,125 @@ final class CurlClientTest extends \Stripe\TestCase
 
     public function testShouldRetryOnTimeout()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_OPERATION_TIMEOUTED, 0, [], 0, null));
     }
 
     public function testShouldRetryOnConnectionFailure()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, \CURLE_COULDNT_CONNECT, 0, [], 0, null));
     }
 
     public function testShouldRetryOnConflict()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 409, [], 0, null));
     }
 
     public function testShouldNotRetryOn429()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 429, [], 0, null));
     }
 
     public function testShouldRetryOn500()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, null));
     }
 
     public function testShouldRetryOn503()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 503, [], 0, null));
     }
 
     public function testShouldRetryOnStripeShouldRetryTrue()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0, 2));
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 400, [], 0, null));
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 400, ['stripe-should-retry' => 'true'], 0, null));
     }
 
     public function testShouldNotRetryOnStripeShouldRetryFalse()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, 2));
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0, 2));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertTrue($this->shouldRetryMethod->invoke($curlClient, 0, 500, [], 0, null));
         self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 500, ['stripe-should-retry' => 'false'], 0, null));
     }
 
     public function testShouldNotRetryAtMaximumCount()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries(), null));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertFalse($this->shouldRetryMethod->invoke($curlClient, 0, 0, [], \Stripe\Stripe::getMaxNetworkRetries(), null));
     }
 
     public function testShouldNotRetryOnCertValidationError()
     {
-        \Stripe\Stripe::setMaxNetworkRetries(2);
-
         $curlClient = new CurlClient();
 
+        // call works when `maxNetworkRetries` is provided directly
+        self::assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0, null));
+
+        // and when the arg is `null` and the value is read globally instead
+        \Stripe\Stripe::setMaxNetworkRetries(2);
         self::assertFalse($this->shouldRetryMethod->invoke($curlClient, \CURLE_SSL_PEER_CERTIFICATE, -1, [], 0, null));
     }
 

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -33,8 +33,7 @@ final class StripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturnOnConsecutiveCalls([

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -63,6 +63,7 @@ trait TestHelper
         Stripe::setApiKey($this->origApiKey);
         Stripe::setClientId($this->origClientId);
         Stripe::setAccountId($this->origAccountId);
+        Stripe::setMaxNetworkRetries(0);
     }
 
     /**


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Most request configuration should happen at the client level, not the global level. The global value is still used as an initial default, but it'll be removed in the future.

> note: I couldn't get end-to-end tests for this working because of problems with getting the mocks right. I've done some local testing and feel good about it working, but I'd feel better with a unit test. We can follow up with that or pair on it, if you'd like.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `max_nextwork_retries` to `RequestOptions`, making it available to every method
- parse those options out of `$config` during RequestOptions parsing
- add arguments to pass that value down through all of the request-related methods
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-1446](https://go/j/DEVSDK-1446)

## Changelog

- Allow setting `maxNetworkRetries` at both the `StripeClient` level and per-request via the `max_network_retries` config argument and `maxNetworkRetries` argument to `RequestOptions` respectively.
    - ⚠️ (potentially breaking) a client's configuration for `maxNetworkRetries` is set during client initialization. Subsequent calls to `Stripe::setMaxNetworkRetries()` after client creation **won't** affect that client.