### PR TITLE
Use the right API version 2025-08-27.preview

### DIFF
--- a/lib/Util/ApiVersion.php
+++ b/lib/Util/ApiVersion.php
@@ -6,5 +6,5 @@ namespace Stripe\Util;
 
 class ApiVersion
 {
-    const CURRENT = '2025-08-04.private';
+    const CURRENT = '2025-08-27.preview';
 }


### PR DESCRIPTION
### Why?
The Open API spec used to generate the SDK was using an older API version. The spec with the fix for this cannot be used as it also contains changes meant for the next release. Therefore, manually making the API version change here

### What?
Update API version 2025-08-04.private to 2025-08-27.preview 


