### PR TITLE
Add new `EventNotificationHandler` class for better thin event management

### DIFF
--- a/examples/EventNotificationHandlerEndpoint.php
+++ b/examples/EventNotificationHandlerEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * event_notification_handler_endpoint.py - receive and process event notifications (AKA thin events) like "v1.billing.meter.error_report_triggered" using EventNotificationHandler.
+ * In this example, we:
+ *     - write a fallback callback to handle unrecognized event notifications
+ *     - create a StripeClient called client
+ *     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+ *     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
+ *     - use handler->handle() to process the received notification webhook body.
+ */
+require 'vendor/autoload.php';
+
+$api_key = getenv('STRIPE_API_KEY');
+$webhook_secret = getenv('WEBHOOK_SECRET');
+
+$app = new Slim\App();
+$client = new Stripe\StripeClient($api_key);
+
+$handler = $client->notificationHandler($webhook_secret, static function ($event_notification, $client, $details) {
+    echo "Received event notification of type {$event_notification->type}\n";
+});
+
+$handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
+    $meter = $event_notification->fetchRelatedObject();
+    echo "Handling V1BillingMeterErrorReportTriggeredEventNotification for meter: {$meter->name}\n";
+});
+
+// Handles events delivered through a channel that has already authenticated them, such as
+// AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+// this handler skips verification. Callbacks are registered separately from the one above.
+$unverified_handler = $client->notificationHandlerWithoutVerification(static function ($event_notification, $client, $details) {
+    echo "Received event notification of type {$event_notification->type}\n";
+});
+
+$unverified_handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
+    $meter = $event_notification->fetchRelatedObject();
+    echo "Handling V1BillingMeterErrorReportTriggeredEventNotification for meter: {$meter->name}\n";
+});
+
+$app->post('/webhook', static function ($request, $response) use ($handler) {
+    $webhook_body = $request->getBody()->getContents();
+    $sig_header = $request->getHeaderLine('Stripe-Signature');
+
+    try {
+        $handler->handle($webhook_body, $sig_header);
+
+        return $response->withStatus(200);
+    } catch (Exception $e) {
+        return $response->withStatus(400)->withJson(['error' => $e->getMessage()]);
+    }
+});
+
+$app->post('/webhook-from-cloud-provider', static function ($request, $response) use ($unverified_handler) {
+    // handle() takes only the body here; there's no signature to check
+    try {
+        $unverified_handler->handle($request->getBody()->getContents());
+
+        return $response->withStatus(200);
+    } catch (Exception $e) {
+        return $response->withStatus(400)->withJson(['error' => $e->getMessage()]);
+    }
+});
+
+$app->run();

--- a/init.php
+++ b/init.php
@@ -94,6 +94,12 @@ require __DIR__ . '/lib/StripeStreamingClientInterface.php';
 require __DIR__ . '/lib/BaseStripeClient.php';
 require __DIR__ . '/lib/StripeClient.php';
 
+// EventRouter
+require __DIR__ . '/lib/UnhandledNotificationDetails.php';
+require __DIR__ . '/lib/AbstractEventNotificationHandler.php';
+require __DIR__ . '/lib/StripeEventNotificationHandler.php';
+require __DIR__ . '/lib/StripeEventNotificationHandlerWithoutVerification.php';
+
 // The beginning of the section generated from our OpenAPI spec
 require __DIR__ . '/lib/Account.php';
 require __DIR__ . '/lib/AccountLink.php';

--- a/lib/AbstractEventNotificationHandler.php
+++ b/lib/AbstractEventNotificationHandler.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * Shared registration and dispatch machinery for StripeEventNotificationHandler and
+ * StripeEventNotificationHandlerWithoutVerification.
+ *
+ * Deliberately declares no handle(). PHP requires an override to stay compatible with
+ * the parent's parameter list, so neither handler can subclass the other without
+ * carrying a parameter it doesn't want; as siblings, each declares its own signature.
+ *
+ * @internal implementation detail; do not depend on this class directly
+ */
+abstract class AbstractEventNotificationHandler
+{
+    /** @var array<string, callable> */
+    protected $registeredHandlers = [];
+    /** @var StripeClient */
+    protected $client;
+    protected $hasHandledEvents = false;
+    protected $fallbackCallback;
+    /** @var array<string, mixed> everything we need to duplicate a client */
+    protected $clientConfig;
+
+    /**
+     * @param StripeClient $client The Stripe client to use for API interactions
+     * @param callable(Events\UnknownEventNotification, StripeClient, UnhandledNotificationDetails): void $fallbackCallback A callback that's invoked for unhandled events
+     */
+    public function __construct($client, $fallbackCallback)
+    {
+        $this->client = $client;
+        $this->fallbackCallback = $fallbackCallback;
+
+        // Extract configuration from the client for creating new instances
+        $this->clientConfig = [
+            'api_key' => $client->getApiKey(),
+            'client_id' => $client->getClientId(),
+            'stripe_account' => $client->getStripeAccount(),
+            'stripe_version' => $client->getStripeVersion(),
+            'api_base' => $client->getApiBase(),
+            'connect_base' => $client->getConnectBase(),
+            'files_base' => $client->getFilesBase(),
+            'meter_events_base' => $client->getMeterEventsBase(),
+            'max_network_retries' => $client->getMaxNetworkRetries(),
+            'app_info' => $client->getAppInfo(),
+        ];
+    }
+
+    /**
+     * Returns a sorted list of registered event types.
+     *
+     * @return string[] List of registered event type strings
+     */
+    public function getRegisteredHandlers()
+    {
+        $eventTypes = array_keys($this->registeredHandlers);
+        \sort($eventTypes);
+
+        return $eventTypes;
+    }
+
+    /**
+     * Dispatches a parsed event notification to the appropriate handler.
+     *
+     * @param V2\Core\EventNotification $notif The parsed event notification
+     *
+     * @return void
+     */
+    protected function dispatch($notif)
+    {
+        $eventType = $notif->type;
+
+        // Create a new client instance with the event's context instead of modifying the shared client
+        $eventClient = $this->createClientWithContext($notif->context);
+
+        if (isset($this->registeredHandlers[$eventType])) {
+            \call_user_func($this->registeredHandlers[$eventType], $notif, $eventClient);
+        } else {
+            \call_user_func($this->fallbackCallback, $notif, $eventClient, new UnhandledNotificationDetails(!$notif instanceof Events\UnknownEventNotification));
+        }
+    }
+
+    /**
+     * Creates a new StripeClient instance with the specified stripe_context.
+     *
+     * @param null|string $context The stripe_context to use for the new client
+     *
+     * @return StripeClient A new StripeClient instance with the specified context
+     */
+    protected function createClientWithContext($context)
+    {
+        $config = $this->clientConfig;
+        $config['stripe_context'] = $context;
+
+        return new StripeClient($config);
+    }
+
+    /**
+     * Registers a handler for a specific event type.
+     *
+     * @param string $eventType The event type to register the handler for
+     * @param callable $handler The handler function to call when the event is received
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    protected function register($eventType, $handler)
+    {
+        if ($this->hasHandledEvents) {
+            throw new Exception\BadMethodCallException('Cannot register new event handlers after .handle() has been called. This is indicative of a bug.');
+        }
+        if (isset($this->registeredHandlers[$eventType])) {
+            throw new Exception\InvalidArgumentException("Handler for event type \"{$eventType}\" is already registered");
+        }
+
+        $this->registeredHandlers[$eventType] = $handler;
+    }
+
+    // event-handler-methods: The beginning of the section generated from our OpenAPI spec
+    /**
+     * Registers a handler for the "v1.billing.meter.error_report_triggered" event.
+     *
+     * @param callable(Events\V1BillingMeterErrorReportTriggeredEvent, StripeClient): void $handler Handles v1.billing.meter.error_report_triggered events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV1BillingMeterErrorReportTriggered($handler)
+    {
+        $this->register('v1.billing.meter.error_report_triggered', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v1.billing.meter.no_meter_found" event.
+     *
+     * @param callable(Events\V1BillingMeterNoMeterFoundEvent, StripeClient): void $handler Handles v1.billing.meter.no_meter_found events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV1BillingMeterNoMeterFound($handler)
+    {
+        $this->register('v1.billing.meter.no_meter_found', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.commerce.product_catalog.imports.failed" event.
+     *
+     * @param callable(Events\V2CommerceProductCatalogImportsFailedEvent, StripeClient): void $handler Handles v2.commerce.product_catalog.imports.failed events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CommerceProductCatalogImportsFailed($handler)
+    {
+        $this->register('v2.commerce.product_catalog.imports.failed', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.commerce.product_catalog.imports.processing" event.
+     *
+     * @param callable(Events\V2CommerceProductCatalogImportsProcessingEvent, StripeClient): void $handler Handles v2.commerce.product_catalog.imports.processing events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CommerceProductCatalogImportsProcessing($handler)
+    {
+        $this->register('v2.commerce.product_catalog.imports.processing', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.commerce.product_catalog.imports.succeeded" event.
+     *
+     * @param callable(Events\V2CommerceProductCatalogImportsSucceededEvent, StripeClient): void $handler Handles v2.commerce.product_catalog.imports.succeeded events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CommerceProductCatalogImportsSucceeded($handler)
+    {
+        $this->register('v2.commerce.product_catalog.imports.succeeded', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.commerce.product_catalog.imports.succeeded_with_errors" event.
+     *
+     * @param callable(Events\V2CommerceProductCatalogImportsSucceededWithErrorsEvent, StripeClient): void $handler Handles v2.commerce.product_catalog.imports.succeeded_with_errors events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CommerceProductCatalogImportsSucceededWithErrors(
+        $handler
+    ) {
+        $this->register(
+            'v2.commerce.product_catalog.imports.succeeded_with_errors',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account.closed" event.
+     *
+     * @param callable(Events\V2CoreAccountClosedEvent, StripeClient): void $handler Handles v2.core.account.closed events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountClosed($handler)
+    {
+        $this->register('v2.core.account.closed', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account.created" event.
+     *
+     * @param callable(Events\V2CoreAccountCreatedEvent, StripeClient): void $handler Handles v2.core.account.created events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountCreated($handler)
+    {
+        $this->register('v2.core.account.created', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account.updated" event.
+     *
+     * @param callable(Events\V2CoreAccountUpdatedEvent, StripeClient): void $handler Handles v2.core.account.updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountUpdated($handler)
+    {
+        $this->register('v2.core.account.updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.customer].capability_status_updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.customer].capability_status_updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.customer].capability_status_updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.customer].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationCustomerUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.customer].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationCustomerUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.customer].updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.merchant].capability_status_updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.merchant].capability_status_updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.merchant].capability_status_updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.merchant].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationMerchantUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.merchant].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationMerchantUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.merchant].updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.recipient].capability_status_updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.recipient].capability_status_updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.recipient].capability_status_updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[configuration.recipient].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingConfigurationRecipientUpdatedEvent, StripeClient): void $handler Handles v2.core.account[configuration.recipient].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingConfigurationRecipientUpdated(
+        $handler
+    ) {
+        $this->register(
+            'v2.core.account[configuration.recipient].updated',
+            $handler
+        );
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[defaults].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingDefaultsUpdatedEvent, StripeClient): void $handler Handles v2.core.account[defaults].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingDefaultsUpdated($handler)
+    {
+        $this->register('v2.core.account[defaults].updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[future_requirements].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingFutureRequirementsUpdatedEvent, StripeClient): void $handler Handles v2.core.account[future_requirements].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingFutureRequirementsUpdated($handler)
+    {
+        $this->register('v2.core.account[future_requirements].updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[identity].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingIdentityUpdatedEvent, StripeClient): void $handler Handles v2.core.account[identity].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingIdentityUpdated($handler)
+    {
+        $this->register('v2.core.account[identity].updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account[requirements].updated" event.
+     *
+     * @param callable(Events\V2CoreAccountIncludingRequirementsUpdatedEvent, StripeClient): void $handler Handles v2.core.account[requirements].updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountIncludingRequirementsUpdated($handler)
+    {
+        $this->register('v2.core.account[requirements].updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account_link.returned" event.
+     *
+     * @param callable(Events\V2CoreAccountLinkReturnedEvent, StripeClient): void $handler Handles v2.core.account_link.returned events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountLinkReturned($handler)
+    {
+        $this->register('v2.core.account_link.returned', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account_person.created" event.
+     *
+     * @param callable(Events\V2CoreAccountPersonCreatedEvent, StripeClient): void $handler Handles v2.core.account_person.created events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountPersonCreated($handler)
+    {
+        $this->register('v2.core.account_person.created', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account_person.deleted" event.
+     *
+     * @param callable(Events\V2CoreAccountPersonDeletedEvent, StripeClient): void $handler Handles v2.core.account_person.deleted events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountPersonDeleted($handler)
+    {
+        $this->register('v2.core.account_person.deleted', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.account_person.updated" event.
+     *
+     * @param callable(Events\V2CoreAccountPersonUpdatedEvent, StripeClient): void $handler Handles v2.core.account_person.updated events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreAccountPersonUpdated($handler)
+    {
+        $this->register('v2.core.account_person.updated', $handler);
+    }
+
+    /**
+     * Registers a handler for the "v2.core.event_destination.ping" event.
+     *
+     * @param callable(Events\V2CoreEventDestinationPingEvent, StripeClient): void $handler Handles v2.core.event_destination.ping events
+     *
+     * @throws Exception\InvalidArgumentException if this event type is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function onV2CoreEventDestinationPing($handler)
+    {
+        $this->register('v2.core.event_destination.ping', $handler);
+    }
+    // event-handler-methods: The end of the section generated from our OpenAPI spec
+}

--- a/lib/BaseStripeClient.php
+++ b/lib/BaseStripeClient.php
@@ -143,6 +143,21 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     }
 
     /**
+     * FOR INTERNAL USE ONLY. MAY CHANGE WITHOUT WARNING. Gets the Stripe Context used by the client to send requests.
+     *
+     * @return null|string the Stripe Context used by the client to send requests
+     */
+    public function getStripeContextHeader()
+    {
+        // use opts instead of config because we modify the default opts and want to make sure we get fresh reads
+        if (!isset($this->defaultOpts->headers['Stripe-Context'])) {
+            return null;
+        }
+
+        return $this->defaultOpts->headers['Stripe-Context'];
+    }
+
+    /**
      * Gets the Stripe Version used by the client to send requests.
      *
      * @return null|string the Stripe Context ID used by the client to send requests
@@ -540,5 +555,31 @@ class BaseStripeClient implements StripeClientInterface, StripeStreamingClientIn
     public function parseEventNotificationWithoutVerification($payload)
     {
         return EventNotification::fromJson(Webhook::maybeExtractFromCloudProviderEnvelope($payload), $this);
+    }
+
+    /**
+     * Creates a new StripeEventNotificationHandler associated with this client.
+     *
+     * @param string $webhookSecret The webhook secret to use for verifying incoming webhook signatures
+     * @param callable(Events\UnknownEventNotification, StripeClient, UnhandledNotificationDetails): void $fallbackCallback a function to call if no other handler processes an event notification
+     *
+     * @return StripeEventNotificationHandler A new StripeEventNotificationHandler instance
+     */
+    public function notificationHandler($webhookSecret, $fallbackCallback)
+    {
+        return new StripeEventNotificationHandler($this, $webhookSecret, $fallbackCallback);
+    }
+
+    /**
+     * Creates a handler that processes events without webhook signature verification.
+     * Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+     *
+     * @param callable $fallbackCallback A callback that's invoked for unhandled events
+     *
+     * @return StripeEventNotificationHandlerWithoutVerification
+     */
+    public function notificationHandlerWithoutVerification($fallbackCallback)
+    {
+        return StripeEventNotificationHandler::withoutVerification($this, $fallbackCallback);
     }
 }

--- a/lib/StripeEventNotificationHandler.php
+++ b/lib/StripeEventNotificationHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Stripe;
+
+class StripeEventNotificationHandler extends AbstractEventNotificationHandler
+{
+    /** @var string */
+    private $webhookSecret;
+
+    /**
+     * Constructor for StripeEventNotificationHandler.
+     *
+     * @param StripeClient $client The Stripe client to use for API interactions
+     * @param string $webhookSecret The webhook secret for verifying signatures
+     * @param callable(Events\UnknownEventNotification, StripeClient, UnhandledNotificationDetails): void $fallbackCallback A callback that's invoked when
+     */
+    public function __construct($client, $webhookSecret, $fallbackCallback)
+    {
+        if (empty($webhookSecret)) {
+            throw new Exception\InvalidArgumentException('webhookSecret must be a non-empty string');
+        }
+
+        parent::__construct($client, $fallbackCallback);
+        $this->webhookSecret = $webhookSecret;
+    }
+
+    /**
+     * Creates a handler that processes events without webhook signature verification.
+     * Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+     *
+     * @param StripeClient $client The Stripe client to use for API interactions
+     * @param callable $fallbackCallback A callback that's invoked for unhandled events
+     *
+     * @return StripeEventNotificationHandlerWithoutVerification
+     */
+    public static function withoutVerification($client, $fallbackCallback)
+    {
+        return new StripeEventNotificationHandlerWithoutVerification($client, $fallbackCallback);
+    }
+
+    /**
+     * Handles an incoming webhook payload by dispatching to the appropriate registered handler, if available.
+     *
+     * @param string $payload The raw webhook payload
+     * @param string $sigHeader The value of the Stripe-Signature header
+     *
+     * @return void
+     *
+     * @throws Exception\UnexpectedValueException if no handler is registered for the event type
+     * @throws \Exception any exception that may be thrown by a registered function
+     */
+    public function handle($payload, $sigHeader)
+    {
+        // we're ok with this write being naiive because the expectation is that users register functions
+        $this->hasHandledEvents = true;
+
+        $notif = $this->client->parseEventNotification(
+            $payload,
+            $sigHeader,
+            $this->webhookSecret
+        );
+
+        $this->dispatch($notif);
+    }
+}

--- a/lib/StripeEventNotificationHandlerWithoutVerification.php
+++ b/lib/StripeEventNotificationHandlerWithoutVerification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * A variant of StripeEventNotificationHandler that parses events without
+ * verifying webhook signatures. Intended for pre-authenticated channels
+ * like AWS EventBridge or Azure Event Grid.
+ *
+ * Because this is a sibling of StripeEventNotificationHandler rather than a subclass,
+ * handle() takes only the payload; there is no vestigial signature parameter.
+ *
+ * Prefer StripeEventNotificationHandler::withoutVerification() or
+ * $client->notificationHandlerWithoutVerification() to construct one.
+ */
+class StripeEventNotificationHandlerWithoutVerification extends AbstractEventNotificationHandler
+{
+    /**
+     * Handles an incoming webhook payload without signature verification.
+     *
+     * @param string $payload The raw webhook payload
+     *
+     * @return void
+     */
+    public function handle($payload)
+    {
+        $this->hasHandledEvents = true;
+
+        $notif = $this->client->parseEventNotificationWithoutVerification($payload);
+
+        $this->dispatch($notif);
+    }
+}

--- a/lib/UnhandledNotificationDetails.php
+++ b/lib/UnhandledNotificationDetails.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stripe;
+
+class UnhandledNotificationDetails
+{
+    /** @var bool whether the SDK has types for this event */
+    public $isKnownEventType;
+
+    public function __construct($isKnownEventType)
+    {
+        $this->isKnownEventType = $isKnownEventType;
+    }
+}

--- a/tests/Stripe/StripeEventNotificationHandlerTest.php
+++ b/tests/Stripe/StripeEventNotificationHandlerTest.php
@@ -1,0 +1,675 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @internal
+ *
+ * @covers \Stripe\StripeEventNotificationHandler
+ */
+final class StripeEventNotificationHandlerTest extends TestCase
+{
+    use TestHelper;
+
+    const WEBHOOK_SECRET = 'whsec_test_secret';
+
+    /** @var StripeClient */
+    private $client;
+
+    /** @var callable */
+    private $fallbackCallback;
+
+    /** @var StripeEventNotificationHandler */
+    private $handler;
+
+    /**
+     * @before
+     */
+    public function setUpFixture()
+    {
+        $this->client = new StripeClient([
+            'api_key' => 'sk_test_123',
+            'stripe_context' => 'original_context_123',
+        ]);
+
+        $this->fallbackCallback = static function ($event, $client, $info) {
+            // Default no-op handler
+        };
+
+        $this->handler = new StripeEventNotificationHandler(
+            $this->client,
+            self::WEBHOOK_SECRET,
+            $this->fallbackCallback
+        );
+    }
+
+    private function generateHeader($payload)
+    {
+        return WebhookTest::generateHeader([
+            'payload' => $payload,
+            'secret' => self::WEBHOOK_SECRET,
+        ]);
+    }
+
+    private function getV1BillingMeterPayload()
+    {
+        return \json_encode([
+            'id' => 'evt_123',
+            'object' => 'v2.core.event',
+            'type' => 'v1.billing.meter.error_report_triggered',
+            'livemode' => false,
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => 'event_context_456',
+            'related_object' => [
+                'id' => 'mtr_123',
+                'type' => 'billing.meter',
+                'url' => '/v1/billing/meters/mtr_123',
+            ],
+        ]);
+    }
+
+    private function getV1BillingMeterNoMeterFoundPayload()
+    {
+        return \json_encode([
+            'id' => 'evt_456',
+            'object' => 'v2.core.event',
+            'type' => 'v1.billing.meter.no_meter_found',
+            'livemode' => false,
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => null,
+        ]);
+    }
+
+    private function getUnknownEventPayload()
+    {
+        return \json_encode([
+            'id' => 'evt_unknown',
+            'object' => 'v2.core.event',
+            'type' => 'llama.created',
+            'livemode' => false,
+            'created' => '2022-02-15T00:27:45.330Z',
+            'context' => 'event_context_unknown',
+            'related_object' => [
+                'id' => 'llama_123',
+                'type' => 'llama',
+                'url' => '/v1/llamas/llama_123',
+            ],
+        ]);
+    }
+
+    public function testRoutesEventToRegisteredHandler()
+    {
+        $callbackCalled = false;
+        $receivedEvent = null;
+
+        $callback = static function ($event, $client) use (&$callbackCalled, &$receivedEvent) {
+            $callbackCalled = true;
+            $receivedEvent = $event;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertTrue($callbackCalled);
+        self::assertInstanceOf(Events\V1BillingMeterErrorReportTriggeredEventNotification::class, $receivedEvent);
+    }
+
+    public function testRoutesDifferentEventsToCorrectHandlers()
+    {
+        $billingHandlerCalled = false;
+        $billingReceivedEvent = null;
+        $noMeterHandlerCalled = false;
+        $noMeterReceivedEvent = null;
+
+        $billingHandler = static function ($event, $client) use (&$billingHandlerCalled, &$billingReceivedEvent) {
+            $billingHandlerCalled = true;
+            $billingReceivedEvent = $event;
+        };
+
+        $noMeterHandler = static function ($event, $client) use (&$noMeterHandlerCalled, &$noMeterReceivedEvent) {
+            $noMeterHandlerCalled = true;
+            $noMeterReceivedEvent = $event;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($billingHandler);
+        $this->handler->onV1BillingMeterNoMeterFound($noMeterHandler);
+
+        $payload1 = $this->getV1BillingMeterPayload();
+        $sigHeader1 = $this->generateHeader($payload1);
+        $this->handler->handle($payload1, $sigHeader1);
+
+        $payload2 = $this->getV1BillingMeterNoMeterFoundPayload();
+        $sigHeader2 = $this->generateHeader($payload2);
+        $this->handler->handle($payload2, $sigHeader2);
+
+        self::assertTrue($billingHandlerCalled);
+        self::assertTrue($noMeterHandlerCalled);
+        self::assertInstanceOf(Events\V1BillingMeterErrorReportTriggeredEventNotification::class, $billingReceivedEvent);
+        self::assertInstanceOf(Events\V1BillingMeterNoMeterFoundEventNotification::class, $noMeterReceivedEvent);
+    }
+
+    public function testHandlerReceivesCorrectRuntimeType()
+    {
+        $receivedEvent = null;
+        $receivedClient = null;
+
+        $callback = static function ($event, $client) use (&$receivedEvent, &$receivedClient) {
+            $receivedEvent = $event;
+            $receivedClient = $client;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertInstanceOf(Events\V1BillingMeterErrorReportTriggeredEventNotification::class, $receivedEvent);
+        self::assertSame('v1.billing.meter.error_report_triggered', $receivedEvent->type);
+        self::assertSame('evt_123', $receivedEvent->id);
+        self::assertSame('mtr_123', $receivedEvent->related_object->id);
+        self::assertInstanceOf(StripeClient::class, $receivedClient);
+    }
+
+    public function testCannotRegisterHandlerAfterHandling()
+    {
+        $callback = static function ($event, $client) {
+            // no-op
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        $this->expectException(Exception\BadMethodCallException::class);
+        $this->compatExpectExceptionMessageMatches('/Cannot register new event handlers after .handle\(\) has been called/');
+
+        $this->handler->onV1BillingMeterNoMeterFound($callback);
+    }
+
+    public function testCannotRegisterDuplicateHandler()
+    {
+        $callback1 = static function ($event, $client) {
+            // no-op
+        };
+        $callback2 = static function ($event, $client) {
+            // no-op
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback1);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->compatExpectExceptionMessageMatches('/Handler for event type "v1.billing.meter.error_report_triggered" is already registered/');
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback2);
+    }
+
+    public function testHandlerUsesEventStripeContext()
+    {
+        $receivedContext = null;
+
+        $callback = static function ($event, $client) use (&$receivedContext) {
+            $receivedContext = $client->getStripeContextHeader();
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertSame('event_context_456', $receivedContext);
+    }
+
+    public function testStripeContextRestoredAfterHandlerSuccess()
+    {
+        $contextDuringHandler = null;
+
+        $callback = static function ($event, $client) use (&$contextDuringHandler) {
+            $contextDuringHandler = $client->getStripeContextHeader();
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertSame('event_context_456', $contextDuringHandler);
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+    }
+
+    public function testStripeContextRestoredAfterHandlerError()
+    {
+        $contextDuringHandler = null;
+
+        $callback = static function ($event, $client) use (&$contextDuringHandler) {
+            $contextDuringHandler = $client->getStripeContextHeader();
+
+            throw new \RuntimeException('Handler error!');
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Handler error!');
+
+        try {
+            $this->handler->handle($payload, $sigHeader);
+        } finally {
+            self::assertSame('event_context_456', $contextDuringHandler);
+            self::assertSame('original_context_123', $this->client->getStripeContext());
+        }
+    }
+
+    public function testStripeContextSetToNullWhenEventHasNoContext()
+    {
+        $receivedContext = 'not_set';
+
+        $callback = static function ($event, $client) use (&$receivedContext) {
+            $receivedContext = $client->getStripeContextHeader();
+        };
+
+        $this->handler->onV1BillingMeterNoMeterFound($callback);
+
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterNoMeterFoundPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertNull($receivedContext);
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+    }
+
+    public function testClientWithNoContextTemporarilyGetsEventContext()
+    {
+        $contextDuringHandler = 'not_set';
+
+        $client = new StripeClient(['api_key' => 'sk_test_123']);
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandler($client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $callback = static function ($event, $receivedClient) use (&$contextDuringHandler) {
+            $contextDuringHandler = $receivedClient->getStripeContextHeader();
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        // Client initially has no context
+        self::assertNull($client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        // During handler, context was set to event's context
+        self::assertSame('event_context_456', $contextDuringHandler);
+
+        // After handler, context is restored to null
+        self::assertNull($client->getStripeContext());
+    }
+
+    public function testUnknownEventRoutesToOnUnhandled()
+    {
+        $onUnhandledCalled = false;
+        $receivedEvent = null;
+        $receivedClient = null;
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$onUnhandledCalled, &$receivedEvent, &$receivedClient, &$receivedInfo) {
+            $onUnhandledCalled = true;
+            $receivedEvent = $event;
+            $receivedClient = $client;
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $payload = $this->getUnknownEventPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertTrue($onUnhandledCalled);
+        self::assertInstanceOf(Events\UnknownEventNotification::class, $receivedEvent);
+        self::assertSame('llama.created', $receivedEvent->type);
+        self::assertInstanceOf(StripeClient::class, $receivedClient);
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertFalse($receivedInfo->isKnownEventType);
+    }
+
+    public function testKnownUnregisteredEventRoutesToOnUnhandled()
+    {
+        $onUnhandledCalled = false;
+        $receivedEvent = null;
+        $receivedClient = null;
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$onUnhandledCalled, &$receivedEvent, &$receivedClient, &$receivedInfo) {
+            $onUnhandledCalled = true;
+            $receivedEvent = $event;
+            $receivedClient = $client;
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertTrue($onUnhandledCalled);
+        self::assertInstanceOf(Events\V1BillingMeterErrorReportTriggeredEventNotification::class, $receivedEvent);
+        self::assertSame('v1.billing.meter.error_report_triggered', $receivedEvent->type);
+        self::assertInstanceOf(StripeClient::class, $receivedClient);
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertTrue($receivedInfo->isKnownEventType);
+    }
+
+    public function testRegisteredEventDoesNotCallOnUnhandled()
+    {
+        $callbackCalled = false;
+        $onUnhandledCalled = false;
+
+        $callback = static function ($event, $client) use (&$callbackCalled) {
+            $callbackCalled = true;
+        };
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$onUnhandledCalled) {
+            $onUnhandledCalled = true;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertTrue($callbackCalled);
+        self::assertFalse($onUnhandledCalled);
+    }
+
+    public function testHandlerClientRetainsConfiguration()
+    {
+        $apiKey = 'sk_test_custom_key';
+        $originalContext = 'original_context_xyz';
+
+        $client = new StripeClient([
+            'api_key' => $apiKey,
+            'stripe_context' => $originalContext,
+        ]);
+
+        $receivedApiKey = null;
+        $receivedContext = null;
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandler($client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $callback = static function ($event, $receivedClient) use (&$receivedApiKey, &$receivedContext) {
+            $receivedApiKey = $receivedClient->getApiKey();
+            $receivedContext = $receivedClient->getStripeContextHeader();
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertSame($apiKey, $receivedApiKey);
+        self::assertSame('event_context_456', $receivedContext);
+        self::assertSame($originalContext, $client->getStripeContext());
+    }
+
+    public function testOnUnhandledReceivesCorrectInfoForUnknown()
+    {
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$receivedInfo) {
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $payload = $this->getUnknownEventPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertFalse($receivedInfo->isKnownEventType);
+    }
+
+    public function testOnUnhandledReceivesCorrectInfoForKnownUnregistered()
+    {
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$receivedInfo) {
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertTrue($receivedInfo->isKnownEventType);
+    }
+
+    public function testValidatesWebhookSignature()
+    {
+        $this->expectException(Exception\SignatureVerificationException::class);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $this->handler->handle($payload, 'invalid_signature');
+    }
+
+    public function testRegisteredEventTypesEmpty()
+    {
+        $types = $this->handler->getRegisteredHandlers();
+
+        self::assertSame([], $types);
+    }
+
+    public function testRegisteredEventTypesSingle()
+    {
+        $callback = static function ($event, $client) {
+            // no-op
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $types = $this->handler->getRegisteredHandlers();
+
+        self::assertSame(['v1.billing.meter.error_report_triggered'], $types);
+    }
+
+    public function testRegisteredEventTypesMultipleAlphabetized()
+    {
+        $callback = static function ($event, $client) {
+            // no-op
+        };
+
+        // Register in non-alphabetical order
+        $this->handler->onV1BillingMeterNoMeterFound($callback);
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $types = $this->handler->getRegisteredHandlers();
+
+        $expected = [
+            'v1.billing.meter.error_report_triggered',
+            'v1.billing.meter.no_meter_found',
+        ];
+
+        self::assertSame($expected, $types);
+    }
+
+    public function testWithoutVerificationRoutesEventToHandler()
+    {
+        $callbackCalled = false;
+        $receivedEvent = null;
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $callback = static function ($event, $client) use (&$callbackCalled, &$receivedEvent) {
+            $callbackCalled = true;
+            $receivedEvent = $event;
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $handler->handle($payload);
+
+        self::assertTrue($callbackCalled);
+        self::assertInstanceOf(Events\V1BillingMeterErrorReportTriggeredEventNotification::class, $receivedEvent);
+    }
+
+    public function testWithoutVerificationFallbackForUnregisteredEvent()
+    {
+        $onUnhandledCalled = false;
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$onUnhandledCalled, &$receivedInfo) {
+            $onUnhandledCalled = true;
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $payload = $this->getV1BillingMeterPayload();
+        $handler->handle($payload);
+
+        self::assertTrue($onUnhandledCalled);
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertTrue($receivedInfo->isKnownEventType);
+    }
+
+    public function testWithoutVerificationUnknownEventType()
+    {
+        $onUnhandledCalled = false;
+        $receivedEvent = null;
+        $receivedInfo = null;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$onUnhandledCalled, &$receivedEvent, &$receivedInfo) {
+            $onUnhandledCalled = true;
+            $receivedEvent = $event;
+            $receivedInfo = $info;
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $payload = $this->getUnknownEventPayload();
+        $handler->handle($payload);
+
+        self::assertTrue($onUnhandledCalled);
+        self::assertInstanceOf(Events\UnknownEventNotification::class, $receivedEvent);
+        self::assertInstanceOf(UnhandledNotificationDetails::class, $receivedInfo);
+        self::assertFalse($receivedInfo->isKnownEventType);
+    }
+
+    public function testWithoutVerificationContextPropagation()
+    {
+        $receivedContext = null;
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $callback = static function ($event, $client) use (&$receivedContext) {
+            $receivedContext = $client->getStripeContextHeader();
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $handler->handle($payload);
+
+        self::assertSame('event_context_456', $receivedContext);
+    }
+
+    public function testWithoutVerificationHandleAcceptsOnlyThePayload()
+    {
+        // The two handlers are siblings rather than parent and child, so this one
+        // declares no signature parameter at all. PHP silently ignores extra arguments
+        // to a userland method, so the guarantee has to be asserted on the signature.
+        $method = new \ReflectionMethod(
+            StripeEventNotificationHandlerWithoutVerification::class,
+            'handle'
+        );
+
+        self::assertSame(1, $method->getNumberOfParameters());
+        self::assertSame('payload', $method->getParameters()[0]->getName());
+    }
+
+    public function testWithoutVerificationStaticFactory()
+    {
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = StripeEventNotificationHandler::withoutVerification($this->client, $fallbackCallback);
+
+        self::assertInstanceOf(StripeEventNotificationHandlerWithoutVerification::class, $handler);
+    }
+
+    public function testWithoutVerificationClientFactory()
+    {
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = $this->client->notificationHandlerWithoutVerification($fallbackCallback);
+
+        self::assertInstanceOf(StripeEventNotificationHandlerWithoutVerification::class, $handler);
+    }
+
+    public function testConstructorRejectsEmptySecret()
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->compatExpectExceptionMessageMatches('/webhookSecret must be a non-empty string/');
+
+        new StripeEventNotificationHandler($this->client, '', $this->fallbackCallback);
+    }
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The event notification handler code has been in the `beta` and `private-preview` branches since last year, but it's time to take it to GA!

This PR is entirely pre-approved code from previous PRs. It takes the static files from codegen, plus all the manual changes I made directly in `beta` to get everything working. It's stacked on top of the non-verified work from this week, too. Once this lands, the managed handler code should be in sync across all channels.

Notably, the static files that we used to share functionality are no longer sourced from codegen. Instead, they're now true manual files in `master` whose changes will flow into preview branches like normal.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `EventNotificationHandler` class & supporting infrastructure (ability to copy a `StripeClient`, etc)
- add `stripeClient` methods for creating a handler bound to that client
- add example
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://stripe.dev/blog/event-notification-handlers-thin-events
- [internal doc](https://docs.google.com/document/d/1hRpQLMLGfOHhZwXrYt5tvsKT-oIya11M4atunvTOih0/edit?tab=t.w21fiib3jsl3#heading=h.p5iqpr8dzdsz)
- Initial PR: https://github.com/stripe/stripe-php/pull/1955
- Update PR (adds non-verified handlers): https://github.com/stripe/stripe-php/pull/2121

## Changelog

- We've been putting a lot of time into rethinking the event handling experience in the SDKs. This new class is the culmination [of that effort](https://stripe.dev/blog/event-notification-handlers-thin-events).
- They're designed for a tight coupling with both `StripeClient` and the fully-typed nature of [thin events](https://docs.stripe.com/event-destinations#thin-events). This delivers painless event destination upgrades, in-editor checks for common mistakes, and better code modularity.
- Now that we've released [thin event notifications for v1 objects](https://docs.stripe.com/changelog#2026-08-26.dahlia), these new handlers are our recommended path for all integrations using thin event notifications.
- See more detailed docs here: https://docs.stripe.com/webhooks/event-notification-handlers
