### PR TITLE
Ensure compatibility with POST on older versions of libcurl

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -267,6 +267,11 @@ class CurlClient implements ClientInterface, StreamingClientInterface
         if ($body) {
             $opts[\CURLOPT_POSTFIELDS] = $body;
         }
+        // inspired by https://github.com/stripe/stripe-php/issues/1817#issuecomment-2670463182
+        else if (isset($opts[\CURLOPT_POST]) && $opts[\CURLOPT_POST] === 1) {
+            $opts[\CURLOPT_POSTFIELDS] = '';
+        }
+
         // this is a little verbose, but makes v1 vs v2 behavior really clear
         if (!$this->hasHeader($headers, 'Idempotency-Key')) {
             // all v2 requests should have an IK

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -44,8 +44,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $this->curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
     }
 
     public function testCtorDoesNotThrowWhenNoParams()
@@ -483,7 +482,7 @@ final class BaseStripeClientTest extends TestCase
             ->method('executeRequestWithRetries')
             ->with(self::callback(function ($opts) {
                 $this->assertSame(1, $opts[\CURLOPT_POST]);
-                $this->assertArrayNotHasKey(\CURLOPT_POSTFIELDS, $opts);
+                $this->assertSame('', $opts[\CURLOPT_POSTFIELDS]);
                 $this->assertContains('Content-Type: application/json', $opts[\CURLOPT_HTTPHEADER]);
 
                 return true;
@@ -568,8 +567,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -607,8 +605,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -641,8 +638,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])
@@ -673,8 +669,7 @@ final class BaseStripeClientTest extends TestCase
     {
         $curlClientStub = $this->getMockBuilder(HttpClient\CurlClient::class)
             ->setMethods(['executeRequestWithRetries'])
-            ->getMock()
-        ;
+            ->getMock();
 
         $curlClientStub->method('executeRequestWithRetries')
             ->willReturn(['{"object": "charge"}', 200, []])

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -548,8 +548,9 @@ EOF;
 http_response_code(200);
 header("Content-Length: 6");
 echo "12345";
-ob_flush();
-flush();
+// explicitly do not flush or ob_flush to test the behavior of the client
+// ob_flush();
+// flush();
 exit();
 EOF;
 


### PR DESCRIPTION
### Why?
Related to https://github.com/stripe/stripe-php/issues/1817.  Several users reported a similar issue where running stripe-php released on or after 9/30 using PHP with curl on or around version 7.29 result in 400 errors.

#### Why did this work previously to the 9/30 release?
The libcurl spec states that:
> If CURLOPT_POSTFIELDS is explicitly set to NULL then libcurl gets the POST data from the read callback. To send a zero-length (empty) POST, set CURLOPT_POSTFIELDS to an empty string, or set CURLOPT_POST to 1 and CURLOPT_POSTFIELDSIZE to 0.

Prior to the acacia major release, CurlClient.php would set CURLOPT_POSTFIELDS when the params hash is empty.  This changed in acacia and when params are empty, CURLOPT_POSTFIELDS not set at all.  [Older versions of libcurl have a bug](https://curl.se/mail/lib-2014-01/0103.html) where not setting CURLOPT_POSTFIELDS will result curl sending a `Content-Length: -1` which is likely the cause of the 400 errors.




### What?
- add code to `constructCurlOptions` explicitly set \CURLOPT_POSTFIELDS to empty string if body is null
- updated tests

This also changes a test in CurlClientTest.php which appears to be flakey; it is testing that we raise an exception when we encounter a disconnect after calling `executeStreamingRequestWithRetries`, but as written the request completes successfully before the server can disconnect the client.

### See Also
https://go/j/RUN_DEVSDK-1629

