### PR TITLE
Add `.preHandle` method to `EventNotificationHandler`

### DIFF
--- a/examples/EventNotificationHandlerEndpoint.php
+++ b/examples/EventNotificationHandlerEndpoint.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * event_notification_handler_endpoint.py - receive and process event notifications (AKA thin events) like "v1.billing.meter.error_report_triggered" using EventNotificationHandler.
+ * EventNotificationHandlerEndpoint.php - receive and process event notifications (AKA thin events) like "v1.billing.meter.error_report_triggered" using EventNotificationHandler.
  * In this example, we:
  *     - write a fallback callback to handle unrecognized event notifications
  *     - create a StripeClient called client
  *     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+ *     - register a preHandle hook that deduplicates events by id before any callback runs
  *     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
- *     - register a preHandle hook that skips events we've already processed
  *     - use handler->handle() to process the received notification webhook body.
  */
 require 'vendor/autoload.php';
@@ -18,11 +18,13 @@ $webhook_secret = getenv('WEBHOOK_SECRET');
 $app = new Slim\App();
 $client = new Stripe\StripeClient($api_key);
 
-// Stripe can deliver the same event more than once, and our docs warn against processing one
-// twice. A preHandle hook is a single place to enforce that: returning false stops handling
-// before any callback below runs, including the fallback. In a real integration this would be
-// backed by a database or cache rather than an in-memory array.
+// Webhooks can be delivered more than once, so we track ids we've already
+// processed. In production, back this with something durable and shared
+// across processes (e.g. Redis or a database table) instead of an in-memory array.
 $processed_event_ids = [];
+
+// Runs before any registered callback. Returning false here skips handling
+// entirely for this delivery, which is useful for deduplicating webhooks.
 $skip_already_processed = static function ($event_notification, $client) use (&$processed_event_ids) {
     if (\in_array($event_notification->id, $processed_event_ids, true)) {
         echo "Skipping duplicate delivery of {$event_notification->id}\n";
@@ -35,16 +37,18 @@ $skip_already_processed = static function ($event_notification, $client) use (&$
     return true;
 };
 
+// can be anywhere in your codebase with access to the `handler`
+$handle_meter_error = static function ($event_notification, $client) {
+    $meter = $event_notification->fetchRelatedObject();
+    echo "Handling V1BillingMeterErrorReportTriggeredEventNotification for meter: {$meter->name}\n";
+};
+
 $handler = $client->notificationHandler($webhook_secret, static function ($event_notification, $client, $details) {
     echo "Received event notification of type {$event_notification->type}\n";
 });
 
 $handler->preHandle($skip_already_processed);
-
-$handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
-    $meter = $event_notification->fetchRelatedObject();
-    echo "Handling V1BillingMeterErrorReportTriggeredEventNotification for meter: {$meter->name}\n";
-});
+$handler->onV1BillingMeterErrorReportTriggered($handle_meter_error);
 
 // Handles events delivered through a channel that has already authenticated them, such as
 // AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
@@ -54,11 +58,7 @@ $unverified_handler = $client->notificationHandlerWithoutVerification(static fun
 });
 
 $unverified_handler->preHandle($skip_already_processed);
-
-$unverified_handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
-    $meter = $event_notification->fetchRelatedObject();
-    echo "Handling V1BillingMeterErrorReportTriggeredEventNotification for meter: {$meter->name}\n";
-});
+$unverified_handler->onV1BillingMeterErrorReportTriggered($handle_meter_error);
 
 $app->post('/webhook', static function ($request, $response) use ($handler) {
     $webhook_body = $request->getBody()->getContents();

--- a/examples/EventNotificationHandlerEndpoint.php
+++ b/examples/EventNotificationHandlerEndpoint.php
@@ -7,6 +7,7 @@
  *     - create a StripeClient called client
  *     - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
  *     - register a specific handler for the "v1.billing.meter.error_report_triggered" event notification type
+ *     - register a preHandle hook that skips events we've already processed
  *     - use handler->handle() to process the received notification webhook body.
  */
 require 'vendor/autoload.php';
@@ -17,9 +18,28 @@ $webhook_secret = getenv('WEBHOOK_SECRET');
 $app = new Slim\App();
 $client = new Stripe\StripeClient($api_key);
 
+// Stripe can deliver the same event more than once, and our docs warn against processing one
+// twice. A preHandle hook is a single place to enforce that: returning false stops handling
+// before any callback below runs, including the fallback. In a real integration this would be
+// backed by a database or cache rather than an in-memory array.
+$processed_event_ids = [];
+$skip_already_processed = static function ($event_notification, $client) use (&$processed_event_ids) {
+    if (\in_array($event_notification->id, $processed_event_ids, true)) {
+        echo "Skipping duplicate delivery of {$event_notification->id}\n";
+
+        return false;
+    }
+
+    $processed_event_ids[] = $event_notification->id;
+
+    return true;
+};
+
 $handler = $client->notificationHandler($webhook_secret, static function ($event_notification, $client, $details) {
     echo "Received event notification of type {$event_notification->type}\n";
 });
+
+$handler->preHandle($skip_already_processed);
 
 $handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
     $meter = $event_notification->fetchRelatedObject();
@@ -32,6 +52,8 @@ $handler->onV1BillingMeterErrorReportTriggered(static function ($event_notificat
 $unverified_handler = $client->notificationHandlerWithoutVerification(static function ($event_notification, $client, $details) {
     echo "Received event notification of type {$event_notification->type}\n";
 });
+
+$unverified_handler->preHandle($skip_already_processed);
 
 $unverified_handler->onV1BillingMeterErrorReportTriggered(static function ($event_notification, $client) {
     $meter = $event_notification->fetchRelatedObject();

--- a/lib/AbstractEventNotificationHandler.php
+++ b/lib/AbstractEventNotificationHandler.php
@@ -111,7 +111,7 @@ abstract class AbstractEventNotificationHandler
     private function assertCanRegister()
     {
         if ($this->hasHandledEvents) {
-            throw new Exception\BadMethodCallException('Cannot register new event handlers after .handle() has been called. This is indicative of a bug.');
+            throw new Exception\BadMethodCallException('Cannot register new callbacks after an event has been handled. This is indicative of a bug.');
         }
     }
 
@@ -128,7 +128,7 @@ abstract class AbstractEventNotificationHandler
     {
         $this->assertCanRegister();
         if (isset($this->registeredHandlers[$eventType])) {
-            throw new Exception\InvalidArgumentException("Handler for event type \"{$eventType}\" is already registered");
+            throw new Exception\InvalidArgumentException("Callback for event type \"{$eventType}\" is already registered");
         }
 
         $this->registeredHandlers[$eventType] = $handler;

--- a/lib/AbstractEventNotificationHandler.php
+++ b/lib/AbstractEventNotificationHandler.php
@@ -22,6 +22,8 @@ abstract class AbstractEventNotificationHandler
     protected $fallbackCallback;
     /** @var array<string, mixed> everything we need to duplicate a client */
     protected $clientConfig;
+    /** @var null|callable(V2\Core\EventNotification, StripeClient): bool */
+    protected $preHandleCallback = null;
 
     /**
      * @param StripeClient $client The Stripe client to use for API interactions
@@ -74,6 +76,10 @@ abstract class AbstractEventNotificationHandler
         // Create a new client instance with the event's context instead of modifying the shared client
         $eventClient = $this->createClientWithContext($notif->context);
 
+        if (null !== $this->preHandleCallback && !\call_user_func($this->preHandleCallback, $notif, $eventClient)) {
+            return;
+        }
+
         if (isset($this->registeredHandlers[$eventType])) {
             \call_user_func($this->registeredHandlers[$eventType], $notif, $eventClient);
         } else {
@@ -97,6 +103,19 @@ abstract class AbstractEventNotificationHandler
     }
 
     /**
+     * Callbacks are expected to be registered once on startup, so registering anything
+     * after handling has begun indicates a bug.
+     *
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    private function assertCanRegister()
+    {
+        if ($this->hasHandledEvents) {
+            throw new Exception\BadMethodCallException('Cannot register new event handlers after .handle() has been called. This is indicative of a bug.');
+        }
+    }
+
+    /**
      * Registers a handler for a specific event type.
      *
      * @param string $eventType The event type to register the handler for
@@ -107,14 +126,30 @@ abstract class AbstractEventNotificationHandler
      */
     protected function register($eventType, $handler)
     {
-        if ($this->hasHandledEvents) {
-            throw new Exception\BadMethodCallException('Cannot register new event handlers after .handle() has been called. This is indicative of a bug.');
-        }
+        $this->assertCanRegister();
         if (isset($this->registeredHandlers[$eventType])) {
             throw new Exception\InvalidArgumentException("Handler for event type \"{$eventType}\" is already registered");
         }
 
         $this->registeredHandlers[$eventType] = $handler;
+    }
+
+    /**
+     * Registers a hook that runs after an event notification is parsed but before any callback callback is invoked.
+     *
+     * @param callable(V2\Core\EventNotification, StripeClient): bool $handler Return false to stop handling before any callback runs
+     *
+     * @throws Exception\InvalidArgumentException if a pre-handle hook is already registered
+     * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
+     */
+    public function preHandle($handler)
+    {
+        $this->assertCanRegister();
+        if (null !== $this->preHandleCallback) {
+            throw new Exception\InvalidArgumentException('A preHandle callback is already registered');
+        }
+
+        $this->preHandleCallback = $handler;
     }
 
     // event-handler-methods: The beginning of the section generated from our OpenAPI spec

--- a/lib/AbstractEventNotificationHandler.php
+++ b/lib/AbstractEventNotificationHandler.php
@@ -135,7 +135,12 @@ abstract class AbstractEventNotificationHandler
     }
 
     /**
-     * Registers a hook that runs after an event notification is parsed but before any callback callback is invoked.
+     * Registers a function that will be run before any event-specific callbacks. A useful place to
+     * store event-agnostic logic, such as logging or checking for
+     * [duplicate event deliveries](https://docs.stripe.com/webhooks#handle-duplicate-events).
+     *
+     * Returning `true` causes handling to continue as normal; returning `false` returns from
+     * `.handle()` immediately, so neither the registered callback nor the fallback callback are called.
      *
      * @param callable(V2\Core\EventNotification, StripeClient): bool $handler Return false to stop handling before any callback runs
      *

--- a/lib/AbstractEventNotificationHandler.php
+++ b/lib/AbstractEventNotificationHandler.php
@@ -103,12 +103,12 @@ abstract class AbstractEventNotificationHandler
     }
 
     /**
-     * Callbacks are expected to be registered once on startup, so registering anything
-     * after handling has begun indicates a bug.
+     * Callbacks are expected to be registered on startup, so registering anything
+     * after handling an event indicates a bug.
      *
      * @throws Exception\BadMethodCallException if the `.handle()` method has already been called on this handler.
      */
-    private function assertCanRegister()
+    private function assertHasntHandledYet()
     {
         if ($this->hasHandledEvents) {
             throw new Exception\BadMethodCallException('Cannot register new callbacks after an event has been handled. This is indicative of a bug.');
@@ -126,7 +126,7 @@ abstract class AbstractEventNotificationHandler
      */
     protected function register($eventType, $handler)
     {
-        $this->assertCanRegister();
+        $this->assertHasntHandledYet();
         if (isset($this->registeredHandlers[$eventType])) {
             throw new Exception\InvalidArgumentException("Callback for event type \"{$eventType}\" is already registered");
         }
@@ -149,7 +149,7 @@ abstract class AbstractEventNotificationHandler
      */
     public function preHandle($handler)
     {
-        $this->assertCanRegister();
+        $this->assertHasntHandledYet();
         if (null !== $this->preHandleCallback) {
             throw new Exception\InvalidArgumentException('A preHandle callback is already registered');
         }

--- a/tests/Stripe/StripeEventNotificationHandlerTest.php
+++ b/tests/Stripe/StripeEventNotificationHandlerTest.php
@@ -672,4 +672,248 @@ final class StripeEventNotificationHandlerTest extends TestCase
 
         new StripeEventNotificationHandler($this->client, '', $this->fallbackCallback);
     }
+
+    public function testHandlerStillRunsWithNoPreHandleRegistered()
+    {
+        $callbackCalled = false;
+
+        $callback = static function ($event, $client) use (&$callbackCalled) {
+            $callbackCalled = true;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertTrue($callbackCalled);
+    }
+
+    public function testPreHandleReturningTrueRunsFirstThenHandler()
+    {
+        $order = [];
+
+        $this->handler->preHandle(static function ($event, $client) use (&$order) {
+            $order[] = 'preHandle';
+
+            return true;
+        });
+
+        $callback = static function ($event, $client) use (&$order) {
+            $order[] = 'handler';
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertSame(['preHandle', 'handler'], $order);
+    }
+
+    public function testPreHandleReturningFalsePreventsRegisteredHandler()
+    {
+        $handlerCalled = false;
+
+        $this->handler->preHandle(static function ($event, $client) {
+            return false;
+        });
+
+        $callback = static function ($event, $client) use (&$handlerCalled) {
+            $handlerCalled = true;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertFalse($handlerCalled);
+    }
+
+    public function testPreHandleReturningFalsePreventsFallback()
+    {
+        $fallbackCalled = false;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$fallbackCalled) {
+            $fallbackCalled = true;
+        };
+
+        $handler = new StripeEventNotificationHandler($this->client, self::WEBHOOK_SECRET, $fallbackCallback);
+        $handler->preHandle(static function ($event, $client) {
+            return false;
+        });
+
+        $payload = $this->getUnknownEventPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $handler->handle($payload, $sigHeader);
+
+        self::assertFalse($fallbackCalled);
+    }
+
+    public function testPreHandleReceivesContextScopedClientAndHandlerClientIsUnmutated()
+    {
+        $preHandleContext = 'not_set';
+
+        $this->handler->preHandle(static function ($event, $client) use (&$preHandleContext) {
+            $preHandleContext = $client->getStripeContextHeader();
+
+            return true;
+        });
+
+        $callback = static function ($event, $client) {
+            // no-op
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        self::assertSame('event_context_456', $preHandleContext);
+        self::assertSame('original_context_123', $this->client->getStripeContext());
+    }
+
+    public function testPreHandleThrowingPropagatesAndPreventsHandler()
+    {
+        $handlerCalled = false;
+
+        $this->handler->preHandle(static function ($event, $client) {
+            throw new \RuntimeException('preHandle error!');
+        });
+
+        $callback = static function ($event, $client) use (&$handlerCalled) {
+            $handlerCalled = true;
+        };
+
+        $this->handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('preHandle error!');
+
+        try {
+            $this->handler->handle($payload, $sigHeader);
+        } finally {
+            self::assertFalse($handlerCalled);
+        }
+    }
+
+    public function testCannotRegisterPreHandleAfterHandling()
+    {
+        $payload = $this->getV1BillingMeterPayload();
+        $sigHeader = $this->generateHeader($payload);
+        $this->handler->handle($payload, $sigHeader);
+
+        $this->expectException(Exception\BadMethodCallException::class);
+        $this->compatExpectExceptionMessageMatches('/Cannot register new event handlers after .handle\(\) has been called/');
+
+        $this->handler->preHandle(static function ($event, $client) {
+            return true;
+        });
+    }
+
+    public function testCannotRegisterDuplicatePreHandle()
+    {
+        $this->handler->preHandle(static function ($event, $client) {
+            return true;
+        });
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+
+        $this->handler->preHandle(static function ($event, $client) {
+            return true;
+        });
+    }
+
+    public function testWithoutVerificationPreHandleReturningFalsePreventsHandler()
+    {
+        $handlerCalled = false;
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $handler->preHandle(static function ($event, $client) {
+            return false;
+        });
+
+        $callback = static function ($event, $client) use (&$handlerCalled) {
+            $handlerCalled = true;
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $handler->handle($payload);
+
+        self::assertFalse($handlerCalled);
+    }
+
+    public function testWithoutVerificationPreHandleReturningFalsePreventsFallback()
+    {
+        $fallbackCalled = false;
+
+        $fallbackCallback = static function ($event, $client, $info) use (&$fallbackCalled) {
+            $fallbackCalled = true;
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $handler->preHandle(static function ($event, $client) {
+            return false;
+        });
+
+        $payload = $this->getUnknownEventPayload();
+        $handler->handle($payload);
+
+        self::assertFalse($fallbackCalled);
+    }
+
+    public function testWithoutVerificationPreHandleReturningTrueRunsHandler()
+    {
+        $order = [];
+
+        $fallbackCallback = static function ($event, $client, $info) {
+            // no-op
+        };
+
+        $handler = new StripeEventNotificationHandlerWithoutVerification(
+            $this->client,
+            $fallbackCallback
+        );
+
+        $handler->preHandle(static function ($event, $client) use (&$order) {
+            $order[] = 'preHandle';
+
+            return true;
+        });
+
+        $callback = static function ($event, $client) use (&$order) {
+            $order[] = 'handler';
+        };
+
+        $handler->onV1BillingMeterErrorReportTriggered($callback);
+
+        $payload = $this->getV1BillingMeterPayload();
+        $handler->handle($payload);
+
+        self::assertSame(['preHandle', 'handler'], $order);
+    }
 }

--- a/tests/Stripe/StripeEventNotificationHandlerTest.php
+++ b/tests/Stripe/StripeEventNotificationHandlerTest.php
@@ -187,7 +187,7 @@ final class StripeEventNotificationHandlerTest extends TestCase
         $this->handler->handle($payload, $sigHeader);
 
         $this->expectException(Exception\BadMethodCallException::class);
-        $this->compatExpectExceptionMessageMatches('/Cannot register new event handlers after .handle\(\) has been called/');
+        $this->compatExpectExceptionMessageMatches('/Cannot register new callbacks after an event has been handled/');
 
         $this->handler->onV1BillingMeterNoMeterFound($callback);
     }
@@ -204,7 +204,7 @@ final class StripeEventNotificationHandlerTest extends TestCase
         $this->handler->onV1BillingMeterErrorReportTriggered($callback1);
 
         $this->expectException(Exception\InvalidArgumentException::class);
-        $this->compatExpectExceptionMessageMatches('/Handler for event type "v1.billing.meter.error_report_triggered" is already registered/');
+        $this->compatExpectExceptionMessageMatches('/Callback for event type "v1.billing.meter.error_report_triggered" is already registered/');
 
         $this->handler->onV1BillingMeterErrorReportTriggered($callback2);
     }
@@ -814,7 +814,7 @@ final class StripeEventNotificationHandlerTest extends TestCase
         $this->handler->handle($payload, $sigHeader);
 
         $this->expectException(Exception\BadMethodCallException::class);
-        $this->compatExpectExceptionMessageMatches('/Cannot register new event handlers after .handle\(\) has been called/');
+        $this->compatExpectExceptionMessageMatches('/Cannot register new callbacks after an event has been handled/');
 
         $this->handler->preHandle(static function ($event, $client) {
             return true;


### PR DESCRIPTION
### Why?

In final testing, users have expressed interest in being able to centrally run code before any other handler executes. It can be used for centralized logging, event deduplication, and more. I don't want to go full middleware, but this felt like a reasonable way to dip our toe into the waters.

Because users are responsible for [deduplicating events](https://docs.stripe.com/webhooks#handle-duplicate-events), this pre-handle hook (if present) should return a `bool`, signifying whether handling should continue.

If the function returns `true` (or is missing entirely), the handler proceeds like normal (running at-most-one other callback). If it returns `false`, no further callback is run and the original `.handle()` call finishes cleanly.

### What?

- add the `.pre_handle` method
- & associated tests
- update some error messages with correct verbs & consistency
- refactored some internal error handling
- updated example

### See Also

- http://go/j/DEVSDK-3249
