### PR TITLE
Avoid using func_get_args

### DIFF
--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -147,7 +147,7 @@ final class CurlClientTest extends \Stripe\TestCase
         // make sure closure-based options work properly, including argument passing
         $ref = null;
         $withClosure = new CurlClient(static function ($method, $absUrl, $headers, $params, $hasFile) use (&$ref) {
-            $ref = \func_get_args();
+            $ref = [$method, $absUrl, $headers, $params, $hasFile];
 
             return [];
         });


### PR DESCRIPTION
### Why?
`func_get_args` has incompatibility issues with PHP 8.0 originally reported in #1739. While we stopped using it a year ago in the library, we still used it in tests.

### What?
Avoid using func_get_args 


