### PR TITLE
Add TStripeObject to iterator PHPDoc comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpstan
-        run: just lint && just lint-test
+        run: just lint-test lint
 
   tests:
     runs-on: "ubuntu-24.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpstan
-        run: just lint
+        run: just lint && just lint-test
 
   tests:
     runs-on: "ubuntu-24.04"

--- a/examples/IteratorExample.php
+++ b/examples/IteratorExample.php
@@ -1,48 +1,38 @@
 <?php
 
 /**
- * This is a template for defining new examples.  It is not intended to be used directly.
+ * This is a simple example to get and list customers.
  *
- * <describe what this example does>
- *
- * In this example, we:
- *   - <key step 1>
- *   - <key step 2
- *   - ...
- *
- * <describe assumptions about the user's stripe account, environment, or configuration;
- * or things to watch out for when running>
+ * It is used by lint-test to ensure that the iterated value type is not resolved to mixed
  */
 require 'vendor/autoload.php'; // Make sure to include Composer's autoload file
 // Use this require statement to import the SDK from this repo folder
 // require '../init.php';
 
-class ExampleTemplate
+class IteratorExample
 {
-    private String $apiKey;
+    private string $apiKey;
 
-    public function __construct(String $apiKey)
+    public function __construct(string $apiKey)
     {
         $this->apiKey = $apiKey;
     }
 
-    public function doSomethingGreat() : void
+    public function iterateOverCustomers(): void
     {
-        // echo "Hello World\n";
-        $client = new \Stripe\StripeClient($this->apiKey);
+        $client = new Stripe\StripeClient($this->apiKey);
         $customers = $client->customers->all();
-        foreach($customers as $customer) {
+        foreach ($customers as $customer) {
             echo $customer->email;
         }
         foreach ($customers->autoPagingIterator() as $customer) {
             echo $customer->id;
         }
-
     }
 }
 
 // Usage
 $apiKey = '{{API_KEY}}';
 
-$example = new ExampleTemplate($apiKey);
-$example->doSomethingGreat();
+$example = new IteratorExample($apiKey);
+$example->iterateOverCustomers();

--- a/examples/IteratorExample.php
+++ b/examples/IteratorExample.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This is a template for defining new examples.  It is not intended to be used directly.
+ *
+ * <describe what this example does>
+ *
+ * In this example, we:
+ *   - <key step 1>
+ *   - <key step 2
+ *   - ...
+ *
+ * <describe assumptions about the user's stripe account, environment, or configuration;
+ * or things to watch out for when running>
+ */
+require 'vendor/autoload.php'; // Make sure to include Composer's autoload file
+// Use this require statement to import the SDK from this repo folder
+// require '../init.php';
+
+class ExampleTemplate
+{
+    private String $apiKey;
+
+    public function __construct(String $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    public function doSomethingGreat() : void
+    {
+        // echo "Hello World\n";
+        $client = new \Stripe\StripeClient($this->apiKey);
+        $customers = $client->customers->all();
+        foreach($customers as $customer) {
+            echo $customer->email;
+        }
+        foreach ($customers->autoPagingIterator() as $customer) {
+            echo $customer->id;
+        }
+
+    }
+}
+
+// Usage
+$apiKey = '{{API_KEY}}';
+
+$example = new ExampleTemplate($apiKey);
+$example->doSomethingGreat();

--- a/justfile
+++ b/justfile
@@ -36,8 +36,9 @@ format-check: (format "--dry-run")
 lint *args:
     php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{args}}
 
+# statically analyze code (strict)
 lint-test:
-    phpstan analyse examples/IteratorExample.php --level=9
+    vendor/bin/phpstan analyse examples/IteratorExample.php --level=9
 
 # for backwards compatibility; ideally removed later
 [private]

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test *args: install
 
 # run tests in CI; can use autoload mode (or not)
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
-ci-test autoload:
+ci-test autoload: && lint-test
     ./build.php {{ autoload }}
 
 # ⭐ format all files
@@ -35,6 +35,9 @@ format-check: (format "--dry-run")
 # ⭐ statically analyze code
 lint *args:
     php -d memory_limit=512M vendor/bin/phpstan analyse lib tests {{args}}
+
+lint-test:
+    phpstan analyse examples/IteratorExample.php --level=9
 
 # for backwards compatibility; ideally removed later
 [private]

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ lint *args:
 
 # statically analyze code (strict)
 lint-test:
-    vendor/bin/phpstan analyse examples/IteratorExample.php --level=9
+    phpstan analyse examples/IteratorExample.php --level=9
 
 # for backwards compatibility; ideally removed later
 [private]

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test *args: install
 
 # run tests in CI; can use autoload mode (or not)
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
-ci-test autoload: && lint-test
+ci-test autoload:
     ./build.php {{ autoload }}
 
 # ⭐ format all files

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -147,7 +147,7 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator an iterator that can be used to iterate
+     * @return \ArrayIterator<int, TStripeObject> an iterator that can be used to iterate
      *    across objects in the current page
      */
     #[\ReturnTypeWillChange]
@@ -157,7 +157,7 @@ class Collection extends StripeObject implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator an iterator that can be used to iterate
+     * @return \ArrayIterator<int, TStripeObject> an iterator that can be used to iterate
      *    backwards across objects in the current page
      */
     public function getReverseIterator()


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
Collection implements `IteratorAggregate<TStripeObject>`, but `getIterator()` and `getReverseIterator()` were annotated to return a bare `\ArrayIterator` with no type parameters. PHPStan uses the method's own declared return type when inferring foreach loop variable types. This caused loop variables to be inferred as `mixed` instead of the concrete type (e.g. `Customer`), producing errors like `"Cannot access property $email on mixed"` for users running PHPStan at the strictest level 9.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- `Collection::getIterator()` and `getReverseIterator()`: `@return \ArrayIterator` → `@return \ArrayIterator<int, TStripeObject>`
- Add `examples/IteratorExample.php`: a minimal reproduction case that iterates a `Collection<Customer>` via both `foreach` and `autoPagingIterator()`, serving as the PHPStan lint target
- Add `lint-test` recipe: runs PHPStan at level 9 against the example to verify the fix and prevent regressions
- Wire just lint-test into CI (phpstan job)

### See Also
<!-- Include any links or additional information that help explain this change. -->
- Issue: https://github.com/stripe/stripe-php/issues/2091

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.
Either fill it out or remove it if there are no entries to report.

List changes that affect end users, e.g.
- Fixes crash when calling `foo.bar()` with null argument
- Adds support for new `baz` parameter on `PaymentIntent` creation

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
- Fixed: PHPStan no longer infers iterated Collection values as `mixed`; loop variables are now correctly typed as the collection's generic type parameter
