### PR TITLE
Surface `object` property on `EventNotification`

### DIFF
--- a/lib/V2/Core/EventNotification.php
+++ b/lib/V2/Core/EventNotification.php
@@ -13,6 +13,7 @@ use Stripe\Util\EventNotificationTypes;
  * If you want more details, use `$stripeClient->v2->core->events->retrieve(thin_event.id)` to fetch the full event object.
  *
  * @property string             $id       Unique identifier for the event.
+ * @property string             $object   String representing the object's type. Objects of the same type share the same value.
  * @property string             $type     The type of the event.
  * @property string             $created  Time at which the object was created.
  * @property null|\Stripe\StripeContext        $context  Authentication context needed to fetch the event or related object.
@@ -22,6 +23,7 @@ use Stripe\Util\EventNotificationTypes;
 abstract class EventNotification
 {
     public $id;
+    public $object;
     public $type;
     public $created;
     public $context;
@@ -42,6 +44,9 @@ abstract class EventNotification
 
         if (\array_key_exists('id', $json)) {
             $this->id = $json['id'];
+        }
+        if (\array_key_exists('object', $json)) {
+            $this->object = $json['object'];
         }
         if (\array_key_exists('type', $json)) {
             $this->type = $json['type'];

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -856,6 +856,7 @@ final class BaseStripeClientTest extends TestCase
         $event = $client->parseEventNotification($eventData, $sigHeader, WebhookTest::SECRET);
 
         self::assertSame('evt_234', $event->id);
+        self::assertSame('v2.core.event', $event->object);
         self::assertSame('v1.billing.meter.error_report_triggered', $event->type);
         self::assertSame('acct_123', (string) $event->context);
         self::assertSame('2022-02-15T00:27:45.330Z', $event->created);


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`object` is present in the original payload, but we didn't surface it on the `EventNotification` class. Because `"v2.core.event"` is the only value that will ever be present, It didn't seem worth adding it to the interface.

I also wanted to better differentiate `EventNotification`s from all other `StripeObject`s (since they _do_ behave differently).

But, that also means interacting with it along with other objects is unnecessarily complicated. From the [original ruby issue](https://github.com/stripe/stripe-ruby/issues/1860):

```rb
def v1?(event)
  (event.try(:object) || event.try(:dig, "object")) == "event"
end

def v2?(event)
  event.is_a?(::Stripe::V2::Core::EventNotification) || # thin event notification
    (event.try(:object) || event.try(:dig, "object")) == "v2.core.event"
end
```

Because the value is present in the original response, it doesn't make sense to eat it.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add public `object` property to `EventNotification`
- add test

### See Also

<!-- Include any links or additional information that help explain this change. -->

- originally brought up in [stripe/stripe-ruby#1860](https://github.com/stripe/stripe-ruby/issues/1860)
- [DEVSDK-3101](https://go/j/DEVSDK-3101)
