### PR TITLE
Added requestCollection and requestSearchResult to StripeClientInterface

### DIFF
--- a/lib/Service/AbstractService.php
+++ b/lib/Service/AbstractService.php
@@ -77,22 +77,16 @@ abstract class AbstractService
 
     protected function requestStream($method, $path, $readBodyChunkCallable, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
         return $this->getStreamingClient()->requestStream($method, $path, $readBodyChunkCallable, self::formatParams($params), $opts);
     }
 
     protected function requestCollection($method, $path, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
         return $this->getClient()->requestCollection($method, $path, self::formatParams($params), $opts);
     }
 
     protected function requestSearchResult($method, $path, $params, $opts)
     {
-        // TODO (MAJOR): Add this method to StripeClientInterface
-        // @phpstan-ignore-next-line
         return $this->getClient()->requestSearchResult($method, $path, self::formatParams($params), $opts);
     }
 

--- a/lib/StripeClientInterface.php
+++ b/lib/StripeClientInterface.php
@@ -18,4 +18,28 @@ interface StripeClientInterface extends BaseStripeClientInterface
      * @return StripeObject the object returned by Stripe's API
      */
     public function request($method, $path, $params, $opts);
+
+    /**
+     * Sends a request to Stripe's API and expects to return a SearchResult.
+     *
+     * @param 'get' $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return SearchResult of ApiResources
+     */
+    public function requestSearchResult($method, $path, $params, $opts);
+
+    /**
+     * Sends a request to Stripe's API and expects to return a Collection|V2\Collection.
+     *
+     * @param 'get' $method the HTTP method
+     * @param string $path the path of the request
+     * @param array $params the parameters of the request
+     * @param array|Util\RequestOptions $opts the special modifiers of the request
+     *
+     * @return Collection|V2\Collection of ApiResources
+     */
+    public function requestCollection($method, $path, $params, $opts);
 }


### PR DESCRIPTION
### Why?
We are adding new helper methods to `StripeClientInterface` to improve the return types in SDKs. 
Stripe's implementation in [BaseStripeClient](https://github.com/stripe/stripe-php/blob/f65c497d0bc175aaa04538602fd49645f44f9384/lib/BaseStripeClient.php#L259-L315).

### See Also
https://jira.corp.stripe.com/browse/DEVSDK-2458#L80-L94

## Changelog
- ⚠️ Added `requestSearchResult`, `requestCollection` to `StripeClientInterface`. 