### PR TITLE
supress warnings when we can't access a directory

### DIFF
--- a/lib/TelemetryId.php
+++ b/lib/TelemetryId.php
@@ -27,7 +27,7 @@ class TelemetryId
 
         $filePath = self::joinPath($configDir, 'telemetry_id');
 
-        if (\file_exists($filePath)) {
+        if (@\file_exists($filePath)) {
             $content = @\file_get_contents($filePath);
             if (false !== $content) {
                 $content = \trim($content);
@@ -41,7 +41,7 @@ class TelemetryId
 
         self::$cachedId = \bin2hex(\random_bytes(16));
 
-        if (!\is_dir($configDir)) {
+        if (!@\is_dir($configDir)) {
             if (!@\mkdir($configDir, 0700, true)) {
                 self::$cachedId = null;
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We print a warning if we can't read/write the config directory. We already handle not being able to read/write gracefully, so we don't need to junk up the logs.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- adds PHP's warning suppressor to telemetry-related file access. 

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-php/issues/2109
- [RUN_DEVSDK-2644](https://go/j/RUN_DEVSDK-2644)