### PR TITLE
Disable trim_trailing_whitespace for CHANGELOG.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_style = tab
 
 [Makefile]
 indent_style = tab
+
+[CHANGELOG.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prevents editors from stripping intentional trailing whitespace in changelog entries.

Fixes: https://go/j/DEVSDK-2229