### PR TITLE
hardcode RateLimitException

### DIFF
--- a/lib/Exception/RateLimitException.php
+++ b/lib/Exception/RateLimitException.php
@@ -1,7 +1,10 @@
 <?php
 
-// File generated from our OpenAPI spec
-
 namespace Stripe\Exception;
 
-class RateLimitException extends ApiErrorException {}
+/**
+ * RateLimitException is thrown in cases where an account is putting too much
+ * load on Stripe's API servers (usually by performing too many requests).
+ * Please back off on request rate.
+ */
+class RateLimitException extends InvalidRequestException {}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-php-next/pull/309 we removed the hardcoded `RateLimitException` because it was being supplied by the v2 spec now. That works fine as long as it's always present (since it's used for v1 endpoints too). But, we've since hidden the API that supplies that RateLimit error (`/v2/reporting/reporting_runs`) from the SDK, so tests are erroring because they can't import that error.

To fix, we'll stick with the hardocded error class and prevent it from being generated (when relevant).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- move `RateLimitException` back to a hardcoded file (normally you shouldn't edit the codegen stuff, but it needs to be present and linting complains if it's redefined. It'll stop being generated when the v2 openapi pr lands).

### See Also
<!-- Include any links or additional information that help explain this change. -->
