### PR TITLE
Add `stripe.major_api_version` constant

### DIFF
--- a/lib/Stripe.php
+++ b/lib/Stripe.php
@@ -25,6 +25,9 @@ class Stripe
     /** @var string The version of the Stripe API to use for requests. */
     public static $apiVersion = Util\ApiVersion::CURRENT;
 
+    /** @var string The major API version (release train). */
+    public static $majorApiVersion = Util\ApiVersion::CURRENT_MAJOR;
+
     /** @var null|string The account ID for connected accounts requests. */
     public static $accountId = null;
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been generating information about the current API version into the SDKs for a while (codegen PR `2555`), but accidentally didn't make those constants user-facing.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- adds a user-facing `major_api_version` constant set to the generated value (currently `"dahlia"`)

### See Also

<!-- Include any links or additional information that help explain this change. -->

- (originally from https://github.com/stripe/stripe-java/issues/2001)
