### PR TITLE
Add Ref type for typed v2 object references

### DIFF
--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -485,7 +485,7 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
      * */
     public function deserialize($json, $apiMode = 'v1')
     {
-        return Util::convertToStripeObject(\json_decode($json, true), [], $apiMode);
+        return Util::convertToStripeObject(\json_decode($json, true), ['client' => $this], $apiMode);
     }
 
     /**

--- a/lib/StripeObject.php
+++ b/lib/StripeObject.php
@@ -30,6 +30,9 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
     /** @var null|ApiResponse */
     protected $_lastResponse;
 
+    /** @var null|BaseStripeClient */
+    protected $_client;
+
     /**
      * @return Util\Set Attributes that should not be sent to the API because
      *    they're not updatable (e.g. ID).
@@ -270,9 +273,10 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
      *
      * @return static the object constructed from the given values
      */
-    public static function constructFrom($values, $opts = null, $apiMode = 'v1')
+    public static function constructFrom($values, $opts = null, $apiMode = 'v1', $client = null)
     {
         $obj = new static(isset($values['id']) ? $values['id'] : null);
+        $obj->_client = $client;
         $obj->refreshFrom($values, $opts, false, $apiMode);
 
         return $obj;
@@ -343,9 +347,9 @@ class StripeObject implements \ArrayAccess, \Countable, \JsonSerializable
             // empty arrays to be lists.
             // The same applies to the previous_attributes attribute.
             if (('metadata' === $k || 'previous_attributes' === $k) && \is_array($v)) {
-                $this->_values[$k] = StripeObject::constructFrom($v, $opts, $apiMode);
+                $this->_values[$k] = StripeObject::constructFrom($v, $opts, $apiMode, $this->_client);
             } else {
-                $this->_values[$k] = Util\Util::convertToStripeObject($v, $opts, $apiMode);
+                $this->_values[$k] = Util\Util::convertToStripeObject($v, $opts, $apiMode, false, $this->_client);
             }
             if ($dirty) {
                 $this->dirtyValue($this->_values[$k]);

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -44,14 +44,14 @@ abstract class Util
      *
      * @return array|StripeObject
      */
-    public static function convertToStripeObject($resp, $opts, $apiMode = 'v1', $isV2DeletedObject = false)
+    public static function convertToStripeObject($resp, $opts, $apiMode = 'v1', $isV2DeletedObject = false, $client = null)
     {
         $types = 'v1' === $apiMode ? ObjectTypes::mapping
             : ObjectTypes::v2Mapping;
         if (self::isList($resp)) {
             $mapped = [];
             foreach ($resp as $i) {
-                $mapped[] = self::convertToStripeObject($i, $opts, $apiMode);
+                $mapped[] = self::convertToStripeObject($i, $opts, $apiMode, false, $client);
             }
 
             return $mapped;
@@ -83,12 +83,12 @@ abstract class Util
                 && \array_key_exists('id', $resp)
                 && \array_key_exists('url', $resp)
             ) {
-                return new \Stripe\V2\Ref($resp, $opts['client'] ?? null);
+                return new \Stripe\V2\Ref($resp, $client);
             } else {
                 $class = StripeObject::class;
             }
 
-            return $class::constructFrom($resp, $opts, $apiMode);
+            return $class::constructFrom($resp, $opts, $apiMode, $client);
         }
 
         return $resp;

--- a/lib/Util/Util.php
+++ b/lib/Util/Util.php
@@ -76,6 +76,14 @@ abstract class Util
                 // TODO: this is a horrible hack. The API needs
                 // to return something for `object` here.
                 $class = \Stripe\V2\Collection::class;
+            } elseif (
+                'v2' === $apiMode
+                && !\array_key_exists('object', $resp)
+                && \array_key_exists('type', $resp)
+                && \array_key_exists('id', $resp)
+                && \array_key_exists('url', $resp)
+            ) {
+                return new \Stripe\V2\Ref($resp, $opts['client'] ?? null);
             } else {
                 $class = StripeObject::class;
             }

--- a/lib/V2/Ref.php
+++ b/lib/V2/Ref.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Stripe\V2;
+
+/**
+ * Ref represents a typed reference to a v2 Stripe object.
+ *
+ * The wire shape is `{type: string, id: string, url: string}`. Call
+ * `fetch()` to retrieve the full object from the API.
+ *
+ * @template T of \Stripe\StripeObject
+ *
+ * @property string $type The object type identifier (e.g. "v2.core.account").
+ * @property string $id   Unique identifier for the referenced object.
+ * @property string $url  Relative URL used to retrieve the full object.
+ */
+class Ref
+{
+    public $type;
+    public $id;
+    public $url;
+
+    /** @var null|\Stripe\BaseStripeClient */
+    protected $client;
+
+    /**
+     * @param array                          $json   the raw JSON payload for the ref field
+     * @param null|\Stripe\BaseStripeClient  $client a StripeClient instance used to fetch the object
+     */
+    public function __construct($json, $client = null)
+    {
+        $this->client = $client;
+        $this->type = $json['type'];
+        $this->id = $json['id'];
+        $this->url = $json['url'];
+    }
+
+    /**
+     * Sets the client used to make requests from this Ref.
+     *
+     * @param \Stripe\BaseStripeClient $client
+     */
+    public function setClient($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Retrieve the full object this reference points to.
+     *
+     * @return T
+     *
+     * @throws \Stripe\Exception\UnexpectedValueException if no client has been set
+     * @throws \Stripe\Exception\ApiErrorException if the request fails
+     */
+    public function fetch()
+    {
+        if (null === $this->client) {
+            throw new \Stripe\Exception\UnexpectedValueException(
+                'Ref has no client. Was it deserialized from a StripeClient response?'
+            );
+        }
+
+        $response = $this->client->rawRequest(
+            'get',
+            $this->url,
+            null,
+            [],
+            null,
+            ['ref_fetch']
+        );
+
+        return $this->client->deserialize($response->body, \Stripe\Util\Util::getApiMode($this->url));
+    }
+}

--- a/tests/Stripe/Util/UtilTest.php
+++ b/tests/Stripe/Util/UtilTest.php
@@ -264,4 +264,84 @@ final class UtilTest extends \Stripe\TestCase
             Util::flattenParams($params)
         );
     }
+
+    public function testConvertToStripeObjectReturnsRefForRefShapedV2Array()
+    {
+        $resp = [
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $result = Util::convertToStripeObject($resp, [], 'v2');
+
+        self::assertInstanceOf(\Stripe\V2\Ref::class, $result);
+        self::assertSame('v2.core.account', $result->type);
+        self::assertSame('acct_123', $result->id);
+        self::assertSame('/v2/core/accounts/acct_123', $result->url);
+    }
+
+    public function testConvertToStripeObjectPassesClientToRef()
+    {
+        $resp = [
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $client = new \Stripe\StripeClient('sk_test_123');
+        $result = Util::convertToStripeObject($resp, ['client' => $client], 'v2');
+
+        self::assertInstanceOf(\Stripe\V2\Ref::class, $result);
+
+        // Verify the client was threaded through by checking that fetch() does
+        // not throw the "no client" exception (it will throw on the HTTP call
+        // instead, which we stub out via reflection — so we just confirm the
+        // client property was set by calling setClient and confirming it replaces).
+        $refWithoutClient = new \Stripe\V2\Ref($resp);
+        try {
+            $refWithoutClient->fetch();
+            self::fail('Expected UnexpectedValueException');
+        } catch (\Stripe\Exception\UnexpectedValueException $e) {
+            self::assertStringContainsString('no client', $e->getMessage());
+        }
+
+        // The Ref returned from convertToStripeObject had a client set, so
+        // accessing the protected $client property via reflection should not be null.
+        $reflProp = new \ReflectionProperty(\Stripe\V2\Ref::class, 'client');
+        $reflProp->setAccessible(true);
+        self::assertSame($client, $reflProp->getValue($result));
+    }
+
+    public function testConvertToStripeObjectDoesNotTreatRefShapeAsRefInV1()
+    {
+        // A v1 array with type/id/url but no object key should fall through to
+        // StripeObject, not become a Ref.
+        $resp = [
+            'type' => 'some_type',
+            'id' => 'obj_123',
+            'url' => '/v1/things/obj_123',
+        ];
+
+        $result = Util::convertToStripeObject($resp, [], 'v1');
+
+        self::assertInstanceOf(\Stripe\StripeObject::class, $result);
+        self::assertNotInstanceOf(\Stripe\V2\Ref::class, $result);
+    }
+
+    public function testConvertToStripeObjectDoesNotTreatObjectKeyedArrayAsRef()
+    {
+        // A v2 array that has an `object` key must not be treated as a Ref even
+        // if it also has type/id/url, because it's a normal typed v2 object.
+        $resp = [
+            'object' => 'v2.core.account',
+            'type' => 'some_type',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $result = Util::convertToStripeObject($resp, [], 'v2');
+
+        self::assertNotInstanceOf(\Stripe\V2\Ref::class, $result);
+    }
 }

--- a/tests/Stripe/V2/RefTest.php
+++ b/tests/Stripe/V2/RefTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Stripe\V2;
+
+/**
+ * @internal
+ *
+ * @covers \Stripe\V2\Ref
+ */
+final class RefTest extends \Stripe\TestCase
+{
+    use \Stripe\TestHelper;
+
+    private function makeRef($overrides = [])
+    {
+        $json = array_merge([
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ], $overrides);
+
+        $client = new \Stripe\StripeClient('sk_test_123');
+
+        return new Ref($json, $client);
+    }
+
+    public function testConstructorPopulatesProperties()
+    {
+        $ref = $this->makeRef();
+
+        self::assertSame('v2.core.account', $ref->type);
+        self::assertSame('acct_123', $ref->id);
+        self::assertSame('/v2/core/accounts/acct_123', $ref->url);
+    }
+
+    public function testFetchMakesGetRequestToUrl()
+    {
+        $responseBody = json_encode([
+            'object' => 'v2.core.account',
+            'id' => 'acct_123',
+        ]);
+
+        $fakeResponse = new \Stripe\ApiResponse($responseBody, 200, [], json_decode($responseBody, true));
+
+        $clientMock = $this->getMockBuilder(\Stripe\StripeClient::class)
+            ->setConstructorArgs(['sk_test_123'])
+            ->setMethods(['rawRequest', 'deserialize'])
+            ->getMock()
+        ;
+
+        $clientMock->expects(self::once())
+            ->method('rawRequest')
+            ->with(
+                'get',
+                '/v2/core/accounts/acct_123',
+                null,
+                [],
+                null,
+                ['ref_fetch']
+            )
+            ->willReturn($fakeResponse)
+        ;
+
+        $expectedObject = new \Stripe\StripeObject();
+        $clientMock->expects(self::once())
+            ->method('deserialize')
+            ->with($responseBody, 'v2')
+            ->willReturn($expectedObject)
+        ;
+
+        $json = [
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $ref = new Ref($json, $clientMock);
+        $result = $ref->fetch();
+
+        self::assertSame($expectedObject, $result);
+    }
+
+    public function testFetchUsesV1ApiModeForV1Urls()
+    {
+        $responseBody = json_encode([
+            'object' => 'account',
+            'id' => 'acct_123',
+        ]);
+
+        $fakeResponse = new \Stripe\ApiResponse($responseBody, 200, [], json_decode($responseBody, true));
+
+        $clientMock = $this->getMockBuilder(\Stripe\StripeClient::class)
+            ->setConstructorArgs(['sk_test_123'])
+            ->setMethods(['rawRequest', 'deserialize'])
+            ->getMock()
+        ;
+
+        $clientMock->expects(self::once())
+            ->method('rawRequest')
+            ->willReturn($fakeResponse)
+        ;
+
+        $clientMock->expects(self::once())
+            ->method('deserialize')
+            ->with($responseBody, 'v1')
+            ->willReturn(new \Stripe\StripeObject())
+        ;
+
+        $json = [
+            'type' => 'account',
+            'id' => 'acct_123',
+            'url' => '/v1/accounts/acct_123',
+        ];
+
+        $ref = new Ref($json, $clientMock);
+        $ref->fetch();
+    }
+
+    public function testFetchThrowsWhenClientIsNull()
+    {
+        $json = [
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $ref = new Ref($json);
+
+        $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Ref has no client.');
+
+        $ref->fetch();
+    }
+
+    public function testSetClientAllowsFetch()
+    {
+        $responseBody = json_encode([
+            'object' => 'v2.core.account',
+            'id' => 'acct_123',
+        ]);
+
+        $fakeResponse = new \Stripe\ApiResponse($responseBody, 200, [], json_decode($responseBody, true));
+
+        $clientMock = $this->getMockBuilder(\Stripe\StripeClient::class)
+            ->setConstructorArgs(['sk_test_123'])
+            ->setMethods(['rawRequest', 'deserialize'])
+            ->getMock()
+        ;
+
+        $clientMock->expects(self::once())
+            ->method('rawRequest')
+            ->willReturn($fakeResponse)
+        ;
+
+        $expectedObject = new \Stripe\StripeObject();
+        $clientMock->expects(self::once())
+            ->method('deserialize')
+            ->willReturn($expectedObject)
+        ;
+
+        $json = [
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ];
+
+        $ref = new Ref($json);
+        $ref->setClient($clientMock);
+        $result = $ref->fetch();
+
+        self::assertSame($expectedObject, $result);
+    }
+}

--- a/tests/Stripe/V2/RefTest.php
+++ b/tests/Stripe/V2/RefTest.php
@@ -132,6 +132,28 @@ final class RefTest extends \Stripe\TestCase
         $ref->fetch();
     }
 
+    public function testDeserializeViaClientCreatesRefWithClientSet()
+    {
+        $client = new \Stripe\StripeClient('sk_test_123');
+
+        $json = json_encode([
+            'type' => 'v2.core.account',
+            'id' => 'acct_123',
+            'url' => '/v2/core/accounts/acct_123',
+        ]);
+
+        $result = $client->deserialize($json, 'v2');
+
+        self::assertInstanceOf(Ref::class, $result);
+        self::assertSame('v2.core.account', $result->type);
+        self::assertSame('acct_123', $result->id);
+        self::assertSame('/v2/core/accounts/acct_123', $result->url);
+
+        $reflProp = new \ReflectionProperty(Ref::class, 'client');
+        $reflProp->setAccessible(true);
+        self::assertSame($client, $reflProp->getValue($result));
+    }
+
     public function testSetClientAllowsFetch()
     {
         $responseBody = json_encode([

--- a/tests/Stripe/V2/RefTest.php
+++ b/tests/Stripe/V2/RefTest.php
@@ -127,7 +127,7 @@ final class RefTest extends \Stripe\TestCase
         $ref = new Ref($json);
 
         $this->expectException(\Stripe\Exception\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Ref has no client.');
+        $this->expectExceptionMessage('Ref has no client. Was it deserialized from a StripeClient response?');
 
         $ref->fetch();
     }


### PR DESCRIPTION
### Why?

Custom objects need typed references to other Stripe objects. A reference has the wire shape `{type, id, url}` and in the SDK becomes `Ref` — a container that can fetch the referenced object.

### What?

- `\Stripe\V2\Ref` class with `@template T of \Stripe\StripeObject`
- Public `$type`, `$id`, `$url` properties
- Stores `$client` (a `BaseStripeClient`) for making requests
- `fetch()` calls `$this->client->rawRequest()` + `$this->client->deserialize()` — same pattern as `EventNotification.fetchRelatedObject()`
- Client threading: `$client` parameter added to `Util::convertToStripeObject()`, passed from `BaseStripeClient.request()` and `BaseStripeClient.deserialize()`. Stored on `StripeObject._client` in `constructFrom()`, threaded through `updateAttributes()` for nested field deserialization.
- Ref shape detection in `convertToStripeObject`: v2 arrays with `type`, `id`, `url` keys and no `object` key are instantiated as `Ref($resp, $client)`

### See Also


Generated with [Claude Code](https://claude.com/claude-code)