### PR TITLE
Remove RateLimitException from manual entries in init file as it is now autogenerated

### DIFF
--- a/init.php
+++ b/init.php
@@ -36,7 +36,6 @@ require __DIR__ . '/lib/Exception/IdempotencyException.php';
 require __DIR__ . '/lib/Exception/InvalidArgumentException.php';
 require __DIR__ . '/lib/Exception/InvalidRequestException.php';
 require __DIR__ . '/lib/Exception/PermissionException.php';
-require __DIR__ . '/lib/Exception/RateLimitException.php';
 require __DIR__ . '/lib/Exception/SignatureVerificationException.php';
 require __DIR__ . '/lib/Exception/UnexpectedValueException.php';
 require __DIR__ . '/lib/Exception/UnknownApiErrorException.php';


### PR DESCRIPTION
### Why?
RateLimitException is now officially part of the spec as a potential error for some of the v2 APIs. Therefore, it is getting included in the autogenerated section of the init.php file. This results in a redeclaration because it was already part of the manual entries in the same file

See https://github.com/stripe/stripe-php/actions/runs/21448520473/job/61770819381?pr=1988 

### What?
- Remove the manual entry for RateLimitException in the init.php file
- Not doing this directly against `beta` branch, because the redeclaration is happening on the branch that gets updated via automation. So, this PR is against the `latest-codegen-beta` branch


