### PR TITLE
Add `StripeContext` object

### DIFF
--- a/lib/StripeContext.php
+++ b/lib/StripeContext.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Class StripeContext
+ *
+ * Represents a path-like context for Stripe API operations, allowing for
+ * hierarchical organization of API calls. The context is externally immutable,
+ * meaning all operations return new instances rather than modifying existing ones.
+ */
+class StripeContext
+{
+    /** @var array<string> */
+    private $segments;
+
+    /**
+     * @param null|array<string> $segments
+     */
+    public function __construct($segments = null)
+    {
+        $this->segments = $segments ? \array_values($segments) : [];
+    }
+
+    /**
+     * Parses a context string into a StripeContext instance.
+     *
+     * @param null|string $contextString
+     * @return StripeContext
+     */
+    public static function parse($contextString)
+    {
+        if (!$contextString) {
+            return new self([]);
+        }
+
+        return new self(\explode('/', $contextString));
+    }
+
+    /**
+     * Returns the parent context by removing the last segment.
+     * Throws an exception if the context is empty.
+     *
+     * @return StripeContext
+     * @throws Exception\InvalidArgumentException
+     */
+    public function parent()
+    {
+        if (empty($this->segments)) {
+            throw new Exception\InvalidArgumentException('Cannot get parent of empty context');
+        }
+
+        return new self(\array_slice($this->segments, 0, -1));
+    }
+
+    /**
+     * Returns a new context with the given segment appended.
+     *
+     * @param string $segment
+     * @return StripeContext
+     */
+    public function child($segment)
+    {
+        $newSegments = $this->segments;
+        $newSegments[] = $segment;
+
+        return new self($newSegments);
+    }
+
+    /**
+     * Returns the string representation of the context.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return \implode('/', $this->segments);
+    }
+}

--- a/lib/ThinEvent.php
+++ b/lib/ThinEvent.php
@@ -10,7 +10,7 @@ namespace Stripe;
  * @property string             $id       Unique identifier for the event.
  * @property string             $type     The type of the event.
  * @property string             $created  Time at which the object was created.
- * @property null|string        $context  Authentication context needed to fetch the event or related object.
+ * @property null|StripeContext $context  Authentication context needed to fetch the event or related object.
  * @property null|RelatedObject $related_object Object containing the reference to API resource relevant to the event.
  * @property null|Reason $reason Reason for the event.
  * @property bool $livemode Livemode indicates if the event is from a production(true) or test(false) account.

--- a/lib/Util/RequestOptions.php
+++ b/lib/Util/RequestOptions.php
@@ -3,9 +3,9 @@
 namespace Stripe\Util;
 
 /**
- * @phpstan-type RequestOptionsArray array{api_key?: string, idempotency_key?: string, stripe_account?: string, stripe_context?: string, stripe_version?: string, api_base?: string, max_network_retries?: int }
+ * @phpstan-type RequestOptionsArray array{api_key?: string, idempotency_key?: string, stripe_account?: string, stripe_context?: string|\Stripe\StripeContext, stripe_version?: string, api_base?: string, max_network_retries?: int }
  *
- * @psalm-type RequestOptionsArray = array{api_key?: string, idempotency_key?: string, stripe_account?: string, stripe_context?: string, stripe_version?: string, api_base?: string, max_network_retries?: int }
+ * @psalm-type RequestOptionsArray = array{api_key?: string, idempotency_key?: string, stripe_account?: string, stripe_context?: string|\Stripe\StripeContext, stripe_version?: string, api_base?: string, max_network_retries?: int }
  */
 class RequestOptions
 {
@@ -147,7 +147,14 @@ class RequestOptions
             }
             if (\array_key_exists('stripe_context', $options)) {
                 if (null !== $options['stripe_context']) {
-                    $headers['Stripe-Context'] = $options['stripe_context'];
+                    if ($options['stripe_context'] instanceof \Stripe\StripeContext) {
+                        $contextValue = (string) $options['stripe_context'];
+                        if ($contextValue !== '') {
+                            $headers['Stripe-Context'] = $contextValue;
+                        }
+                    } elseif (\is_string($options['stripe_context']) && '' !== $options['stripe_context']) {
+                        $headers['Stripe-Context'] = $options['stripe_context'];
+                    }
                 }
                 unset($options['stripe_context']);
             }

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -111,6 +111,9 @@ abstract class Util
                     $reason->id = $json['reason']['id'];
                     $reason->idempotency_key = $json['reason']['idempotency_key'];
                     $property->setValue($instance, $reason);
+                } elseif ('context' === $property->getName() && null !== $json[$property->getName()]) {
+                    $context = \Stripe\StripeContext::parse($json[$property->getName()]);
+                    $property->setValue($instance, $context);
                 } else {
                     $property->setAccessible(true);
                     $property->setValue($instance, $json[$property->getName()]);

--- a/tests/Stripe/StripeContextTest.php
+++ b/tests/Stripe/StripeContextTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ * @covers \Stripe\StripeContext
+ */
+final class StripeContextTest extends \Stripe\TestCase
+{
+    public function testEmptyContext()
+    {
+        $context = new StripeContext();
+        static::assertSame('', (string) $context);
+    }
+
+    public function testContextWithSegments()
+    {
+        $context = new StripeContext(['a', 'b', 'c']);
+        static::assertSame('a/b/c', (string) $context);
+    }
+
+    public function testParseEmptyString()
+    {
+        $context = StripeContext::parse('');
+        static::assertSame('', (string) $context);
+    }
+
+    public function testParseNull()
+    {
+        $context = StripeContext::parse(null);
+        static::assertSame('', (string) $context);
+    }
+
+    public function testParseSingleSegment()
+    {
+        $context = StripeContext::parse('a');
+        static::assertSame('a', (string) $context);
+    }
+
+    public function testParseMultipleSegments()
+    {
+        $context = StripeContext::parse('a/b/c');
+        static::assertSame('a/b/c', (string) $context);
+    }
+
+    public function testParentReturnsNewInstance()
+    {
+        $context = StripeContext::parse('a/b/c');
+        $parent = $context->parent();
+
+        // Original unchanged
+        static::assertSame('a/b/c', (string) $context);
+        // New instance with removed segment
+        static::assertSame('a/b', (string) $parent);
+    }
+
+    public function testParentOfSingleSegment()
+    {
+        $context = StripeContext::parse('a');
+        $parent = $context->parent();
+        static::assertSame('', (string) $parent);
+    }
+
+    public function testParentOfEmptyContextThrowsException()
+    {
+        $context = new StripeContext();
+
+        $this->expectException(\Stripe\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot get parent of empty context');
+
+        $context->parent();
+    }
+
+    public function testChildReturnsNewInstance()
+    {
+        $context = StripeContext::parse('a/b');
+        $child = $context->child('c');
+
+        // Original unchanged
+        static::assertSame('a/b', (string) $context);
+        // New instance with added segment
+        static::assertSame('a/b/c', (string) $child);
+    }
+
+    public function testChildOnEmptyContext()
+    {
+        $context = new StripeContext();
+        $child = $context->child('a');
+        static::assertSame('a', (string) $child);
+    }
+
+    public function testMethodChaining()
+    {
+        $context = StripeContext::parse('a');
+        $result = $context->child('b')->child('c')->parent();
+        static::assertSame('a/b', (string) $result);
+    }
+
+    public function testInitWithNullSegments()
+    {
+        $context = new StripeContext(null);
+        static::assertSame('', (string) $context);
+    }
+
+    public function testInitWithEmptyArray()
+    {
+        $context = new StripeContext([]);
+        static::assertSame('', (string) $context);
+    }
+
+    public function testRequestOptionsWithStripeContext()
+    {
+        $context = StripeContext::parse('org_123/proj_456');
+
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => $context,
+            'api_key' => 'sk_test_123'
+        ]);
+
+        static::assertSame('org_123/proj_456', $options->headers['Stripe-Context']);
+    }
+
+    public function testRequestOptionsWithStripeContextString()
+    {
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => 'org_123/proj_456',
+            'api_key' => 'sk_test_123'
+        ]);
+
+        static::assertSame('org_123/proj_456', $options->headers['Stripe-Context']);
+    }
+
+    public function testRequestOptionsWithEmptyStripeContext()
+    {
+        $context = new StripeContext();
+
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => $context,
+            'api_key' => 'sk_test_123'
+        ]);
+
+        static::assertArrayNotHasKey('Stripe-Context', $options->headers);
+    }
+
+    public function testRequestOptionsWithEmptyStripeContextString()
+    {
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => '',
+            'api_key' => 'sk_test_123'
+        ]);
+
+        static::assertArrayNotHasKey('Stripe-Context', $options->headers);
+    }
+
+    public function testRequestOptionsWithNullStripeContext()
+    {
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => null,
+            'api_key' => 'sk_test_123'
+        ]);
+
+        static::assertArrayNotHasKey('Stripe-Context', $options->headers);
+    }
+
+    public function testEmptyContextDoesNotSetHeader()
+    {
+        $emptyContext = new StripeContext();
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => $emptyContext,
+            'api_key' => 'sk_test_123'
+        ]);
+
+        // Empty context should not set Stripe-Context header
+        static::assertArrayNotHasKey('Stripe-Context', $options->headers);
+    }
+
+    public function testNonEmptyContextSetsHeader()
+    {
+        $context = StripeContext::parse('org_123/proj_456');
+        $options = \Stripe\Util\RequestOptions::parse([
+            'stripe_context' => $context,
+            'api_key' => 'sk_test_123'
+        ]);
+
+        // Non-empty context should set the header
+        static::assertSame('org_123/proj_456', $options->headers['Stripe-Context']);
+    }
+}

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -224,4 +224,65 @@ final class UtilTest extends \Stripe\TestCase
         self::assertSame('2022-02-15T00:27:45.330Z', $event->created);
         self::assertNull($event->reason);
     }
+
+    public function testJsonDecodeThinEventObjectWithContext()
+    {
+        $eventData = json_encode([
+            'id' => 'evt_234',
+            'object' => 'event',
+            'type' => 'financial_account.balance.opened',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => 'org_123/proj_456',
+        ]);
+
+        $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
+        self::assertInstanceOf(ThinEvent::class, $event);
+        self::assertInstanceOf(\Stripe\StripeContext::class, $event->context);
+        self::assertSame('org_123/proj_456', (string) $event->context);
+    }
+
+    public function testJsonDecodeThinEventObjectWithEmptyContext()
+    {
+        $eventData = json_encode([
+            'id' => 'evt_234',
+            'object' => 'event',
+            'type' => 'financial_account.balance.opened',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => '',
+        ]);
+
+        $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
+        self::assertInstanceOf(ThinEvent::class, $event);
+        self::assertInstanceOf(\Stripe\StripeContext::class, $event->context);
+        self::assertSame('', (string) $event->context);
+    }
+
+    public function testJsonDecodeThinEventObjectWithNullContext()
+    {
+        $eventData = json_encode([
+            'id' => 'evt_234',
+            'object' => 'event',
+            'type' => 'financial_account.balance.opened',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => null,
+        ]);
+
+        $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
+        self::assertInstanceOf(ThinEvent::class, $event);
+        self::assertNull($event->context);
+    }
+
+    public function testJsonDecodeThinEventObjectWithoutContext()
+    {
+        $eventData = json_encode([
+            'id' => 'evt_234',
+            'object' => 'event',
+            'type' => 'financial_account.balance.opened',
+            'created' => '2022-02-15T00:27:45.330Z',
+        ]);
+
+        $event = Util::json_decode_thin_event_object($eventData, ThinEvent::class);
+        self::assertInstanceOf(ThinEvent::class, $event);
+        self::assertNull($event->context);
+    }
 }


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
