### PR TITLE
Faster parallel runner for PHP formatter

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,8 +6,12 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true);
-// TODO Enable the parallel runner to speed up formatter when we upgrade to php-cs-fixer v4+
-// $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+if(PHP_OS == "Darwin") {
+    // TODO Enable the parallel runner for CI to speed up formatter when we upgrade to php-cs-fixer v4+
+    // PHP CS Fixer's parallel runner currently does not support Linux and is in beta.
+    // Only enabling it locally for faster formatting.
+    $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+}
 $config->setRules([
     // Rulesets
     '@PSR2' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,6 +6,8 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true);
+// TODO Enable the parallel runner to speed up formatter when we upgrade to php-cs-fixer v4+
+// $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 $config->setRules([
     // Rulesets
     '@PSR2' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,6 +10,7 @@ if(PHP_OS == "Darwin") {
     // TODO Enable the parallel runner for CI to speed up formatter when we upgrade to php-cs-fixer v4+
     // PHP CS Fixer's parallel runner currently does not support Linux and is in beta.
     // Only enabling it locally for faster formatting.
+    // See: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/b62538df5cf84c9f1c990e67c04819fbf4c8f285/tests/Runner/RunnerTest.php#L254
     $config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 }
 $config->setRules([


### PR DESCRIPTION
### Why?
Currently PHP CS Fixer takes a long time to run(~50s). With a parallel runner(currently in beta), it only takes ~7s.

### What?
Added ability for PHP CS Fixer to run parallel on multiple cores. This feature is limited to our local machines due to [incompatibility](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/b62538df5cf84c9f1c990e67c04819fbf4c8f285/tests/Runner/RunnerTest.php#L254) of the parallel runner with linux machines.

### See Also

