### PR TITLE
Added StripeContext, StripeAccount and StripeVersion to BaseStripeClientInterface

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -132,6 +132,24 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     }
 
     /**
+     * Gets the Stripe Context ID used by the client to send requests.
+     *
+     * @return null|string the Stripe Context ID used by the client to send requests
+     */
+    public function getStripeContext() {
+        return $this->config['stripe_context'];
+    }
+
+    /**
+     * Gets the Stripe Version used by the client to send requests.
+     *
+     * @return null|string the Stripe Context ID used by the client to send requests
+     */
+    public function getStripeVersion() {
+        return $this->config['stripe_version'];
+    }
+
+    /**
      * Gets the base URL for Stripe's API.
      *
      * @return string the base URL for Stripe's API

--- a/lib/BaseStripeClientInterface.php
+++ b/lib/BaseStripeClientInterface.php
@@ -22,6 +22,27 @@ interface BaseStripeClientInterface
     public function getClientId();
 
     /**
+     * Gets the Stripe account ID used by the client to send requests.
+     *
+     * @return null|string the Stripe account ID used by the client to send requests
+     */
+    public function getStripeAccount();
+
+    /**
+     * Gets the Stripe Context ID used by the client to send requests.
+     *
+     * @return null|string the Stripe Context ID used by the client to send requests
+     */
+    public function getStripeContext();
+
+    /**
+     * Gets the Stripe Version used by the client to send requests.
+     *
+     * @return null|string the Stripe Context ID used by the client to send requests
+     */
+    public function getStripeVersion();
+
+    /**
      * Gets the base URL for Stripe's API.
      *
      * @return string the base URL for Stripe's API


### PR DESCRIPTION
### Why?
As followup to https://github.com/stripe/stripe-php/pull/1894. This PR adds 3 new getter methods to `BaseStripeClientInterface` to allow StripeClient to get StripeContext, StripeVersion and StripeAccount set on the client. 

### See Also
[DEVSDK-2718](https://jira.corp.stripe.com/browse/DEVSDK-2718)

## Changelog
- ⚠️ Add getter methods `getStripeContext`, `getStripeVersion` and `getStripeAccount` to `BaseStripeClientInterface`. Users with custom StripeClient that implement `StripeClientInterface`, `StripeStreamingClientInterface` or `BaseStripeClientInterface` will have to add implementations for these methods. 