### PR TITLE
Handle external_account field

### DIFF
--- a/lib/Service/ExternalAccountService.php
+++ b/lib/Service/ExternalAccountService.php
@@ -29,7 +29,7 @@ class ExternalAccountService extends AbstractService
     /**
      * Create an external account for a given connected account.
      *
-     * @param null|array{default_for_currency?: bool, expand?: string[], external_account: string, metadata?: \Stripe\StripeObject} $params
+     * @param null|array{default_for_currency?: bool, expand?: string[], external_account: array|string, metadata?: \Stripe\StripeObject} $params
      * @param null|RequestOptionsArray|\Stripe\Util\RequestOptions $opts
      *
      * @return \Stripe\BankAccount|\Stripe\Card


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `external_account` should be a union type, not a `string`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Changes `external_account` field in `externalAccounts.create` from a `string` to a union type.


## Changelog
- Changes `external_account` field in `externalAccounts.create` from a `string` to a union type.