### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -134,6 +134,7 @@ class ApiRequestor
         $headers = $headers ?: [];
         list($rbody, $rcode, $rheaders, $myApiKey)
             = $this->_requestRaw($method, $url, $params, $headers, $apiMode, $usage, $maxNetworkRetries);
+        $this->_maybeEmitStripeNotice($rheaders);
         $json = $this->_interpretResponse($rbody, $rcode, $rheaders, $apiMode);
         $resp = new ApiResponse($rbody, $rcode, $rheaders, $json);
 
@@ -158,6 +159,7 @@ class ApiRequestor
         $headers = $headers ?: [];
         list($rbody, $rcode, $rheaders, $myApiKey)
             = $this->_requestRawStreaming($method, $url, $params, $headers, $apiMode, $usage, $readBodyChunkCallable, $maxNetworkRetries);
+        $this->_maybeEmitStripeNotice($rheaders);
         if ($rcode >= 300) {
             $this->_interpretResponse($rbody, $rcode, $rheaders, $apiMode);
         }
@@ -555,6 +557,13 @@ class ApiRequestor
         }
 
         return [$absUrl, $rawHeaders, $params, $hasFile, $myApiKey];
+    }
+
+    private function _maybeEmitStripeNotice($rheaders)
+    {
+        if (isset($rheaders['stripe-notice']) && \is_string($rheaders['stripe-notice'])) {
+            \trigger_error($rheaders['stripe-notice'], \E_USER_WARNING);
+        }
     }
 
     /**

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -858,4 +858,54 @@ final class ApiRequestorTest extends TestCase
         });
         self::assertSame('cursor', $result);
     }
+
+    public function testEmitsWarningWhenStripeNoticeHeaderPresent()
+    {
+        // https://github.com/sebastianbergmann/phpunit/issues/5062
+        // (if we go to phpunit@10)
+        $this->expectWarning();
+        $this->expectWarningMessage('test notice');
+
+        $stub = $this->createMock('\Stripe\HttpClient\ClientInterface');
+        $stub->expects(self::once())
+            ->method('request')
+            ->willReturn([
+                \json_encode(['id' => 'ch_123', 'object' => 'charge']),
+                200,
+                ['stripe-notice' => 'test notice'],
+            ])
+        ;
+        ApiRequestor::setHttpClient($stub);
+
+        Charge::retrieve('ch_123');
+    }
+
+    public function testNoWarningWhenStripeNoticeHeaderAbsent()
+    {
+        $warningEmitted = false;
+        \set_error_handler(static function () use (&$warningEmitted) {
+            $warningEmitted = true;
+
+            return true;
+        }, \E_USER_WARNING);
+
+        try {
+            $stub = $this->createMock('\Stripe\HttpClient\ClientInterface');
+            $stub->expects(self::once())
+                ->method('request')
+                ->willReturn([
+                    \json_encode(['id' => 'ch_123', 'object' => 'charge']),
+                    200,
+                    [],
+                ])
+            ;
+            ApiRequestor::setHttpClient($stub);
+
+            Charge::retrieve('ch_123');
+        } finally {
+            \restore_error_handler();
+        }
+
+        self::assertFalse($warningEmitted);
+    }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
