### PR TITLE
Validate that webhook secrets are non-empty

### DIFF
--- a/examples/EventNotificationHandlerEndpoint.php
+++ b/examples/EventNotificationHandlerEndpoint.php
@@ -15,6 +15,12 @@ require 'vendor/autoload.php';
 $api_key = getenv('STRIPE_API_KEY');
 $webhook_secret = getenv('WEBHOOK_SECRET');
 
+if (empty($webhook_secret)) {
+    fwrite(STDERR, "WEBHOOK_SECRET environment variable is not set. It should start with `whsec_`\n");
+
+    exit(1);
+}
+
 $app = new Slim\App();
 $client = new Stripe\StripeClient($api_key);
 

--- a/examples/EventNotificationWebhookHandler.php
+++ b/examples/EventNotificationWebhookHandler.php
@@ -14,6 +14,12 @@ require 'vendor/autoload.php';
 $api_key = getenv('STRIPE_API_KEY');
 $webhook_secret = getenv('WEBHOOK_SECRET');
 
+if (empty($webhook_secret)) {
+    fwrite(STDERR, "WEBHOOK_SECRET environment variable is not set. It should start with `whsec_`\n");
+
+    exit(1);
+}
+
 $app = new Slim\App();
 $client = new Stripe\StripeClient($api_key);
 

--- a/lib/WebhookSignature.php
+++ b/lib/WebhookSignature.php
@@ -42,6 +42,13 @@ abstract class WebhookSignature
                 $header
             );
         }
+        if (empty($secret)) {
+            throw Exception\SignatureVerificationException::factory(
+                'No webhook secret value was provided. It should start with `whsec_`',
+                $payload,
+                $header
+            );
+        }
 
         // Check if expected signature is found in list of signatures from
         // header

--- a/tests/Stripe/WebhookTest.php
+++ b/tests/Stripe/WebhookTest.php
@@ -86,6 +86,24 @@ final class WebhookTest extends TestCase
         WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, self::SECRET);
     }
 
+    public function testEmptySecretRejected()
+    {
+        $this->expectException(Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('No webhook secret value was provided. It should start with `whsec_`');
+
+        $sigHeader = WebhookSignature::generateSignatureHeader(self::EVENT_PAYLOAD, self::SECRET);
+        WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, '');
+    }
+
+    public function testNullSecretRejected()
+    {
+        $this->expectException(Exception\SignatureVerificationException::class);
+        $this->expectExceptionMessage('No webhook secret value was provided. It should start with `whsec_`');
+
+        $sigHeader = WebhookSignature::generateSignatureHeader(self::EVENT_PAYLOAD, self::SECRET);
+        WebhookSignature::verifyHeader(self::EVENT_PAYLOAD, $sigHeader, null);
+    }
+
     public function testTimestampTooOld()
     {
         $this->expectException(Exception\SignatureVerificationException::class);


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a potential security issue where, if the user passes an empty string into the event validation functions, the SDK would still generate a signature. If an attacker knew that a victim was inadvertently using an empty webhook secret, the attacker could send signed webhooks (using the empty secret) that a victim's integration would treat as valid.

The solution is to throw an error if the webhook secret is empty. This ensures all payloads are validated against an actual secret.

We also updated our examples to have better defaults, helping users to avoid this issue.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- verify that a webhook secret is non-empty & non-null when verifying a webhook
- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
