### PR TITLE
Fail Code formatter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run PHP-CS-Fixer
-        run: just format
+        run: just format-check
 
   phpstan:
     name: PHPStan

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -18,7 +18,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     /** @var string default base URL for Stripe's Meter Events API */
     const DEFAULT_METER_EVENTS_BASE = 'https://meter-events.stripe.com';
 
-    /** @var array<string, null|string|int> */
+    /** @var array<string, null|int|string> */
     const DEFAULT_CONFIG = [
         'api_key' => null,
         'app_info' => null,
@@ -83,7 +83,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
             throw new Exception\InvalidArgumentException('$config must be a string or an array');
         }
 
-        if (!\array_key_exists("max_network_retries", $config)) {
+        if (!\array_key_exists('max_network_retries', $config)) {
             // if no value is passed, inherit the global value at the time of client creation
             $config['max_network_retries'] = Stripe::getMaxNetworkRetries();
         }
@@ -97,7 +97,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
             'stripe_account' => $config['stripe_account'],
             'stripe_context' => $config['stripe_context'],
             'stripe_version' => $config['stripe_version'],
-            'max_network_retries' => $config['max_network_retries']
+            'max_network_retries' => $config['max_network_retries'],
         ]);
     }
 
@@ -164,7 +164,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     /**
      * Gets the configured number of retries.
      *
-     * @return int the number of times this client will retry failed requests.
+     * @return int the number of times this client will retry failed requests
      */
     public function getMaxNetworkRetries()
     {

--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -232,7 +232,7 @@ class Stripe
     /**
      * > NOTE: this value is only read during client creation, so creating a client and _then_ calling this method won't affect your client's behavior.
      *
-     * @param int $maxNetworkRetries Maximum number of request retries.
+     * @param int $maxNetworkRetries maximum number of request retries
      */
     public static function setMaxNetworkRetries($maxNetworkRetries)
     {

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -44,7 +44,8 @@ final class BaseStripeClientTest extends TestCase
     {
         $this->curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
     }
 
     public function testCtorDoesNotThrowWhenNoParams()
@@ -567,7 +568,8 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -605,7 +607,8 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -638,7 +641,8 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -669,7 +673,8 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])

--- a/tests/Stripe/StripeClientTest.php
+++ b/tests/Stripe/StripeClientTest.php
@@ -33,7 +33,8 @@ final class StripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock();
+            ->getMock()
+        ;
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturnOnConsecutiveCalls([


### PR DESCRIPTION
### Why?
CI PHP Code Formatter was always green and wasn't failing even for incorrect formatting. This PR fixes that and I ran the formatter on the unformatted files. 

### What?
Changed formatting command from `just format` to `just format-check`

### See Also
<!-- Include any links or additional information that help explain this change. -->
