### PR TITLE
bump phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7 || ^9.0",
+    "phpunit/phpunit": "^8.0 || ^9.0",
     "friendsofphp/php-cs-fixer": "3.94.0",
     "phpstan/phpstan": "^1.2"
   },
@@ -44,13 +44,6 @@
   "extra": {
     "branch-alias": {
       "dev-master": "2.0-dev"
-    }
-  },
-  "config": {
-    "audit": {
-      "ignore": {
-        "PKSA-z3gr-8qht-p93v": "PHPUnit is only a dev dependency. Temporarily ignore PHPUnit security advisory to ensure continued support for PHP 5.6 in CI."
-      }
     }
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In [this CI run](https://github.com/stripe/stripe-php/actions/runs/26188935559/job/77051890274), our dependencies could not be resolved:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires phpunit/phpunit ^5.7 || ^9.0 -> satisfiable by phpunit/phpunit[5.7.0, ..., 5.7.27, 9.0.0, ..., 9.6.34].
    - phpunit/phpunit[5.7.0, ..., 5.7.23] require symfony/yaml ~2.1|~3.0 -> found symfony/yaml[v2.1.0, ..., v2.8.52, v3.0.0, ..., v3.4.47] but these were not loaded, because they are affected by security advisories ("PKSA-v5yj-8nmz-sk2q", "PKSA-ft77-7h5f-p3r6", "PKSA-b14r-zh1d-vdrc", "PKSA-xxgb-wq2d-7gpg"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
    - phpunit/phpunit[5.7.24, ..., 5.7.27] require symfony/yaml ~2.1|~3.0|~4.0 -> found symfony/yaml[v2.1.0, ..., v2.8.52, v3.0.0, ..., v3.4.47, v4.0.0, ..., v4.4.45] but these were not loaded, because they are affected by security advisories ("PKSA-v5yj-8nmz-sk2q", "PKSA-ft77-7h5f-p3r6", "PKSA-b14r-zh1d-vdrc", "PKSA-xxgb-wq2d-7gpg"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
    - phpunit/phpunit[9.0.0, ..., 9.2.6] require php ^7.3 -> your php version (7.2.34) does not satisfy that requirement.
    - phpunit/phpunit[9.3.9, ..., 9.6.34] require php >=7.3 -> your php version (7.2.34) does not satisfy that requirement.
    - phpunit/phpunit[9.3.0, ..., 9.3.8] require php ^7.3 || ^8.0 -> your php version (7.2.34) does not satisfy that requirement.
```

We were pinned to an old phpunit version because we needed to support php 5.6... but now we don't, so we can upgrade our deps.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- bump phpunit version
- remove unused audit override

### See Also
<!-- Include any links or additional information that help explain this change. -->

