### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
         run: just lint-test lint
 
   tests:
-    runs-on: "ubuntu-24.04"
+    name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
 
     permissions:
       contents: read
@@ -107,11 +108,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - "ubuntu-24.04"
         autoload:
           - "0"
           - "1"
         php-version:
           # https://docs.stripe.com/sdks/versioning?lang=php
+          # https://endoflife.date/php
           - "7.2"
           - "7.3"
           - "7.4"
@@ -121,7 +125,15 @@ jobs:
           - "8.3"
           - "8.4"
           - "8.5"
-    name: Tests (php@${{ matrix.php-version }}, AUTOLOAD=${{ matrix.autoload }})
+        include:
+          - os: windows-latest
+            # use any modern-ish version
+            php-version: "8.5"
+            autoload: "1"
+          - os: windows-latest
+            # use any modern-ish version
+            php-version: "8.5"
+            autoload: "0"
 
     steps:
       - uses: extractions/setup-just@v2

--- a/build.php
+++ b/build.php
@@ -14,7 +14,7 @@ if (!$autoload) {
     \file_put_contents('composer.json', \json_encode($composer, \JSON_PRETTY_PRINT));
 }
 
-\passthru('composer update', $returnStatus);
+\passthru('composer dump-autoload', $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -20,7 +20,7 @@ if (0 !== $returnStatus) {
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
-\passthru("php vendor/bin/phpunit -c {$config} --verbose", $returnStatus);
+\passthru("php vendor/bin/phpunit -c {$config} --testdox", $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -20,7 +20,7 @@ if (0 !== $returnStatus) {
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
-\passthru("php vendor/bin/phpunit -c {$config} --testdox", $returnStatus);
+\passthru("php vendor/bin/phpunit -c {$config}", $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -14,13 +14,13 @@ if (!$autoload) {
     \file_put_contents('composer.json', \json_encode($composer, \JSON_PRETTY_PRINT));
 }
 
-\passthru('composer dump-autoload', $returnStatus);
+\passthru('composer update', $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
-\passthru("php vendor/bin/phpunit -c {$config}", $returnStatus);
+\passthru("php vendor/bin/phpunit -c {$config} --verbose", $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -20,7 +20,7 @@ if (0 !== $returnStatus) {
 }
 
 $config = $autoload ? 'phpunit.xml' : 'phpunit.no_autoload.xml';
-\passthru("./vendor/bin/phpunit -c {$config}", $returnStatus);
+\passthru("php vendor/bin/phpunit -c {$config}", $returnStatus);
 if (0 !== $returnStatus) {
     exit(1);
 }

--- a/init.php
+++ b/init.php
@@ -67,6 +67,7 @@ require __DIR__ . '/lib/ApiOperations/Update.php';
 // Plumbing
 require __DIR__ . '/lib/ApiResponse.php';
 require __DIR__ . '/lib/RequestTelemetry.php';
+require __DIR__ . '/lib/TelemetryId.php';
 require __DIR__ . '/lib/StripeObject.php';
 require __DIR__ . '/lib/ApiRequestor.php';
 require __DIR__ . '/lib/ApiResource.php';

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ test *args: install
 # run tests in CI; can use autoload mode (or not)
 [confirm("This will modify local files and is intended for use in CI; do you want to proceed?")]
 ci-test autoload:
-    ./build.php {{ autoload }}
+    php build.php {{ autoload }}
 
 # ⭐ format all files
 format *args: install

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -435,31 +435,17 @@ class ApiRequestor
 
         // Fallback to global configuration to maintain backwards compatibility.
         $appInfo = $appInfo ?: Stripe::getAppInfo();
-        // `static` here means it persists for the lifetime of the process
-        static $cachedSource = null;
-        if (null === $cachedSource) {
-            $uname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'php_uname');
-            if ($uname_disabled) {
-                $cachedSource = false;
-            } else {
-                $parts = [\php_uname()];
-                $hostname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'gethostname');
-                if (!$hostname_disabled) {
-                    $parts[] = \gethostname();
-                }
-                $cachedSource = \md5(\implode(' ', $parts));
-            }
-        }
 
         $ua = [
             'bindings_version' => Stripe::VERSION,
             'lang' => 'php',
             'lang_version' => $langVersion,
         ];
-        if ($cachedSource) {
-            $ua['source'] = $cachedSource;
-        }
         if (Stripe::getEnableTelemetry()) {
+            $telemetryId = TelemetryId::get();
+            if (null !== $telemetryId) {
+                $ua['telemetry_id'] = $telemetryId;
+            }
             $uname_disabled = self::_isDisabled(\ini_get('disable_functions'), 'php_uname');
             $ua['platform'] = $uname_disabled
                 ? '(disabled)'

--- a/lib/TelemetryId.php
+++ b/lib/TelemetryId.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Stripe;
+
+class TelemetryId
+{
+    /** @var null|string */
+    private static $cachedId;
+
+    /** @var bool */
+    private static $loaded = false;
+
+    /**
+     * @return null|string
+     */
+    public static function get()
+    {
+        if (self::$loaded) {
+            return self::$cachedId;
+        }
+        self::$loaded = true;
+
+        $configDir = self::getConfigDir();
+        if (null === $configDir) {
+            return null;
+        }
+
+        $filePath = $configDir . \DIRECTORY_SEPARATOR . 'telemetry_id';
+
+        if (\file_exists($filePath)) {
+            $content = @\file_get_contents($filePath);
+            if (false !== $content) {
+                $content = \trim($content);
+                if ('' !== $content) {
+                    self::$cachedId = $content;
+
+                    return self::$cachedId;
+                }
+            }
+        }
+
+        self::$cachedId = \bin2hex(\random_bytes(16));
+
+        if (!\is_dir($configDir)) {
+            if (!@\mkdir($configDir, 0700, true)) {
+                self::$cachedId = null;
+
+                return null;
+            }
+        }
+        if (false === @\file_put_contents($filePath, self::$cachedId)) {
+            self::$cachedId = null;
+
+            return null;
+        }
+
+        return self::$cachedId;
+    }
+
+    /**
+     * @return null|string
+     */
+    public static function getConfigDir()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $appData = \getenv('APPDATA');
+            if (false === $appData || '' === $appData) {
+                return null;
+            }
+
+            return $appData . \DIRECTORY_SEPARATOR . 'Stripe';
+        }
+
+        $xdg = \getenv('XDG_CONFIG_HOME');
+        if (false !== $xdg && '' !== $xdg) {
+            return $xdg . \DIRECTORY_SEPARATOR . 'stripe';
+        }
+
+        $home = \getenv('HOME');
+        if (false === $home || '' === $home) {
+            return null;
+        }
+
+        return $home . \DIRECTORY_SEPARATOR . '.config' . \DIRECTORY_SEPARATOR . 'stripe';
+    }
+
+    /**
+     * @internal For testing only
+     */
+    public static function reset()
+    {
+        self::$cachedId = null;
+        self::$loaded = false;
+    }
+}

--- a/lib/TelemetryId.php
+++ b/lib/TelemetryId.php
@@ -25,7 +25,7 @@ class TelemetryId
             return null;
         }
 
-        $filePath = $configDir . \DIRECTORY_SEPARATOR . 'telemetry_id';
+        $filePath = self::joinPath($configDir, 'telemetry_id');
 
         if (\file_exists($filePath)) {
             $content = @\file_get_contents($filePath);
@@ -68,12 +68,12 @@ class TelemetryId
                 return null;
             }
 
-            return $appData . \DIRECTORY_SEPARATOR . 'Stripe';
+            return self::joinPath($appData, 'Stripe');
         }
 
         $xdg = \getenv('XDG_CONFIG_HOME');
         if (false !== $xdg && '' !== $xdg) {
-            return $xdg . \DIRECTORY_SEPARATOR . 'stripe';
+            return self::joinPath($xdg, 'stripe');
         }
 
         $home = \getenv('HOME');
@@ -81,7 +81,17 @@ class TelemetryId
             return null;
         }
 
-        return $home . \DIRECTORY_SEPARATOR . '.config' . \DIRECTORY_SEPARATOR . 'stripe';
+        return self::joinPath($home, '.config', 'stripe');
+    }
+
+    /**
+     * @param string ...$segments
+     *
+     * @return string
+     */
+    private static function joinPath(...$segments)
+    {
+        return \implode(\DIRECTORY_SEPARATOR, $segments);
     }
 
     /**

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -101,90 +101,55 @@ final class ApiRequestorTest extends TestCase
         self::assertSame($headers['Authorization'], 'Bearer ' . $apiKey);
     }
 
-    public function testDefaultHeadersIncludeSource()
+    public function testDefaultHeadersIncludeTelemetryIdWhenTelemetryEnabled()
     {
         $this->clearAgentEnvVars();
-
-        $reflector = new \ReflectionClass(ApiRequestor::class);
-        $method = $reflector->getMethod('_defaultHeaders');
-        $method->setAccessible(true);
-
-        $headers = $method->invoke(null, 'sk_test_notarealkey');
-
-        $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
-        // source is either absent (when php_uname is disabled) or a 32-char hex MD5
-        if (\array_key_exists('source', $ua)) {
-            $source = $ua['source'];
-            self::assertTrue(
-                (bool) \preg_match('/^[0-9a-f]{32}$/', $source),
-                "Expected source to be a 32-char hex MD5, got: {$source}"
-            );
-        }
-    }
-
-    public function testDefaultHeadersSourceIndependentOfTelemetrySetting()
-    {
-        $this->clearAgentEnvVars();
-
-        $reflector = new \ReflectionClass(ApiRequestor::class);
-        $method = $reflector->getMethod('_defaultHeaders');
-        $method->setAccessible(true);
+        TelemetryId::reset();
 
         $originalTelemetry = Stripe::getEnableTelemetry();
+        Stripe::setEnableTelemetry(true);
 
         try {
-            Stripe::setEnableTelemetry(true);
-            $headersEnabled = $method->invoke(null, 'sk_test_notarealkey');
-            $uaEnabled = \json_decode($headersEnabled['X-Stripe-Client-User-Agent'], true);
+            $reflector = new \ReflectionClass(ApiRequestor::class);
+            $method = $reflector->getMethod('_defaultHeaders');
+            $method->setAccessible(true);
 
-            Stripe::setEnableTelemetry(false);
-            $headersDisabled = $method->invoke(null, 'sk_test_notarealkey');
-            $uaDisabled = \json_decode($headersDisabled['X-Stripe-Client-User-Agent'], true);
+            $headers = $method->invoke(null, 'sk_test_notarealkey');
 
-            // source presence is independent of the telemetry flag:
-            // both calls should agree on whether source is present
-            self::assertSame(
-                \array_key_exists('source', $uaEnabled),
-                \array_key_exists('source', $uaDisabled),
-                'source presence should not depend on the telemetry flag'
-            );
+            $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
+            if (\array_key_exists('telemetry_id', $ua)) {
+                // telemetry_id is a 32-char hex string (16 random bytes as hex)
+                self::assertTrue(
+                    (bool) \preg_match('/^[0-9a-f]{32}$/', $ua['telemetry_id']),
+                    'Expected telemetry_id to be a 32-char hex string, got: ' . $ua['telemetry_id']
+                );
+            }
         } finally {
             Stripe::setEnableTelemetry($originalTelemetry);
+            TelemetryId::reset();
         }
     }
 
-    public function testDefaultHeadersOmitSourceWhenPhpUnameDisabled()
+    public function testDefaultHeadersOmitTelemetryIdWhenTelemetryDisabled()
     {
         $this->clearAgentEnvVars();
+        TelemetryId::reset();
 
-        // Verify that _isDisabled correctly identifies php_uname as disabled,
-        // and that when it is, _defaultHeaders does not set source to a sentinel
-        // string — it either omits source or sets it to a valid MD5 hash.
-        //
-        // We cannot force php_uname into disable_functions at runtime (it is a
-        // PHP ini setting), and the static $cachedSource variable inside
-        // _defaultHeaders is initialised once per process, so we verify the
-        // contract indirectly: source must never be the old sentinel '(disabled)'.
-        $reflector = new \ReflectionClass(ApiRequestor::class);
-        $method = $reflector->getMethod('_defaultHeaders');
-        $method->setAccessible(true);
+        $originalTelemetry = Stripe::getEnableTelemetry();
+        Stripe::setEnableTelemetry(false);
 
-        $headers = $method->invoke(null, 'sk_test_notarealkey');
+        try {
+            $reflector = new \ReflectionClass(ApiRequestor::class);
+            $method = $reflector->getMethod('_defaultHeaders');
+            $method->setAccessible(true);
 
-        $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
-        if (\array_key_exists('source', $ua)) {
-            self::assertNotSame(
-                '(disabled)',
-                $ua['source'],
-                'source must not be set to the sentinel string "(disabled)"; it should be omitted when php_uname is disabled'
-            );
-            self::assertTrue(
-                (bool) \preg_match('/^[0-9a-f]{32}$/', $ua['source']),
-                'When source is present it must be a 32-char lowercase hex MD5, got: ' . $ua['source']
-            );
-        } else {
-            // source is absent — this is the correct behaviour when php_uname is disabled
-            self::assertArrayNotHasKey('source', $ua);
+            $headers = $method->invoke(null, 'sk_test_notarealkey');
+
+            $ua = \json_decode($headers['X-Stripe-Client-User-Agent'], true);
+            self::assertArrayNotHasKey('telemetry_id', $ua);
+        } finally {
+            Stripe::setEnableTelemetry($originalTelemetry);
+            TelemetryId::reset();
         }
     }
 

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -492,7 +492,7 @@ final class CurlClientTest extends \Stripe\TestCase
     public function testExecuteStreamingRequestWithRetriesRetries()
     {
         if (\PHP_OS_FAMILY === 'Windows') {
-            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+            self::markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
         }
         $serverCode = <<<'EOF'
 <?php
@@ -532,7 +532,7 @@ EOF;
     public function testExecuteStreamingRequestWithRetriesHandlesDisconnect()
     {
         if (\PHP_OS_FAMILY === 'Windows') {
-            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+            self::markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
         }
         $serverCode = <<<'EOF'
 <?php
@@ -574,7 +574,7 @@ EOF;
     public function testExecuteStreamingRequestWithRetriesPersistentConnection()
     {
         if (\PHP_OS_FAMILY === 'Windows') {
-            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+            self::markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
         }
         $curl = new CurlClient();
         $coupon = \Stripe\Coupon::retrieve('coupon_xyz');

--- a/tests/Stripe/HttpClient/CurlClientTest.php
+++ b/tests/Stripe/HttpClient/CurlClientTest.php
@@ -491,6 +491,9 @@ final class CurlClientTest extends \Stripe\TestCase
 
     public function testExecuteStreamingRequestWithRetriesRetries()
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+        }
         $serverCode = <<<'EOF'
 <?php
 http_response_code(500);
@@ -528,6 +531,9 @@ EOF;
 
     public function testExecuteStreamingRequestWithRetriesHandlesDisconnect()
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+        }
         $serverCode = <<<'EOF'
 <?php
 http_response_code(200);
@@ -567,6 +573,9 @@ EOF;
 
     public function testExecuteStreamingRequestWithRetriesPersistentConnection()
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('TestServer uses pkill/kill which are unavailable on Windows');
+        }
         $curl = new CurlClient();
         $coupon = \Stripe\Coupon::retrieve('coupon_xyz');
 

--- a/tests/Stripe/StripeObjectTest.php
+++ b/tests/Stripe/StripeObjectTest.php
@@ -192,11 +192,7 @@ final class StripeObjectTest extends TestCase
         $s->foo = 'a';
 
         $string = (string) $s;
-        $expected = <<<'EOS'
-Stripe\StripeObject JSON: {
-    "foo": "a"
-}
-EOS;
+        $expected = "Stripe\\StripeObject JSON: {\n    \"foo\": \"a\"\n}";
         self::assertSame($expected, $string);
     }
 

--- a/tests/Stripe/TelemetryIdTest.php
+++ b/tests/Stripe/TelemetryIdTest.php
@@ -142,7 +142,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetConfigDirUsesXdgConfigHome()
     {
         if (self::isWindows()) {
-            $this->markTestSkipped('XDG is not used on Windows');
+            self::markTestSkipped('XDG is not used on Windows');
         }
         \putenv('XDG_CONFIG_HOME=/custom/xdg');
         $dir = TelemetryId::getConfigDir();
@@ -152,7 +152,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetConfigDirFallsBackToHome()
     {
         if (self::isWindows()) {
-            $this->markTestSkipped('XDG is not used on Windows');
+            self::markTestSkipped('XDG is not used on Windows');
         }
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME=/home/testuser');
@@ -163,7 +163,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetConfigDirReturnsNullWhenNoHome()
     {
         if (self::isWindows()) {
-            $this->markTestSkipped('XDG is not used on Windows');
+            self::markTestSkipped('XDG is not used on Windows');
         }
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME');

--- a/tests/Stripe/TelemetryIdTest.php
+++ b/tests/Stripe/TelemetryIdTest.php
@@ -106,6 +106,25 @@ final class TelemetryIdTest extends TestCase
         }
     }
 
+    public function testGetCreatesParentDirectoriesIfMissing()
+    {
+        $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
+        $nestedDir = $tmpDir . \DIRECTORY_SEPARATOR . 'nested' . \DIRECTORY_SEPARATOR . 'deep';
+        \putenv('XDG_CONFIG_HOME=' . $nestedDir);
+
+        try {
+            self::assertDirectoryNotExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe');
+
+            $id = TelemetryId::get();
+
+            self::assertNotNull($id);
+            self::assertDirectoryExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe');
+            self::assertFileExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe' . \DIRECTORY_SEPARATOR . 'telemetry_id');
+        } finally {
+            self::cleanupDir($tmpDir);
+        }
+    }
+
     public function testGetConfigDirUsesXdgConfigHome()
     {
         \putenv('XDG_CONFIG_HOME=/custom/xdg');

--- a/tests/Stripe/TelemetryIdTest.php
+++ b/tests/Stripe/TelemetryIdTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ *
+ * @covers \Stripe\TelemetryId
+ */
+final class TelemetryIdTest extends TestCase
+{
+    /**
+     * @after
+     */
+    public function resetTelemetryId()
+    {
+        TelemetryId::reset();
+        // Clean up any env vars we set during tests
+        \putenv('XDG_CONFIG_HOME');
+        \putenv('HOME');
+        \putenv('APPDATA');
+    }
+
+    public function testGetReturnsHexString()
+    {
+        $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
+        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+
+        try {
+            $id = TelemetryId::get();
+            self::assertNotNull($id);
+            self::assertTrue(
+                (bool) \preg_match('/^[0-9a-f]{32}$/', $id),
+                'Expected telemetry_id to be a 32-char hex string, got: ' . $id
+            );
+        } finally {
+            self::cleanupDir($tmpDir);
+        }
+    }
+
+    public function testGetReturnsSameValueOnSubsequentCalls()
+    {
+        $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
+        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+
+        try {
+            $first = TelemetryId::get();
+            $second = TelemetryId::get();
+            self::assertSame($first, $second, 'Subsequent calls should return the same telemetry_id');
+        } finally {
+            self::cleanupDir($tmpDir);
+        }
+    }
+
+    public function testGetReturnsSameValueAfterReset()
+    {
+        $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
+        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+
+        try {
+            $first = TelemetryId::get();
+
+            // reset in-memory cache but keep the file
+            TelemetryId::reset();
+
+            $second = TelemetryId::get();
+            self::assertSame($first, $second, 'After reset, should read the same id from disk');
+        } finally {
+            self::cleanupDir($tmpDir);
+        }
+    }
+
+    public function testGetReturnsNullWhenNoHomeDir()
+    {
+        // Remove all config dir env vars so getConfigDir() returns null
+        \putenv('XDG_CONFIG_HOME');
+        \putenv('HOME');
+        // On Windows APPDATA would matter, but on Unix we unset HOME and XDG_CONFIG_HOME
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $id = TelemetryId::get();
+            self::assertNull($id, 'Should return null when no home directory is available');
+        } else {
+            \putenv('APPDATA');
+            $id = TelemetryId::get();
+            self::assertNull($id, 'Should return null when APPDATA is not set on Windows');
+        }
+    }
+
+    public function testResetClearsCache()
+    {
+        $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
+        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+
+        try {
+            $first = TelemetryId::get();
+            TelemetryId::reset();
+
+            // Delete the file so a new id is generated
+            $filePath = $tmpDir . \DIRECTORY_SEPARATOR . 'stripe' . \DIRECTORY_SEPARATOR . 'telemetry_id';
+            @\unlink($filePath);
+
+            $second = TelemetryId::get();
+            self::assertNotSame($first, $second, 'After reset and file deletion, a new id should be generated');
+        } finally {
+            self::cleanupDir($tmpDir);
+        }
+    }
+
+    public function testGetConfigDirUsesXdgConfigHome()
+    {
+        \putenv('XDG_CONFIG_HOME=/custom/xdg');
+        $dir = TelemetryId::getConfigDir();
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            self::assertSame('/custom/xdg' . \DIRECTORY_SEPARATOR . 'stripe', $dir);
+        }
+    }
+
+    public function testGetConfigDirFallsBackToHome()
+    {
+        \putenv('XDG_CONFIG_HOME');
+        \putenv('HOME=/home/testuser');
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $dir = TelemetryId::getConfigDir();
+            self::assertSame('/home/testuser/.config/stripe', $dir);
+        }
+    }
+
+    public function testGetConfigDirReturnsNullWhenNoHome()
+    {
+        \putenv('XDG_CONFIG_HOME');
+        \putenv('HOME');
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $dir = TelemetryId::getConfigDir();
+            self::assertNull($dir);
+        }
+    }
+
+    /**
+     * Recursively remove a directory.
+     *
+     * @param string $dir
+     */
+    private static function cleanupDir($dir)
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+        $files = \scandir($dir);
+        foreach ($files as $file) {
+            if ('.' === $file || '..' === $file) {
+                continue;
+            }
+            $path = $dir . \DIRECTORY_SEPARATOR . $file;
+            if (\is_dir($path)) {
+                self::cleanupDir($path);
+            } else {
+                @\unlink($path);
+            }
+        }
+        @\rmdir($dir);
+    }
+}

--- a/tests/Stripe/TelemetryIdTest.php
+++ b/tests/Stripe/TelemetryIdTest.php
@@ -9,13 +9,31 @@ namespace Stripe;
  */
 final class TelemetryIdTest extends TestCase
 {
+    private static function isWindows()
+    {
+        return \PHP_OS_FAMILY === 'Windows';
+    }
+
+    private static function stripeSubdir()
+    {
+        return self::isWindows() ? 'Stripe' : 'stripe';
+    }
+
+    private function setConfigEnv($path)
+    {
+        if (self::isWindows()) {
+            \putenv('APPDATA=' . $path);
+        } else {
+            \putenv('XDG_CONFIG_HOME=' . $path);
+        }
+    }
+
     /**
      * @after
      */
     public function resetTelemetryId()
     {
         TelemetryId::reset();
-        // Clean up any env vars we set during tests
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME');
         \putenv('APPDATA');
@@ -24,7 +42,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetReturnsHexString()
     {
         $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
-        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+        $this->setConfigEnv($tmpDir);
 
         try {
             $id = TelemetryId::get();
@@ -41,7 +59,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetReturnsSameValueOnSubsequentCalls()
     {
         $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
-        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+        $this->setConfigEnv($tmpDir);
 
         try {
             $first = TelemetryId::get();
@@ -55,7 +73,7 @@ final class TelemetryIdTest extends TestCase
     public function testGetReturnsSameValueAfterReset()
     {
         $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
-        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+        $this->setConfigEnv($tmpDir);
 
         try {
             $first = TelemetryId::get();
@@ -72,31 +90,25 @@ final class TelemetryIdTest extends TestCase
 
     public function testGetReturnsNullWhenNoHomeDir()
     {
-        // Remove all config dir env vars so getConfigDir() returns null
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME');
-        // On Windows APPDATA would matter, but on Unix we unset HOME and XDG_CONFIG_HOME
-        if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $id = TelemetryId::get();
-            self::assertNull($id, 'Should return null when no home directory is available');
-        } else {
-            \putenv('APPDATA');
-            $id = TelemetryId::get();
-            self::assertNull($id, 'Should return null when APPDATA is not set on Windows');
-        }
+        \putenv('APPDATA');
+        $id = TelemetryId::get();
+        self::assertNull($id, 'Should return null when no config directory is available');
     }
 
     public function testResetClearsCache()
     {
         $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
-        \putenv('XDG_CONFIG_HOME=' . $tmpDir);
+        $this->setConfigEnv($tmpDir);
 
         try {
             $first = TelemetryId::get();
             TelemetryId::reset();
 
             // Delete the file so a new id is generated
-            $filePath = $tmpDir . \DIRECTORY_SEPARATOR . 'stripe' . \DIRECTORY_SEPARATOR . 'telemetry_id';
+            $subdir = self::stripeSubdir();
+            $filePath = $tmpDir . \DIRECTORY_SEPARATOR . $subdir . \DIRECTORY_SEPARATOR . 'telemetry_id';
             @\unlink($filePath);
 
             $second = TelemetryId::get();
@@ -110,16 +122,18 @@ final class TelemetryIdTest extends TestCase
     {
         $tmpDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'stripe_test_' . \bin2hex(\random_bytes(8));
         $nestedDir = $tmpDir . \DIRECTORY_SEPARATOR . 'nested' . \DIRECTORY_SEPARATOR . 'deep';
-        \putenv('XDG_CONFIG_HOME=' . $nestedDir);
+        $this->setConfigEnv($nestedDir);
+
+        $subdir = self::stripeSubdir();
 
         try {
-            self::assertDirectoryNotExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe');
+            self::assertDirectoryNotExists($nestedDir . \DIRECTORY_SEPARATOR . $subdir);
 
             $id = TelemetryId::get();
 
             self::assertNotNull($id);
-            self::assertDirectoryExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe');
-            self::assertFileExists($nestedDir . \DIRECTORY_SEPARATOR . 'stripe' . \DIRECTORY_SEPARATOR . 'telemetry_id');
+            self::assertDirectoryExists($nestedDir . \DIRECTORY_SEPARATOR . $subdir);
+            self::assertFileExists($nestedDir . \DIRECTORY_SEPARATOR . $subdir . \DIRECTORY_SEPARATOR . 'telemetry_id');
         } finally {
             self::cleanupDir($tmpDir);
         }
@@ -127,31 +141,34 @@ final class TelemetryIdTest extends TestCase
 
     public function testGetConfigDirUsesXdgConfigHome()
     {
+        if (self::isWindows()) {
+            $this->markTestSkipped('XDG is not used on Windows');
+        }
         \putenv('XDG_CONFIG_HOME=/custom/xdg');
         $dir = TelemetryId::getConfigDir();
-        if ('\\' !== \DIRECTORY_SEPARATOR) {
-            self::assertSame('/custom/xdg' . \DIRECTORY_SEPARATOR . 'stripe', $dir);
-        }
+        self::assertSame('/custom/xdg/stripe', $dir);
     }
 
     public function testGetConfigDirFallsBackToHome()
     {
+        if (self::isWindows()) {
+            $this->markTestSkipped('XDG is not used on Windows');
+        }
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME=/home/testuser');
-        if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $dir = TelemetryId::getConfigDir();
-            self::assertSame('/home/testuser/.config/stripe', $dir);
-        }
+        $dir = TelemetryId::getConfigDir();
+        self::assertSame('/home/testuser/.config/stripe', $dir);
     }
 
     public function testGetConfigDirReturnsNullWhenNoHome()
     {
+        if (self::isWindows()) {
+            $this->markTestSkipped('XDG is not used on Windows');
+        }
         \putenv('XDG_CONFIG_HOME');
         \putenv('HOME');
-        if ('\\' !== \DIRECTORY_SEPARATOR) {
-            $dir = TelemetryId::getConfigDir();
-            self::assertNull($dir);
-        }
+        $dir = TelemetryId::getConfigDir();
+        self::assertNull($dir);
     }
 
     /**


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
