### PR TITLE
Fix 2D array parameter encoding

### DIFF
--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -274,12 +274,12 @@ abstract class Util
             if (self::isList($elem)) {
                 $result = \array_merge(
                     $result,
-                    self::flattenParamsList($elem, "{$calculatedKey}[{$i}]")
+                    self::flattenParamsList($elem, "{$calculatedKey}[{$i}]", $apiMode)
                 );
             } elseif (\is_array($elem)) {
                 $result = \array_merge(
                     $result,
-                    self::flattenParams($elem, "{$calculatedKey}[{$i}]")
+                    self::flattenParams($elem, "{$calculatedKey}[{$i}]", $apiMode)
                 );
             } else {
                 // Always use indexed format for arrays

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -274,7 +274,7 @@ abstract class Util
             if (self::isList($elem)) {
                 $result = \array_merge(
                     $result,
-                    self::flattenParamsList($elem, $calculatedKey)
+                    self::flattenParamsList($elem, "{$calculatedKey}[{$i}]")
                 );
             } elseif (\is_array($elem)) {
                 $result = \array_merge(

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -247,4 +247,21 @@ final class UtilTest extends \Stripe\TestCase
             Util::flattenParams($params)
         );
     }
+
+    public function testFlattenParamsNestedArrays()
+    {
+        $params = [
+            'a' => [[1, 2], [3, 4]],
+        ];
+
+        self::assertSame(
+            [
+                ['a[0][0]', 1],
+                ['a[0][1]', 2],
+                ['a[1][0]', 3],
+                ['a[1][1]', 4],
+            ],
+            Util::flattenParams($params)
+        );
+    }
 }


### PR DESCRIPTION
### Why?

When encoding nested arrays (e.g. `[[1, 2], [3, 4]]`) as form parameters, the recursive call in `flattenParamsList` passed the parent key without the outer array index. This produced `a[0]=1&a[1]=2` instead of the correct `a[0][0]=1&a[0][1]=2`, silently sending wrong data to the API.

### What?

- Fix one-line bug in `lib/Util/Util.php`: append `[{$i}]` to the key before recursing into nested arrays
- Add regression test `testFlattenParamsNestedArrays` in `tests/Stripe/Util/UtilTest.php`

### See Also

- https://jira.corp.stripe.com/browse/RUN_DEVSDK-2304
- Parallel fixes in stripe-ruby and stripe-python (same bug pattern)
- Test-only PRs in stripe-go and stripe-dotnet (correct but untested)

## Changelog
- Fixes an issue encoding two-dimensional array request params where the SDK incorrectly flattens the array.