### PR TITLE
Remove link for stale youtube video playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ You can continue to use the legacy integration patterns used prior to version [7
 
 See the [PHP API docs](https://stripe.com/docs/api/?lang=php#intro).
 
-See [video demonstrations][youtube-playlist] covering how to use the library.
-
 ## Legacy Version Support
 
 ### PHP 5.4 & 5.5


### PR DESCRIPTION
### Why?
The link is broken and there are no plans to revive the playlist

### What?
Remove link for stale youtube video playlist


