### PR TITLE
Remove deprecated usage of curl_close() for PHP versions > 8.0

### DIFF
--- a/lib/HttpClient/CurlClient.php
+++ b/lib/HttpClient/CurlClient.php
@@ -758,7 +758,9 @@ class CurlClient implements ClientInterface, StreamingClientInterface
     private function closeCurlHandle()
     {
         if (null !== $this->curlHandle) {
-            \curl_close($this->curlHandle);
+            if (PHP_VERSION_ID < 80000) {
+                \curl_close($this->curlHandle);
+            }
             $this->curlHandle = null;
         }
     }


### PR DESCRIPTION
### Why?
```
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in /vendor/stripe/stripe-php/lib/HttpClient/CurlClient.php on line 761
```

### What?
Only use `curl_close()` on PHP versions before 8.0 when it still did something

### See Also
#1972
