### PR TITLE
Include new PHP 8.3 and 8.4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
     name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }})
 
     steps:


### PR DESCRIPTION
### Why?
In order to keep supporting new versions of PHP we need to test against them.

### What?
Added PHP version `8.3` and `8.4` in CI workflow. 

### See Also

