### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -480,14 +480,14 @@ class ApiRequestor
      *
      * The absolute URL is built by concatenating the API base onto this path,
      * and no base URL ends in a slash. A path like "@evil.example/v1/x" or
-     * ".evil.example/v1/x" would therefore land inside the authority component
-     * and send the request — Authorization header included — to a host of the
-     * path's choosing. Some request paths originate in remote data (a webhook
-     * body's related_object.url, a response's next_page_url), so this cannot be
-     * assumed to be well-formed.
+     * ".evil.example/v1/x" would modify the resulting host and direct the
+     * request (including the API key) to a non-Stripe host.
      *
-     * Stripe only ever issues plain paths, so anything else is tampering and is
-     * rejected rather than sanitized.
+     * Because some relative urls arrive from potentially untrusted sources (like
+     * webhook bodies), we have to be a little defensive.
+     *
+     * So, we require that a path starts with a leading slash and that
+     * parse_url() finds no scheme or authority in it.
      *
      * @param string $url
      *

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -475,12 +475,73 @@ class ApiRequestor
     }
 
     /**
-     * @param 'delete'|'get'|'post' $method
      * @param string $url
-     * @param array $params
-     * @param array $headers
-     * @param 'v1'|'v2' $apiMode
      */
+    /**
+     * Asserts that a request path is origin-relative: that it begins with a
+     * single "/" and carries no scheme, authority or userinfo.
+     *
+     * The absolute URL is built by concatenating the API base onto this path,
+     * and no base URL ends in a slash. A path like "@evil.example/v1/x" or
+     * ".evil.example/v1/x" would therefore land inside the authority component
+     * and send the request — Authorization header included — to a host of the
+     * path's choosing. Some request paths originate in remote data (a webhook
+     * body's related_object.url, a response's next_page_url), so this cannot be
+     * assumed to be well-formed.
+     *
+     * Stripe only ever issues plain paths, so anything else is tampering and is
+     * rejected rather than sanitized.
+     *
+     * @param string $url
+     *
+     * @throws Exception\InvalidArgumentException
+     */
+    private static function validatePath($url)
+    {
+        if (!\is_string($url) || '/' !== \substr($url, 0, 1) || '//' === \substr($url, 0, 2)) {
+            throw new Exception\InvalidArgumentException(
+                'Request path must be a string beginning with a single "/".'
+            );
+        }
+
+        $parts = \parse_url($url);
+        if (false === $parts || isset($parts['scheme']) || isset($parts['host']) || isset($parts['user'])) {
+            throw new Exception\InvalidArgumentException(
+                'Request path may not contain a scheme or authority.'
+            );
+        }
+    }
+
+    /**
+     * Rejects CR, LF and NUL in a header name or value.
+     *
+     * Header lines are assembled by concatenation, so a newline in either half
+     * would let the remainder be parsed as additional headers. Some of these
+     * values originate in remote data - fetchRelatedObject() sets Stripe-Context
+     * and Stripe-Request-Trigger from the webhook body - and a per-request
+     * api_key reaches the Authorization value without the whitespace check that
+     * Stripe::setApiKey() applies.
+     *
+     * @param string $header
+     * @param mixed  $value
+     *
+     * @throws Exception\InvalidArgumentException
+     */
+    private static function assertNoHeaderInjection($header, $value)
+    {
+        foreach ([$header, $value] as $part) {
+            if (!\is_string($part)) {
+                continue;
+            }
+
+            if (false !== \strpbrk($part, "\r\n") || false !== \strpos($part, "\0")) {
+                throw new Exception\InvalidArgumentException(
+                    'Header names and values may not contain CR, LF or NUL characters.'
+                );
+            }
+        }
+    }
+
     private function _prepareRequest($method, $url, $params, $headers, $apiMode)
     {
         Util\AgentPluginHint::maybeEmit();
@@ -522,6 +583,7 @@ class ApiRequestor
             }
         }
 
+        self::validatePath($url);
         $absUrl = $this->_apiBase . $url;
         if ('v1' === $apiMode) {
             $params = self::_encodeObjects($params);
@@ -560,6 +622,7 @@ class ApiRequestor
         $rawHeaders = [];
 
         foreach ($combinedHeaders as $header => $value) {
+            self::assertNoHeaderInjection($header, $value);
             $rawHeaders[] = $header . ': ' . $value;
         }
 

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -475,9 +475,6 @@ class ApiRequestor
     }
 
     /**
-     * @param string $url
-     */
-    /**
      * Asserts that a request path is origin-relative: that it begins with a
      * single "/" and carries no scheme, authority or userinfo.
      *

--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -542,6 +542,13 @@ class ApiRequestor
         }
     }
 
+    /**
+     * @param 'delete'|'get'|'post' $method
+     * @param string $url
+     * @param array $params
+     * @param array $headers
+     * @param 'v1'|'v2' $apiMode
+     */
     private function _prepareRequest($method, $url, $params, $headers, $apiMode)
     {
         Util\AgentPluginHint::maybeEmit();

--- a/lib/V2/Core/EventNotification.php
+++ b/lib/V2/Core/EventNotification.php
@@ -116,7 +116,10 @@ abstract class EventNotification
     {
         $response = $this->client->rawRequest(
             'get',
-            "/v2/core/events/{$this->id}",
+            // `id` comes from the notification body, so encode it the way
+            // buildPath() does for generated services -- otherwise it can inject
+            // extra path or query segments.
+            '/v2/core/events/' . \urlencode($this->id),
             null,
             [
                 'stripe_context' => $this->context,

--- a/tests/Stripe/ApiRequestorTest.php
+++ b/tests/Stripe/ApiRequestorTest.php
@@ -960,4 +960,159 @@ final class ApiRequestorTest extends TestCase
 
         self::assertFalse($warningEmitted);
     }
+
+    private function assertOriginRelativePath($url)
+    {
+        $reflector = new \ReflectionClass(ApiRequestor::class);
+        $method = $reflector->getMethod('validatePath');
+        $method->setAccessible(true);
+        $method->invoke(null, $url);
+    }
+
+    public function testAssertOriginRelativePathAcceptsPlainPaths()
+    {
+        $valid = [
+            '/v1/customers/cus_123',
+            '/v1/customers',
+            '/v2/core/accounts?page=page_123&limit=2',
+            // '@' is legal inside a path or query string -- it only opens an
+            // authority when it precedes the first '/'.
+            '/v1/customers?email=user%40example.com',
+            '/v1/invoices/in_123@456',
+            // A backslash does not open an authority: the '/' already closed it.
+            '/v1/\evil.example',
+        ];
+
+        foreach ($valid as $url) {
+            $this->assertOriginRelativePath($url);
+        }
+
+        // Reaching here without an exception is the assertion.
+        self::assertTrue(true);
+    }
+
+    public function testAssertOriginRelativePathRejectsHostilePaths()
+    {
+        $hostile = [
+            // Concatenated onto a base URL with no trailing slash, each of these
+            // moves the request's authority off api.stripe.com.
+            '@evil.example/v1/leak',
+            ':pw@evil.example/v1/leak',
+            ':80@evil.example/v1/leak',
+            // Extends the host into an attacker-owned subdomain
+            // (api.stripe.com.evil.example), which has a valid certificate.
+            '.evil.example/v1/leak',
+            '-evil.example/v1/leak',
+            'https://evil.example/v1/leak',
+            '//evil.example/v1/leak',
+            '',
+            'v1/customers',
+            null,
+            42,
+        ];
+
+        foreach ($hostile as $url) {
+            try {
+                $this->assertOriginRelativePath($url);
+                self::fail('Expected InvalidArgumentException for path: ' . \var_export($url, true));
+            } catch (Exception\InvalidArgumentException $e) {
+                self::assertNotNull($e);
+            }
+        }
+    }
+
+    public function testRawRequestRejectsHostilePathWithoutIssuingRequest()
+    {
+        ApiRequestor::setHttpClient($this->clientMock);
+        $this->clientMock->expects(self::never())->method('request');
+
+        $client = new StripeClient(['api_key' => 'sk_test_123']);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $client->rawRequest('get', '@evil.example/v1/leak');
+    }
+
+    public function testFetchRelatedObjectRejectsHostileUrlWithoutIssuingRequest()
+    {
+        ApiRequestor::setHttpClient($this->clientMock);
+        $this->clientMock->expects(self::never())->method('request');
+
+        $client = new StripeClient(['api_key' => 'sk_test_123']);
+        $payload = \json_encode([
+            'id' => 'evt_123',
+            'object' => 'v2.core.event',
+            'type' => 'v2.core.account.created',
+            'created' => '2026-01-01T00:00:00Z',
+            'related_object' => [
+                'id' => 'acct_123',
+                'type' => 'account',
+                'url' => '@evil.example/v1/leak',
+            ],
+        ]);
+        $secret = 'whsec_test_secret';
+        $sigHeader = WebhookSignature::generateSignatureHeader($payload, $secret);
+
+        $notification = $client->parseEventNotification($payload, $sigHeader, $secret);
+        // fetchRelatedObject() is protected on the base class and re-exposed
+        // publicly by each generated notification subclass.
+        self::assertInstanceOf(Events\V2CoreAccountCreatedEventNotification::class, $notification);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $notification->fetchRelatedObject();
+    }
+
+    public function testAutoPagingIteratorRejectsHostileNextPageUrlWithoutIssuingRequest()
+    {
+        ApiRequestor::setHttpClient($this->clientMock);
+        $this->clientMock->expects(self::never())->method('request');
+
+        $collection = V2\Collection::constructFrom([
+            'data' => [['id' => 'il_123']],
+            'next_page_url' => '@evil.example/v2/leak',
+        ]);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+        foreach ($collection->autoPagingIterator() as $item) {
+            // The single element of `data` is yielded before any page is
+            // fetched; the exception must arrive when turning the page.
+        }
+    }
+
+    private function assertNoHeaderInjection($header, $value)
+    {
+        $reflector = new \ReflectionClass(ApiRequestor::class);
+        $method = $reflector->getMethod('assertNoHeaderInjection');
+        $method->setAccessible(true);
+        $method->invoke(null, $header, $value);
+    }
+
+    public function testAssertNoHeaderInjectionAcceptsOrdinaryHeaders()
+    {
+        $this->assertNoHeaderInjection('Stripe-Context', 'acct_123/wksp_456');
+        $this->assertNoHeaderInjection('Authorization', 'Bearer sk_test_123');
+        // Non-string values are stringified by concatenation and cannot inject.
+        $this->assertNoHeaderInjection('Content-Length', 42);
+
+        self::assertTrue(true);
+    }
+
+    public function testAssertNoHeaderInjectionRejectsControlCharacters()
+    {
+        $hostile = [
+            ['Stripe-Context', "acct_123\r\nX-Injected: 1"],
+            ['Stripe-Request-Trigger', "event=evt_1\nX-Injected: 1"],
+            ['Authorization', "Bearer sk_test_123\r\n"],
+            ['Authorization', "Bearer sk_test_123\0"],
+            ["X-Injected\r\nEvil", 'value'],
+        ];
+
+        foreach ($hostile as list($header, $value)) {
+            try {
+                $this->assertNoHeaderInjection($header, $value);
+                self::fail('Expected InvalidArgumentException for header: ' . \var_export($header, true));
+            } catch (Exception\InvalidArgumentException $e) {
+                self::assertNotNull($e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- Encode the `event.id` path param in `fetch_event()` to match the sanitation in the rest of the generated endpoints
- fix a bug where malicious newlines in headers could lead to injection attacks
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
