### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -435,11 +435,30 @@ class ApiRequestor
 
         // Fallback to global configuration to maintain backwards compatibility.
         $appInfo = $appInfo ?: Stripe::getAppInfo();
+        // `static` here means it persists for the lifetime of the process
+        static $cachedSource = null;
+        if (null === $cachedSource) {
+            $uname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'php_uname');
+            if ($uname_disabled) {
+                $cachedSource = false;
+            } else {
+                $parts = [\php_uname()];
+                $hostname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'gethostname');
+                if (!$hostname_disabled) {
+                    $parts[] = \gethostname();
+                }
+                $cachedSource = \md5(\implode(' ', $parts));
+            }
+        }
+
         $ua = [
             'bindings_version' => Stripe::VERSION,
             'lang' => 'php',
             'lang_version' => $langVersion,
         ];
+        if ($cachedSource) {
+            $ua['source'] = $cachedSource;
+        }
         if (Stripe::getEnableTelemetry()) {
             $uname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'php_uname');
             $ua['platform'] = $uname_disabled

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -101,6 +101,93 @@ final class ApiRequestorTest extends TestCase
         self::assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
 
+    public function testDefaultHeadersIncludeSource()
+    {
+        $this->clearAgentEnvVars();
+
+        $reflector = new \ReflectionClass(ApiRequestor::class);
+        $method = $reflector->getMethod('_defaultHeaders');
+        $method->setAccessible(true);
+
+        $headers = $method->invoke(null, 'sk_test_notarealkey');
+
+        $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
+        // source is either absent (when php_uname is disabled) or a 32-char hex MD5
+        if (\array_key_exists('source', $ua)) {
+            $source = $ua['source'];
+            self::assertTrue(
+                (bool) \preg_match('/^[0-9a-f]{32}$/', $source),
+                "Expected source to be a 32-char hex MD5, got: {$source}"
+            );
+        }
+    }
+
+    public function testDefaultHeadersSourceIndependentOfTelemetrySetting()
+    {
+        $this->clearAgentEnvVars();
+
+        $reflector = new \ReflectionClass(ApiRequestor::class);
+        $method = $reflector->getMethod('_defaultHeaders');
+        $method->setAccessible(true);
+
+        $originalTelemetry = Stripe::getEnableTelemetry();
+
+        try {
+            Stripe::setEnableTelemetry(true);
+            $headersEnabled = $method->invoke(null, 'sk_test_notarealkey');
+            $uaEnabled = \json_decode($headersEnabled['X-Stripe-Client-User-Agent'], true);
+
+            Stripe::setEnableTelemetry(false);
+            $headersDisabled = $method->invoke(null, 'sk_test_notarealkey');
+            $uaDisabled = \json_decode($headersDisabled['X-Stripe-Client-User-Agent'], true);
+
+            // source presence is independent of the telemetry flag:
+            // both calls should agree on whether source is present
+            self::assertSame(
+                \array_key_exists('source', $uaEnabled),
+                \array_key_exists('source', $uaDisabled),
+                'source presence should not depend on the telemetry flag'
+            );
+        } finally {
+            Stripe::setEnableTelemetry($originalTelemetry);
+        }
+    }
+
+    public function testDefaultHeadersOmitSourceWhenPhpUnameDisabled()
+    {
+        $this->clearAgentEnvVars();
+
+        // Verify that _isDisabled correctly identifies php_uname as disabled,
+        // and that when it is, _defaultHeaders does not set source to a sentinel
+        // string — it either omits source or sets it to a valid MD5 hash.
+        //
+        // We cannot force php_uname into disable_functions at runtime (it is a
+        // PHP ini setting), and the static $cachedSource variable inside
+        // _defaultHeaders is initialised once per process, so we verify the
+        // contract indirectly: source must never be the old sentinel '(disabled)'.
+        $reflector = new \ReflectionClass(ApiRequestor::class);
+        $method = $reflector->getMethod('_defaultHeaders');
+        $method->setAccessible(true);
+
+        $headers = $method->invoke(null, 'sk_test_notarealkey');
+
+        $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
+        if (\array_key_exists('source', $ua)) {
+            self::assertNotSame(
+                '(disabled)',
+                $ua['source'],
+                'source must not be set to the sentinel string "(disabled)"; it should be omitted when php_uname is disabled'
+            );
+            self::assertTrue(
+                (bool) \preg_match('/^[0-9a-f]{32}$/', $ua['source']),
+                'When source is present it must be a 32-char lowercase hex MD5, got: ' . $ua['source']
+            );
+        } else {
+            // source is absent — this is the correct behaviour when php_uname is disabled
+            self::assertArrayNotHasKey('source', $ua);
+        }
+    }
+
     public function testDefaultHeadersOmitPlatformWhenTelemetryDisabled()
     {
         $this->clearAgentEnvVars();


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
