### PR TITLE
remove global `setMaxNetworkRetries()` deprecation

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -233,9 +233,6 @@ class Stripe
      * > NOTE: this value is only read during client creation, so creating a client and _then_ calling this method won't affect your client's behavior.
      *
      * @param int $maxNetworkRetries Maximum number of request retries.
-     *
-     * @deprecated The `setMaxNetworkRetries` method is deprecated and will be removed in a
-     *     future major version of the library. Configure the number of max retries at the client level or a per-request level.
      */
     public static function setMaxNetworkRetries($maxNetworkRetries)
     {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

I had deprecated the global setter in https://github.com/stripe/stripe-php/pull/1826, but it's actually still the recommended path for users on the resource-based pattern. So we shouldn't bother them about it.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- remove deprecation warning.

### See Also
<!-- Include any links or additional information that help explain this change. -->
