### PR TITLE
Support `EventNotification`s with singleton related objects

### DIFF
--- a/init.php
+++ b/init.php
@@ -81,6 +81,7 @@ require __DIR__ . '/lib/V2/Core/EventNotification.php';
 require __DIR__ . '/lib/Events/UnknownEventNotification.php';
 require __DIR__ . '/lib/Reason.php';
 require __DIR__ . '/lib/RelatedObject.php';
+require __DIR__ . '/lib/RelatedSingletonObject.php';
 require __DIR__ . '/lib/Collection.php';
 require __DIR__ . '/lib/V2/Collection.php';
 require __DIR__ . '/lib/SearchResult.php';

--- a/lib/RelatedSingletonObject.php
+++ b/lib/RelatedSingletonObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Stripe;
+
+/**
+ * @property string $type the "object" of the related object.
+ * @property string $url a relative url to retrieve the related object.
+ */
+class RelatedSingletonObject
+{
+    public $type;
+    public $url;
+
+    public function __construct($json)
+    {
+        $this->type = $json['type'];
+        $this->url = $json['url'];
+    }
+}

--- a/lib/V2/Core/EventNotification.php
+++ b/lib/V2/Core/EventNotification.php
@@ -22,6 +22,11 @@ use Stripe\Util\EventNotificationTypes;
  */
 abstract class EventNotification
 {
+    /**
+     * The class used to deserialize the `related_object` payload. EventNotifications whose related object is a singleton override this with `\Stripe\RelatedSingletonObject`.
+     */
+    const RELATED_OBJECT_CLASS = RelatedObject::class;
+
     public $id;
     public $object;
     public $type;
@@ -60,8 +65,10 @@ abstract class EventNotification
         if (\array_key_exists('livemode', $json)) {
             $this->livemode = $json['livemode'];
         }
-        if (\array_key_exists('related_object', $json)) {
-            $this->related_object = new RelatedObject($json['related_object']);
+        if (\array_key_exists('related_object', $json) && null !== $json['related_object']) {
+            // late static binding, so a subclass' RELATED_OBJECT_CLASS wins
+            $relatedObjectClass = static::RELATED_OBJECT_CLASS;
+            $this->related_object = new $relatedObjectClass($json['related_object']);
         }
         if (\array_key_exists('reason', $json)) {
             $this->reason = new Reason($json['reason']);

--- a/tests/Stripe/BaseStripeClientTest.php
+++ b/tests/Stripe/BaseStripeClientTest.php
@@ -869,6 +869,54 @@ final class BaseStripeClientTest extends TestCase
         self::assertSame('meter_123', $event->related_object->id);
     }
 
+    /**
+     * Codegen emits `const RELATED_OBJECT_CLASS = \Stripe\RelatedSingletonObject::class`
+     * on singleton event notifications. No such event exists in the spec yet, so stand in
+     * for one with the same shape codegen produces and check the base constructor's late
+     * static binding picks it up.
+     */
+    public function testRelatedObjectClassOverrideSelectsSingletonObject()
+    {
+        $json = [
+            'id' => 'evt_234',
+            'object' => 'v2.core.event',
+            'type' => 'v1.balance.available',
+            'created' => '2022-02-15T00:27:45.330Z',
+            'livemode' => false,
+            'related_object' => [
+                'id' => null,
+                'type' => 'balance',
+                'url' => '/v1/balance',
+            ],
+        ];
+        $client = new BaseStripeClient(['api_key' => 'sk_test_client', 'api_base' => MOCK_URL]);
+
+        $notification = new class($json, $client) extends V2\Core\EventNotification {
+            const RELATED_OBJECT_CLASS = RelatedSingletonObject::class;
+            public $related_object;
+        };
+
+        self::assertInstanceOf(RelatedSingletonObject::class, $notification->related_object);
+        self::assertSame('balance', $notification->related_object->type);
+        self::assertSame('/v1/balance', $notification->related_object->url);
+
+        // the base class default is unaffected
+        self::assertSame(RelatedObject::class, V2\Core\EventNotification::RELATED_OBJECT_CLASS);
+    }
+
+    public function testRelatedSingletonObjectExposesNoId()
+    {
+        $related = new RelatedSingletonObject([
+            'type' => 'balance',
+            'url' => '/v1/balance',
+        ]);
+
+        self::assertSame('balance', $related->type);
+        self::assertSame('/v1/balance', $related->url);
+        self::assertFalse(property_exists($related, 'id'));
+        self::assertSame(['type', 'url'], array_keys(get_object_vars($related)));
+    }
+
     public function testParseUnknownEventNotification()
     {
         $jsonEvent = [


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a few event notification types whose related object is a singleton. As a result, its `id` field will always be `null`. Rather than mark the root `RelatedObject` class as having a nullable string for its id (causing every user to have to do null checks even when we _know_ it'll be there), we're adding a second class and generating accordingly. There'll never be any ambiguity as ot whether a id field will be present in the response.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `RelatedSingletonObject` class, which is a copy of `RelatedObject`, but without an `id`. I didn't do inheritance (when relevant) because it's such a tiny, colocated class. If the repetition bothers us, we can reassess.
- add related methods, as needed
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2825](https://go/j/RUN_DEVSDK-2825)
