### PR TITLE
Ignore PHPUnit 5.7.27 security advisory in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,12 @@
     "branch-alias": {
       "dev-master": "2.0-dev"
     }
+  },
+  "config": {
+    "audit": {
+        "ignore": {
+            "PKSA-z3gr-8qht-p93v": "PHPUnit is only a dev dependency. Temporarily ignore PHPUnit security advisory to ensure continued support for PHP 5.6 in CI."
+        }
+    }
   }
 }


### PR DESCRIPTION
### Why?
Our CI started reporting [errors](https://github.com/stripe/stripe-php/actions/runs/21448520473/job/61770819562?pr=1988#step:9:15) when installing phpunit dependency for testing. 
The root cause for this was a [security advisory](https://github.com/advisories/GHSA-vvj3-c3rp-c85p). PHPUnit stopped supporting v5 in February 2, 2018 and since we support PHP 5.6+ we have continued using this version. 

This will change in March this year when we officially drop support for some of the older PHP versions

### What?
* Ignored audit for the given security advisory in our composer.json. Since this dependency is a dev dependency that we only require for testing, this does not impact our users in any way. 

### See Also
https://jira.corp.stripe.com/browse/RUN_DEVSDK-2180
