### PR TITLE
Remove tests for endpoints that were removed

### DIFF
--- a/tests/Stripe/InvoiceTest.php
+++ b/tests/Stripe/InvoiceTest.php
@@ -118,16 +118,6 @@ final class InvoiceTest extends TestCase
         self::assertSame($resource, $invoice);
     }
 
-    public function testCanRetrieveUpcoming()
-    {
-        $this->expectsRequest(
-            'get',
-            '/v1/invoices/upcoming'
-        );
-        $resource = Invoice::upcoming(['customer' => 'cus_123']);
-        self::assertInstanceOf(Invoice::class, $resource);
-    }
-
     public function testCanSendInvoice()
     {
         $invoice = Invoice::retrieve(self::TEST_RESOURCE_ID);

--- a/tests/Stripe/Service/InvoiceServiceTest.php
+++ b/tests/Stripe/Service/InvoiceServiceTest.php
@@ -121,27 +121,6 @@ final class InvoiceServiceTest extends \Stripe\TestCase
         self::assertInstanceOf(\Stripe\Invoice::class, $resource);
     }
 
-    public function testUpcoming()
-    {
-        $this->expectsRequest(
-            'get',
-            '/v1/invoices/upcoming'
-        );
-        $resource = $this->service->upcoming(['customer' => 'cus_123']);
-        self::assertInstanceOf(\Stripe\Invoice::class, $resource);
-    }
-
-    public function testUpcomingLines()
-    {
-        $this->expectsRequest(
-            'get',
-            '/v1/invoices/upcoming/lines'
-        );
-        $resources = $this->service->upcomingLines();
-        self::compatAssertIsArray($resources->data);
-        self::assertInstanceOf(\Stripe\InvoiceLineItem::class, $resources->data[0]);
-    }
-
     public function testUpdate()
     {
         $this->expectsRequest(

--- a/tests/Stripe/Service/SubscriptionItemServiceTest.php
+++ b/tests/Stripe/Service/SubscriptionItemServiceTest.php
@@ -89,28 +89,4 @@ final class SubscriptionItemServiceTest extends \Stripe\TestCase
         self::assertInstanceOf(\Stripe\SubscriptionItem::class, $resource);
         self::assertTrue($resource->isDeleted());
     }
-
-    public function testCreateUsageRecord()
-    {
-        $this->expectsRequest(
-            'post',
-            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_records'
-        );
-        $resource = $this->service->createUsageRecord(self::TEST_RESOURCE_ID, [
-            'quantity' => 100,
-            'timestamp' => 12341234,
-            'action' => 'set',
-        ]);
-    }
-
-    public function testListUsageRecordSummaries()
-    {
-        $this->expectsRequest(
-            'get',
-            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_record_summaries'
-        );
-        $resources = $this->service->allUsageRecordSummaries(self::TEST_RESOURCE_ID);
-        self::compatAssertIsArray($resources->data);
-        self::assertInstanceOf(\Stripe\UsageRecordSummary::class, $resources->data[0]);
-    }
 }

--- a/tests/Stripe/SubscriptionItemTest.php
+++ b/tests/Stripe/SubscriptionItemTest.php
@@ -86,40 +86,4 @@ final class SubscriptionItemTest extends TestCase
         $resource->delete();
         self::assertInstanceOf(SubscriptionItem::class, $resource);
     }
-
-    public function testCanCreateUsageRecord()
-    {
-        $this->expectsRequest(
-            'post',
-            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_records'
-        );
-        $resource = SubscriptionItem::createUsageRecord(self::TEST_RESOURCE_ID, [
-            'quantity' => 100,
-            'timestamp' => 12341234,
-            'action' => 'set',
-        ]);
-    }
-
-    public function testCanListUsageRecordSummariesDeprecated()
-    {
-        $resource = SubscriptionItem::retrieve(self::TEST_RESOURCE_ID);
-        $this->expectsRequest(
-            'get',
-            '/v1/subscription_items/' . $resource->id . '/usage_record_summaries'
-        );
-        $resources = $resource->allUsageRecordSummaries(self::TEST_RESOURCE_ID);
-        self::compatAssertIsArray($resources->data);
-        self::assertInstanceOf(UsageRecordSummary::class, $resources->data[0]);
-    }
-
-    public function testCanListUsageRecordSummaries()
-    {
-        $this->expectsRequest(
-            'get',
-            '/v1/subscription_items/' . self::TEST_RESOURCE_ID . '/usage_record_summaries'
-        );
-        $resources = SubscriptionItem::allUsageRecordSummaries(self::TEST_RESOURCE_ID);
-        self::compatAssertIsArray($resources->data);
-        self::assertInstanceOf(UsageRecordSummary::class, $resources->data[0]);
-    }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a lot of endpoints being (re)moved in the upcoming GA release. This remove manually maintained tests that reference these endpoints.



### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
Removes tests for:

Invoice.upcoming
UsageRecord
UsageRecordSummary

### See Also
<!-- Include any links or additional information that help explain this change. -->
