### PR TITLE
Add getter for Stripe Account on BaseStripeClient

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -124,7 +124,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     /**
      * Gets the Stripe account ID used by the client to send requests.
      *
-     * @return null|string the Stripe account used by the client to send requests
+     * @return null|string the Stripe account ID used by the client to send requests
      */
     public function getStripeAccount()
     {


### PR DESCRIPTION
### Why?
In an application that deals with different Stripe accounts, a mapping is required to keep track of the customer ids to one specific application user.

### What?
The method `BaseStripeClient::getStripeAccount()` is introduced that allows to obtain the configured `stripe_account` from the used client instance again.

Fixes: #1893

## Changelog
- Add `getStripeAccount` method on `BaseStripeClient` to retrieve [Stripe Account ID](https://docs.stripe.com/connect/authentication?lang=php) from a `StripeClient` instance.